### PR TITLE
feat(syncfusion): 34.1.32 upgrade + MCP/skills + deps audit (006)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -5,14 +5,14 @@
       "args": [
         "-y",
         "@modelcontextprotocol/server-filesystem",
-        "/Users/stephenmckitrick/BusBuddy/BusBuddy-3"
+        "/Users/stephenmckitrick/Library/CloudStorage/Box-Box/BusBuddy/BusBuddy-3"
       ]
     },
     "syncfusion-wpf-assistant": {
       "type": "stdio",
       "command": "/bin/bash",
       "args": [
-        "/Users/stephenmckitrick/BusBuddy/BusBuddy-3/.github/scripts/run-syncfusion-mcp.sh"
+        "/Users/stephenmckitrick/Library/CloudStorage/Box-Box/BusBuddy/BusBuddy-3/.github/scripts/run-syncfusion-mcp.sh"
       ],
       "env": {}
     },
@@ -20,7 +20,7 @@
       "type": "stdio",
       "command": "python3",
       "args": ["-m", "rag.mcp_server"],
-      "cwd": "/Users/stephenmckitrick/BusBuddy/BusBuddy-3",
+      "cwd": "/Users/stephenmckitrick/Library/CloudStorage/Box-Box/BusBuddy/BusBuddy-3",
       "env": {}
     }
   }

--- a/.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md
+++ b/.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md
@@ -22,20 +22,32 @@ npx skills update
 
 ## BusBuddy packages in use
 
-Version: `$(SyncfusionVersion)` in `Directory.Build.props` (currently **33.x**). Match NuGet references in `BusBuddy.WPF/BusBuddy.WPF.csproj` — do not add packages the project does not already reference unless explicitly requested.
+Version: `$(SyncfusionVersion)` in `Directory.Build.props` (currently **34.1.32** / Syncfusion WPF 34.x). Match NuGet references in `BusBuddy.WPF/BusBuddy.WPF.csproj` — do not add packages the project does not already reference unless explicitly requested.
 
-| Control / area | NuGet | Official skill |
-|----------------|-------|----------------|
-| SfDataGrid | Syncfusion.SfGrid.WPF | `syncfusion-wpf-datagrid` |
-| SfChart | Syncfusion.SfChart.WPF | `syncfusion-wpf-charts` |
-| SfTextBoxExt, inputs | Syncfusion.SfInput.WPF | `syncfusion-wpf-textboxext`, `syncfusion-wpf-combobox`, etc. |
-| ButtonAdv | Syncfusion.Tools.WPF | `syncfusion-wpf-button` |
-| SfBusyIndicator | Syncfusion.SfBusyIndicator.WPF | `syncfusion-wpf-busy-indicator` |
-| Navigation drawer | Syncfusion.SfNavigationDrawer.WPF | `syncfusion-wpf-navigation-drawer` |
-| SfTreeView | Syncfusion.SfTreeView.WPF | `syncfusion-wpf-treeview` |
-| SfScheduler | Syncfusion.SfScheduler.WPF | `syncfusion-wpf-scheduler` |
-| SfAccordion | Syncfusion.SfAccordion.WPF | `syncfusion-wpf-accordion` |
-| Themes | FluentDark / FluentLight | `syncfusion-wpf-skin-manager` |
+Refresh vendor skills after clone or Syncfusion major bumps:
+
+```bash
+.github/scripts/setup-syncfusion-skills.sh          # all components
+.github/scripts/setup-syncfusion-skills.sh minimal  # interactive subset
+npx skills list
+npx skills update
+```
+
+MCP: project `.cursor/mcp.json` → `syncfusion-wpf-assistant` via `.github/scripts/run-syncfusion-mcp.sh` (Passwords / `Syncfusion_API_Key`). Spec: `specs/006-syncfusion-tool-integration/`.
+
+
+| Control / area       | NuGet                             | Official skill                                               |
+| -------------------- | --------------------------------- | ------------------------------------------------------------ |
+| SfDataGrid           | Syncfusion.SfGrid.WPF             | `syncfusion-wpf-datagrid`                                    |
+| SfChart              | Syncfusion.SfChart.WPF            | `syncfusion-wpf-charts`                                      |
+| SfTextBoxExt, inputs | Syncfusion.SfInput.WPF            | `syncfusion-wpf-textboxext`, `syncfusion-wpf-combobox`, etc. |
+| ButtonAdv            | Syncfusion.Tools.WPF              | `syncfusion-wpf-button`                                      |
+| SfBusyIndicator      | Syncfusion.SfBusyIndicator.WPF    | `syncfusion-wpf-busy-indicator`                              |
+| Navigation drawer    | Syncfusion.SfNavigationDrawer.WPF | `syncfusion-wpf-navigation-drawer`                           |
+| SfTreeView           | Syncfusion.SfTreeView.WPF         | `syncfusion-wpf-treeview`                                    |
+| SfScheduler          | Syncfusion.SfScheduler.WPF        | `syncfusion-wpf-scheduler`                                   |
+| SfAccordion          | Syncfusion.SfAccordion.WPF        | `syncfusion-wpf-accordion`                                   |
+| Themes               | FluentDark / FluentLight          | `syncfusion-wpf-skin-manager`                                |
 
 ## Mandatory XAML patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ AI agents (Cursor, Copilot, Claude, Grok, etc.) working in this repo should foll
 ## Primary standards
 
 - **Constitution (Spec-Kit)**: [.specify/memory/constitution.md](.specify/memory/constitution.md) — immutable architectural DNA. Use Cursor `/speckit-*` skills (Constitution → Specify → Plan → Tasks → Implement). Feature specs live under `specs/`. Never run `specify init --here --force` without backing up the constitution.
+- **Due-outs tracker**: [docs/action-items.md](docs/action-items.md) — living checklist (Spec-Kit + Finish items). Historical narrative: [STEADY-STATE-AND-FINISH-ROADMAP.md](STEADY-STATE-AND-FINISH-ROADMAP.md).
 - **Full technical rules**: [.github/copilot-instructions.md](.github/copilot-instructions.md) — architecture, Syncfusion, Serilog, RAG/MCP, anti-regression.
-- **Syncfusion WPF skills**: [.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md](.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md) — BusBuddy overlay; vendor skills in `.agents/skills/` (gitignored, install via [.github/scripts/setup-syncfusion-skills.sh](.github/scripts/setup-syncfusion-skills.sh)).
+- **Syncfusion WPF skills**: [.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md](.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md) — BusBuddy overlay; vendor skills in `.agents/skills/` (gitignored, install via [.github/scripts/setup-syncfusion-skills.sh](.github/scripts/setup-syncfusion-skills.sh)). NuGet pin `SyncfusionVersion` in `Directory.Build.props` (**34.1.32**); MCP via `.cursor/mcp.json` → `run-syncfusion-mcp.sh`. Feature: [specs/006-syncfusion-tool-integration/spec.md](specs/006-syncfusion-tool-integration/spec.md).
 - **CI/CD workflow (solo developer)**: same file, section **Solo developer CI/CD workflow** — branch → PR → gates → auto-merge.
 - **GCP / GEE / secrets**: [Documentation/GCP-GEE-SECRETS-AND-AUTH.md](Documentation/GCP-GEE-SECRETS-AND-AUTH.md) — canonical auth reference.
 - **Architecture map**: [STEADY-STATE-AND-FINISH-ROADMAP.md](STEADY-STATE-AND-FINISH-ROADMAP.md) (BusBuddy-3 Architecture Map section).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,19 +7,19 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <!-- UseWPF only in BusBuddy.WPF / test projects — not globally (breaks Core + WebDAV builds) -->
         <!-- Syncfusion / EF / Serilog Versions (single definitions) -->
-        <SyncfusionVersion>33.2.10</SyncfusionVersion> <!-- bumped per 2026 package update plan; see STEADY-STATE-AND-FINISH-ROADMAP.md for Syncfusion 33.x upgrade notes (license + control patterns) -->
-        <EntityFrameworkVersion>9.0.8</EntityFrameworkVersion>
-    <NpgsqlVersion>9.0.3</NpgsqlVersion> <!-- for Postgres in docker-compose test/dev profiles -->
-        <SerilogVersion>4.3.0</SerilogVersion>
+        <SyncfusionVersion>34.1.32</SyncfusionVersion> <!-- 006: latest nuget.org Syncfusion WPF (SfGrid.WPF) as of 2026-07-24 -->
+        <EntityFrameworkVersion>9.0.18</EntityFrameworkVersion>
+    <NpgsqlVersion>9.0.4</NpgsqlVersion> <!-- for Postgres in docker-compose test/dev profiles -->
+        <SerilogVersion>4.4.0</SerilogVersion>
         <SerilogSinksFileVersion>7.0.0</SerilogSinksFileVersion>
-        <SerilogSinksConsoleVersion>6.0.0</SerilogSinksConsoleVersion>
+        <SerilogSinksConsoleVersion>6.1.1</SerilogSinksConsoleVersion>
         <SerilogSinksDebugVersion>3.0.0</SerilogSinksDebugVersion>
         <SerilogExtensionsLoggingVersion>9.0.2</SerilogExtensionsLoggingVersion>
         <!-- WPF/UI Package Versions (.NET 9 Compatible) -->
         <AutoMapperVersion>12.0.1</AutoMapperVersion>
         <AutoMapperExtensionsDIVersion>12.0.1</AutoMapperExtensionsDIVersion>
         <CommunityToolkitMvvmVersion>8.4.2</CommunityToolkitMvvmVersion> <!-- patch update -->
-        <WebView2Version>1.0.3405.78</WebView2Version>
+        <WebView2Version>1.0.4078.44</WebView2Version>
         <XamlBehaviorsVersion>1.1.135</XamlBehaviorsVersion>
         <!-- Testing Package Versions (.NET 9 Compatible) -->
         <NUnitVersion>4.4.0</NUnitVersion>
@@ -28,23 +28,23 @@
         <CoverletVersion>6.0.4</CoverletVersion>
         <MoqVersion>4.20.72</MoqVersion>
         <!-- External API Package Versions (.NET 9 Compatible) -->
-        <SqlClientVersion>6.1.1</SqlClientVersion>
-        <GoogleApisVersion>1.70.0</GoogleApisVersion>
-        <GoogleCloudStorageVersion>4.13.0</GoogleCloudStorageVersion>
-        <GoogleApisDriveVersion>1.70.0.3856</GoogleApisDriveVersion>
-        <OpenAIVersion>2.3.0</OpenAIVersion>
-        <PollyVersion>8.6.3</PollyVersion>
-        <SystemNetHttpJsonVersion>9.0.8</SystemNetHttpJsonVersion>
+        <SqlClientVersion>6.1.6</SqlClientVersion>
+        <GoogleApisVersion>1.75.0</GoogleApisVersion>
+        <GoogleCloudStorageVersion>4.15.0</GoogleCloudStorageVersion>
+        <GoogleApisDriveVersion>1.75.0.4210</GoogleApisDriveVersion>
+        <OpenAIVersion>2.12.0</OpenAIVersion>
+        <PollyVersion>8.7.0</PollyVersion>
+        <SystemNetHttpJsonVersion>9.0.18</SystemNetHttpJsonVersion>
         <NetTopologySuiteVersion>2.6.0</NetTopologySuiteVersion>
-        <MicrosoftIdentityClientVersion>4.76.0</MicrosoftIdentityClientVersion>
+        <MicrosoftIdentityClientVersion>4.86.1</MicrosoftIdentityClientVersion>
         <SerilogSettingsConfigurationVersion>9.0.0</SerilogSettingsConfigurationVersion>
         <NUnit3TestAdapterVersion>5.1.0</NUnit3TestAdapterVersion>
         <MoqEntityFrameworkCoreVersion>9.0.0.5</MoqEntityFrameworkCoreVersion>
         <!-- Microsoft.Extensions Package Versions — Consistent versioning -->
-        <MicrosoftExtensionsVersion>9.0.8</MicrosoftExtensionsVersion>
-        <MicrosoftExtensionsDependencyInjectionVersion>9.0.8</MicrosoftExtensionsDependencyInjectionVersion>
-        <MicrosoftExtensionsHostingVersion>9.0.8</MicrosoftExtensionsHostingVersion>
-        <MicrosoftExtensionsLoggingVersion>9.0.8</MicrosoftExtensionsLoggingVersion>
+        <MicrosoftExtensionsVersion>9.0.18</MicrosoftExtensionsVersion>
+        <MicrosoftExtensionsDependencyInjectionVersion>9.0.18</MicrosoftExtensionsDependencyInjectionVersion>
+        <MicrosoftExtensionsHostingVersion>9.0.18</MicrosoftExtensionsHostingVersion>
+        <MicrosoftExtensionsLoggingVersion>9.0.18</MicrosoftExtensionsLoggingVersion>
         <!-- INDUSTRY STANDARD: Practical Code Quality -->
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AnalysisMode>Recommended</AnalysisMode>

--- a/Documentation/PACKAGE-MANAGEMENT.md
+++ b/Documentation/PACKAGE-MANAGEMENT.md
@@ -86,22 +86,22 @@ Following [Syncfusion WPF Installation Guide](https://help.syncfusion.com/window
 
 ### Current Syncfusion Configuration
 
-- **Version**: `33.2.10` (pinned in Directory.Build.props; updated 2026 per package plan)
+- **Version**: `34.1.32` (pinned in `Directory.Build.props`; Spec 006 Syncfusion Tool Integration)
 - **Source**: `nuget.org` (official public feed)
-- **License**: Community/Commercial (configured via environment variable)
-- **Controls Used**: DockingManager, NavigationDrawer, SfDataGrid, Charts
+- **License**: Community/Commercial (configured via environment variable / macOS Passwords)
+- **Controls Used**: DockingManager, NavigationDrawer, SfDataGrid, Charts, SfScheduler, SfSkinManager (FluentDark/Light), and others per `BusBuddy.WPF.csproj`
 
 ### Syncfusion Package References
 
 ```xml
 <!-- Centralized in Directory.Build.props -->
 <PropertyGroup>
-  <SyncfusionVersion>30.1.40</SyncfusionVersion>
+  <SyncfusionVersion>34.1.32</SyncfusionVersion>
 </PropertyGroup>
 
 <!-- Individual project references -->
 <PackageReference Include="Syncfusion.SfChart.WPF" Version="$(SyncfusionVersion)" />
-<PackageReference Include="Syncfusion.SfDataGrid.WPF" Version="$(SyncfusionVersion)" />
+<PackageReference Include="Syncfusion.SfGrid.WPF" Version="$(SyncfusionVersion)" />
 <PackageReference Include="Syncfusion.Tools.WPF" Version="$(SyncfusionVersion)" />
 ```
 

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -1,0 +1,76 @@
+# BusBuddy Action Items (Due-Outs Tracker)
+
+**Canonical due-outs file for agents and humans.**
+**Historical finish narrative:** [STEADY-STATE-AND-FINISH-ROADMAP.md](../STEADY-STATE-AND-FINISH-ROADMAP.md)
+**Spec-Kit features:** [specs/](../specs/) (each feature may also have `tasks.md`)
+**Generated inventory (optional):** run function-inventory scanner → `docs/function-inventory.generated.md`
+**Visual tree (optional):** [function-tree.md](./function-tree.md)
+
+**Update rule:** When starting or finishing work, check boxes here and link the PR/spec. Prefer this file for “what’s left”; use Spec-Kit `tasks.md` for implementation steps inside a feature.
+
+---
+
+## Priorities (now)
+
+### P0 — Platform / tooling in flight
+
+- [x] Spec-Kit brownfield bootstrap (001–005) — merged [PR #20](https://github.com/Bigessfour/BusBuddy-3/pull/20)
+- [ ] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) (branch `feature/006-syncfusion-tool-integration`)
+  - [x] Fix Syncfusion WPF MCP paths (`.cursor/mcp.json` → Box workspace path)
+  - [x] Refresh WPF skills overlay notes for 34.x (run `setup-syncfusion-skills.sh` locally after clone)
+  - [x] Bump `SyncfusionVersion` **33.2.10 → 34.1.32** (build green on Mac with EnableWindowsTargeting)
+  - [x] Core infra deps audit → [deps-audit.md](../specs/006-syncfusion-tool-integration/deps-audit.md) + safe bumps
+  - [ ] Docs/`AGENTS.md` + `python -m rag.index` after merge
+  - [ ] Windows VM: Syncfusion license + UI smoke on 34.x
+  - [ ] P2 follow-up: AutoMapper 12 → ≥15.1.1 (GHSA-rvv3-g6hj-g44x) — deferred in audit
+  - **Verification:** `dotnet build BusBuddy.sln -c Release -p:EnableWindowsTargeting=true`; MCP assistant starts; Windows VM smoke for license/UI
+
+### P1 — Finish / domain (from roadmap; Spec-Kit wave 2)
+
+- [ ] Student import / optimize end-to-end (UI + SeedDataService + tests)
+- [ ] Reports: PdfReportService + AI path fully wired in UI
+- [ ] Driver availability + SfScheduler
+- [ ] Maintenance UI polish
+- [ ] Google Earth Engine enhancements (beyond current DI/auth)
+- [ ] End-to-end student → assign → report proof test
+
+### P2 — Hygiene / quality
+
+- [ ] Bootstrap function-inventory generated scan (`docs/function-inventory.generated.md`)
+- [ ] Resolve/exclude corrupted LFS noise on `TWN_CICD_Checklist_…pdf` if still dirty locally
+- [ ] AutoMapper 12.x advisory — upgrade or document risk acceptance (in 006 audit)
+- [ ] Ensure `Documentation/GCP-GEE-SECRETS-AND-AUTH.md` present or AGENTS links fixed (file was missing at Spec-Kit adopt)
+
+---
+
+## Spec-Kit features — status
+
+| Spec | Title                              | Status                                                                       |
+| ---- | ---------------------------------- | ---------------------------------------------------------------------------- |
+| 001  | Spec-Kit Integration & Bootstrap   | Done (PR #20)                                                                |
+| 002  | RAG Formalization & Agent Contract | Done (PR #20)                                                                |
+| 003  | Project Constitution               | Done (PR #20)                                                                |
+| 004  | Local LLM (Ollama)                 | Done (PR #20)                                                                |
+| 005  | Hybrid Dev Environment Guardrails  | Done (PR #20)                                                                |
+| 006  | Syncfusion Tool Integration        | **Implementing** (NuGet + MCP + audit done; VM smoke + RAG re-index pending) |
+
+---
+
+## AI / agent tooling
+
+- [x] `busbuddy-rag` MCP + mandatory RAG rule
+- [ ] Syncfusion WPF MCP path-correct + key documented (006)
+- [ ] Syncfusion WPF skills refresh for NuGet major (006)
+- [x] Spec-Kit `/speckit-*` skills committed
+
+---
+
+## Meta
+
+- Re-check this file at the start of each session.
+- After structural changes: update architecture map in `STEADY-STATE-AND-FINISH-ROADMAP.md` and re-index RAG.
+- Do not put secrets here.
+
+---
+
+*Bootstrapped 2026-07-24 to give BusBuddy a single due-outs checklist (function-inventory convention).*

--- a/docs/function-tree.md
+++ b/docs/function-tree.md
@@ -1,0 +1,27 @@
+# BusBuddy Function Tree (overview)
+
+High-level surface area. Detail and due-outs: [action-items.md](./action-items.md).
+
+```mermaid
+flowchart TB
+  subgraph agents [Agents]
+    SpecKit[Spec-Kit skills]
+    RAG[busbuddy-rag]
+    SfMCP[Syncfusion WPF MCP]
+    SfSkills[Syncfusion WPF skills]
+  end
+  subgraph app [BusBuddy]
+    WPF[BusBuddy.WPF Syncfusion UI]
+    Core[BusBuddy.Core services]
+    Data[EF + Postgres Docker]
+  end
+  SpecKit --> Core
+  SpecKit --> WPF
+  RAG --> SpecKit
+  SfMCP --> WPF
+  SfSkills --> WPF
+  WPF --> Core
+  Core --> Data
+```
+
+Update when major layers change (new services, new agent tooling).

--- a/specs/006-syncfusion-tool-integration/deps-audit.md
+++ b/specs/006-syncfusion-tool-integration/deps-audit.md
@@ -1,0 +1,44 @@
+# Dependency audit — Spec 006 (2026-07-24)
+
+Source: `dotnet list … package --outdated` + nuget.org flat container. Pins live in `Directory.Build.props`.
+
+## Applied (this PR)
+
+| Property                                          | Was         | Now             | Rationale                               |
+| ------------------------------------------------- | ----------- | --------------- | --------------------------------------- |
+| SyncfusionVersion                                 | 33.2.10     | **34.1.32**     | Latest Syncfusion WPF on nuget.org      |
+| EntityFrameworkVersion                            | 9.0.8       | **9.0.18**      | Latest EF Core 9.x patch (stay on net9) |
+| MicrosoftExtensionsVersion (+ DI/Hosting/Logging) | 9.0.8       | **9.0.18**      | Align with EF 9.0.18                    |
+| SystemNetHttpJsonVersion                          | 9.0.8       | **9.0.18**      | Align Extensions 9.x                    |
+| NpgsqlVersion                                     | 9.0.3       | **9.0.4**       | Latest Npgsql EF provider on 9.x        |
+| SqlClientVersion                                  | 6.1.1       | **6.1.6**       | Latest 6.x (defer SqlClient 7)          |
+| SerilogVersion                                    | 4.3.0       | **4.4.0**       | Latest Serilog 4.x                      |
+| SerilogSinksConsoleVersion                        | 6.0.0       | **6.1.1**       | Latest console sink                     |
+| WebView2Version                                   | 1.0.3405.78 | **1.0.4078.44** | Latest WebView2                         |
+| GoogleApisVersion                                 | 1.70.0      | **1.75.0**      | GEE/auth stack                          |
+| GoogleCloudStorageVersion                         | 4.13.0      | **4.15.0**      | GEE-related                             |
+| GoogleApisDriveVersion                            | 1.70.0.3856 | **1.75.0.4210** | Match Google.Apis 1.75                  |
+| MicrosoftIdentityClientVersion                    | 4.76.0      | **4.86.1**      | MSAL patch/minor                        |
+| PollyVersion                                      | 8.6.3       | **8.7.0**       | Resilience minor                        |
+| OpenAIVersion                                     | 2.3.0       | **2.12.0**      | Used by Core OpenAI-compatible client   |
+
+## Deferred (explicit)
+
+| Package                               | Current | Latest seen                                           | Why deferred                                                                                                     |
+| ------------------------------------- | ------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| AutoMapper (+ DI extensions)          | 12.0.1  | 15.x / 16.x (patched ≥15.1.1 for GHSA-rvv3-g6hj-g44x) | Major API + license/DI package changes; **risk accepted short-term** — track as P2 due-out to migrate or replace |
+| Microsoft.EntityFrameworkCore *       | 9.0.18  | 10.0.10                                               | EF 10 implies broader stack move; stay on net9                                                                   |
+| Microsoft.Extensions.*                | 9.0.18  | 10+/11 preview                                        | Keep aligned with EF 9                                                                                           |
+| Npgsql.EntityFrameworkCore.PostgreSQL | 9.0.4   | 10.0.3                                                | Requires EF 10                                                                                                   |
+| Microsoft.Data.SqlClient              | 6.1.6   | 7.x                                                   | Major; validate separately                                                                                       |
+| Serilog.Extensions.Logging            | 9.0.2   | 10.0.0                                                | Major; app uses Serilog directly                                                                                 |
+| CommunityToolkit.Mvvm                 | 8.4.2   | 8.4.2                                                 | Already current                                                                                                  |
+
+## Verification
+
+```bash
+dotnet restore BusBuddy.sln -p:EnableWindowsTargeting=true
+dotnet build BusBuddy.sln -c Release -p:EnableWindowsTargeting=true
+```
+
+Windows VM: Syncfusion license smoke after 34.x bump.

--- a/specs/006-syncfusion-tool-integration/plan.md
+++ b/specs/006-syncfusion-tool-integration/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: Syncfusion Tool Integration (006)
+
+**Branch**: `feature/006-syncfusion-tool-integration`
+**Spec**: [spec.md](./spec.md)
+**Due-outs**: [docs/action-items.md](../../docs/action-items.md)
+
+## Technical approach
+
+1. **MCP** — Point `.cursor/mcp.json` at the active clone (Box path) and prefer repo-relative launchers where Cursor resolves cwd to the project root. Keep `run-syncfusion-mcp.sh` loading `Syncfusion_API_Key` from Passwords.
+2. **Skills** — Document refresh via `setup-syncfusion-skills.sh` / `npx skills update`; update BusBuddy overlay for Syncfusion **34.x**.
+3. **NuGet** — Set `SyncfusionVersion` to **34.1.32** (nuget.org latest for SfGrid.WPF at implement time); all PackageReferences already use `$(SyncfusionVersion)`.
+4. **Deps audit** — `dotnet list package --outdated` → `deps-audit.md`; bump safe patch/minor aligned to net9; defer majors with rationale (e.g. AutoMapper).
+5. **Docs** — `AGENTS.md`, `PACKAGE-MANAGEMENT.md` Syncfusion pin, action-items checkboxes; RAG re-index after merge.
+
+## Constraints
+
+- Constitution: Syncfusion-only UI, Serilog-only, hybrid Mac/Windows, RAG-first.
+- Mac gate: build with `-p:EnableWindowsTargeting=true`.
+- Do not commit `.agents/skills/` or secrets.
+
+## Risks
+
+- Syncfusion 34.x XAML/API breaks → fix compile errors in-repo.
+- License key must cover 34.x Essential Studio line.
+- AutoMapper NU1903 — document; prefer upgrade path if available without large rewrite.

--- a/specs/006-syncfusion-tool-integration/spec.md
+++ b/specs/006-syncfusion-tool-integration/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Syncfusion Tool Integration
+
+**Feature Branch**: `feature/006-syncfusion-tool-integration`
+
+**Created**: 2026-07-24
+
+**Status**: Implementing (NuGet 34.1.32 + MCP paths + deps audit applied; Windows VM smoke pending)
+
+**Input**: Integrate and refresh Syncfusion agent tooling (WPF MCP + WPF Skills), upgrade Syncfusion WPF NuGet packages to the latest stable release, and audit/bump core infrastructure dependency versions in `Directory.Build.props` for current enhancements—without breaking Syncfusion-only UI, hybrid Mac/Windows builds, or license bootstrap.
+
+## Baseline (as of draft)
+
+| Area                 | Current                                                                                                                                                                                                                                                        | Target intent                                                                                                             |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Syncfusion NuGet pin | `33.2.10` in [`Directory.Build.props`](../../Directory.Build.props)                                                                                                                                                                                            | Latest stable on nuget.org (observed **34.1.31** for `Syncfusion.SfGrid.WPF` as of 2026-07-13; confirm at implement time) |
+| WPF MCP              | `syncfusion-wpf-assistant` via [`.github/scripts/run-syncfusion-mcp.sh`](../../.github/scripts/run-syncfusion-mcp.sh) (`npx @syncfusion/wpf-assistant@latest`)                                                                                                 | Working from this repo path; key from Passwords / env; documented for agents                                              |
+| MCP paths            | [`.cursor/mcp.json`](../../.cursor/mcp.json) still references `/Users/stephenmckitrick/BusBuddy/BusBuddy-3` for filesystem + script                                                                                                                            | Paths resolve to the active BusBuddy-3 workspace (Box path or relative/script-based)                                      |
+| WPF Skills           | Overlay [`.cursor/skills/syncfusion-wpf-busbuddy`](../../.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md); vendor skills via [`.github/scripts/setup-syncfusion-skills.sh`](../../.github/scripts/setup-syncfusion-skills.sh) → `.agents/skills/` (gitignored) | Overlay updated for new major; vendor skills refreshable (`npx skills update`)                                            |
+| Core infra pins      | EF `9.0.8`, Serilog `4.3.0`, Microsoft.Extensions `9.0.8`, CommunityToolkit.Mvvm `8.4.2`, etc.                                                                                                                                                                 | Audited against nuget.org; bump to latest **compatible** stables (same major TFM / no breaking host assumptions)          |
+
+Constitution constraints (MUST obey): Syncfusion-only UI; Serilog-only logging; Windows WPF + `EnableWindowsTargeting` on Mac; RAG-first for architectural changes; no AWS/cloud app hosting.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Syncfusion WPF MCP works in Cursor (Priority: P1)
+
+As a developer using Cursor, I can invoke the Syncfusion WPF MCP assistant against this repo so UI guidance comes from Syncfusion’s assistant, not invented APIs.
+
+**Why this priority**: Without a working MCP, agents invent Syncfusion patterns and violate constitution Syncfusion-only rules.
+
+**Independent Test**: From the active workspace, MCP server `syncfusion-wpf-assistant` starts; a probe prompt (e.g. SfDataGrid binding) returns a usable answer when `Syncfusion_API_Key` / Passwords entry is present. Paths in `.cursor/mcp.json` match the workspace (no stale `/Users/stephenmckitrick/BusBuddy/BusBuddy-3` unless that is still the real clone).
+
+**Acceptance Scenarios**:
+
+1. **Given** `Syncfusion_API_Key` (or Passwords name `SYNCFUSION_API_KEY` / `Syncfusion_API_Key`), **When** Cursor loads project MCP, **Then** `syncfusion-wpf-assistant` is listed and runnable via `run-syncfusion-mcp.sh`.
+2. **Given** the Box (or current) clone path, **When** inspecting `.cursor/mcp.json`, **Then** filesystem / script paths point at this repo (or use a path strategy that does not break on machine moves).
+3. **Given** no API key, **When** the launcher runs, **Then** it fails clearly (non-zero / stderr) without hanging or leaking secrets into the repo.
+
+---
+
+### User Story 2 - Syncfusion WPF Skills are current and BusBuddy-aware (Priority: P1)
+
+As an agent editing WPF XAML, I load official Syncfusion component skills plus the BusBuddy overlay so markup matches installed packages and project themes.
+
+**Why this priority**: Skills must track the NuGet major (33 → 34) and existing BusBuddy theming rules.
+
+**Independent Test**: `.github/scripts/setup-syncfusion-skills.sh` succeeds; `.agents/skills/syncfusion-wpf-*` exist locally; overlay skill documents the pinned `SyncfusionVersion` and package→skill map; `npx skills update` documented as the refresh path.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh clone, **When** running `setup-syncfusion-skills.sh`, **Then** vendor skills install under `.agents/skills/` (still gitignored).
+2. **Given** Syncfusion NuGet major bump, **When** reviewing `.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md`, **Then** version notes and package map match `Directory.Build.props` / `BusBuddy.WPF.csproj`.
+3. **Given** agent UI work, **When** following overlay rules, **Then** FluentDark/FluentLight via `SfSkinManager` remains mandatory and view-level theme dictionary merges stay forbidden.
+
+---
+
+### User Story 3 - Syncfusion WPF packages upgraded to latest stable (Priority: P1)
+
+As a maintainer, all Syncfusion WPF PackageReferences resolve to one latest stable version via `$(SyncfusionVersion)`.
+
+**Why this priority**: Primary product ask; unlocks control enhancements and fixes.
+
+**Independent Test**: `Directory.Build.props` `SyncfusionVersion` equals the chosen nuget.org latest; `dotnet restore` + `dotnet build … -p:EnableWindowsTargeting=true` succeed; no mixed Syncfusion versions across projects.
+
+**Acceptance Scenarios**:
+
+1. **Given** implement-time nuget.org latest for `Syncfusion.SfGrid.WPF` (and peer WPF packages), **When** updating `SyncfusionVersion`, **Then** every Syncfusion.* PackageReference uses `$(SyncfusionVersion)` only.
+2. **Given** the bump, **When** building Release with `EnableWindowsTargeting`, **Then** 0 errors (warnings triage documented if new analyzer noise appears).
+3. **Given** license registration in `App.xaml.cs`, **When** app starts on Windows VM, **Then** Syncfusion license still registers from env / Passwords (no trial watermarks when key present).
+4. **Given** upgrade notes / breaking changes in Syncfusion 34.x release notes, **When** compiling XAML, **Then** any API renames required by the bump are fixed in-repo (no deferred broken views).
+
+---
+
+### User Story 4 - Core infrastructure dependency version check (Priority: P2)
+
+As a maintainer, I audit and selectively bump non-Syncfusion pins in `Directory.Build.props` (EF Core, Npgsql, Serilog, Microsoft.Extensions.*, CommunityToolkit.Mvvm, WebView2, test packages, Google client libs used by GEE, etc.) to latest compatible stables.
+
+**Why this priority**: High leverage but secondary to Syncfusion tooling; must not destabilize CI.
+
+**Independent Test**: Produce an audit table (current → candidate → decision); apply safe bumps; restore/build/test Core filter still green locally or in CI.
+
+**Acceptance Scenarios**:
+
+1. **Given** `Directory.Build.props` version properties, **When** checking nuget.org (or `dotnet list package --outdated`), **Then** an audit artifact is recorded under this feature folder (e.g. `deps-audit.md`).
+2. **Given** a candidate bump, **When** it is a major that breaks net9-windows / Syncfusion / EF provider alignment, **Then** it is deferred with rationale (not force-upgraded).
+3. **Given** applied bumps, **When** `dotnet test` with CI filter (`Category!=Integration&Category!=InMemoryFlaky`), **Then** Core regression set still passes (Windows CI or documented Mac limitation).
+4. **Given** AutoMapper 12.x known advisory, **When** auditing, **Then** either upgrade to a fixed line or document explicit risk acceptance / replacement plan (do not ignore silently).
+
+---
+
+### User Story 5 - Docs and agent pointers stay aligned (Priority: P2)
+
+As an agent, I discover MCP + skills + version pins from `AGENTS.md` / constitution-adjacent docs without stale “30.1.40” or wrong paths.
+
+**Why this priority**: Stale docs caused prior version drift (PACKAGE-MANAGEMENT still mentions old versions in places).
+
+**Independent Test**: Touch `AGENTS.md` Syncfusion bullet(s), `Documentation/PACKAGE-MANAGEMENT.md` Syncfusion section, overlay skill, and re-run `python -m rag.index` after merge.
+
+**Acceptance Scenarios**:
+
+1. **Given** new SyncfusionVersion, **When** searching docs for old pins (e.g. `30.1.40`, `33.2.10` after bump), **Then** canonical docs are updated or clearly marked archived.
+2. **Given** MCP/skills setup, **When** reading `AGENTS.md`, **Then** one short pointer covers MCP key, skills install script, and NuGet pin location.
+
+## Edge Cases
+
+- License key valid for 33.x but not 34.x → document Syncfusion account license regeneration / Essential Studio version alignment.
+- Mac cannot run WPF UI tests → build with `EnableWindowsTargeting` is the Mac gate; full UI smoke on Windows VM.
+- Vendor skills install fails offline → script documents network requirement; overlay still committed.
+- Mixed Syncfusion versions from transitive packages → force alignment via central property / explicit PackageReference versions.
+- `mcp.json` is machine-specific → prefer script-relative invocation; avoid hard-coding another developer’s home path.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Syncfusion WPF MCP (`syncfusion-wpf-assistant`) MUST launch via repo script with key from env/Passwords; no keys in git.
+- **FR-002**: MCP configuration paths MUST resolve for the active BusBuddy-3 workspace.
+- **FR-003**: BusBuddy Syncfusion overlay skill MUST remain committed; vendor skills remain installable and gitignored.
+- **FR-004**: `SyncfusionVersion` MUST be updated to the latest stable Syncfusion WPF line confirmed at implement time; all Syncfusion PackageReferences MUST use that property.
+- **FR-005**: Solution MUST restore and build Release with `-p:EnableWindowsTargeting=true` after the bump.
+- **FR-006**: Produce `specs/006-syncfusion-tool-integration/deps-audit.md` listing core infra package current vs candidate vs action.
+- **FR-007**: Apply agreed non-Syncfusion bumps from the audit; defer incompatible majors with written rationale.
+- **FR-008**: Update agent/docs pointers (`AGENTS.md`, `PACKAGE-MANAGEMENT.md` Syncfusion section, overlay skill) and re-index RAG after merge.
+- **FR-009**: Remain Syncfusion-only UI; do not introduce standard WPF DataGrid or non-Serilog logging while upgrading.
+
+### Non-Goals
+
+- Rewriting views for new Syncfusion controls not already in use.
+- Cloud hosting / AWS.
+- Committing `.agents/skills/` vendor tree or chroma DB.
+- Expanding Spec-Kit constitution beyond a one-line pointer if versions are already covered by docs.
+
+## Success Criteria *(mandatory)*
+
+- MCP + skills refresh path documented and path-correct for this clone.
+- Single Syncfusion NuGet version = latest stable at implement time; build green.
+- `deps-audit.md` exists; safe bumps applied or explicitly deferred.
+- Docs/RAG reflect new pins; no secret material added.
+
+## Implementation notes (for `/speckit.plan`)
+
+Suggested order:
+
+1. Fix MCP paths + verify assistant launch.
+2. Refresh skills (`setup-syncfusion-skills.sh` / `npx skills update`) + overlay version notes.
+3. Bump `SyncfusionVersion` → restore/build → fix compile breaks from 34.x.
+4. Run outdated audit → selective infra bumps → test filter.
+5. Doc + RAG re-index.
+
+Primary files: `Directory.Build.props`, `BusBuddy.WPF/BusBuddy.WPF.csproj`, `.cursor/mcp.json`, `.github/scripts/run-syncfusion-mcp.sh`, `.github/scripts/setup-syncfusion-skills.sh`, `.cursor/skills/syncfusion-wpf-busbuddy/*`, `AGENTS.md`, `Documentation/PACKAGE-MANAGEMENT.md`.
+
+## References
+
+- Syncfusion WPF NuGet: https://www.nuget.org/packages/Syncfusion.SfGrid.WPF
+- Syncfusion WPF skills: https://help.syncfusion.com/wpf/skills/component-skills
+- Constitution: `.specify/memory/constitution.md` (Syncfusion-only, hybrid, RAG-first)

--- a/specs/006-syncfusion-tool-integration/tasks.md
+++ b/specs/006-syncfusion-tool-integration/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Syncfusion Tool Integration (006)
+
+## Phase 1 — Tracking & MCP
+- [x] Bootstrap `docs/action-items.md` due-outs tracker
+- [x] Fix `.cursor/mcp.json` paths (Syncfusion MCP + filesystem + RAG cwd → Box workspace)
+- [ ] Smoke: Cursor reload MCP / `run-syncfusion-mcp.sh` with key (manual)
+
+## Phase 2 — Skills
+- [x] Update `.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md` for 34.x pin
+- [x] Note vendor refresh: `.github/scripts/setup-syncfusion-skills.sh` / `npx skills update`
+
+## Phase 3 — Syncfusion NuGet
+- [x] Set `SyncfusionVersion` → `34.1.32` in `Directory.Build.props`
+- [x] `dotnet restore` + `dotnet build -c Release -p:EnableWindowsTargeting=true` (0 errors)
+- [x] No 34.x compile breaks on Mac cross-build
+
+## Phase 4 — Core infra audit
+- [x] Write `deps-audit.md` from outdated list
+- [x] Apply safe bumps; defer AutoMapper major / EF10 / Extensions10
+- [x] Re-build after bumps (0 errors; AutoMapper NU1903 remains until P2)
+
+## Phase 5 — Docs
+- [x] Update `AGENTS.md` (due-outs pointer + Syncfusion pin)
+- [x] Update `Documentation/PACKAGE-MANAGEMENT.md` Syncfusion version section
+- [x] Update `docs/action-items.md` checkboxes
+- [ ] `python -m rag.index` after merge (operator)
+- [ ] Windows VM license + UI smoke
+
+## Done when
+Spec FR-001–FR-009 acceptance scenarios met; build green; action-items 006 rows updated; VM smoke + RAG re-index after merge.


### PR DESCRIPTION
## Summary
- Spec **006 Syncfusion Tool Integration**: bump `SyncfusionVersion` **33.2.10 → 34.1.32**; fix `.cursor/mcp.json` paths to the Box workspace; update BusBuddy Syncfusion overlay skill for 34.x.
- Core infra audit ([deps-audit.md](specs/006-syncfusion-tool-integration/deps-audit.md)): safe bumps (EF/Extensions **9.0.18**, Npgsql **9.0.4**, Serilog **4.4.0**, WebView2, Google/MSAL/Polly/OpenAI, etc.); defer AutoMapper major and EF/Extensions 10.
- Bootstrap due-outs tracker at [docs/action-items.md](docs/action-items.md) and point `AGENTS.md` at it.

## Test plan
- [x] `dotnet restore/build BusBuddy.sln -c Release -p:EnableWindowsTargeting=true` (0 errors)
- [ ] Reload Cursor MCP; confirm `syncfusion-wpf-assistant` + `busbuddy-rag` resolve
- [ ] Windows VM: Syncfusion license + UI smoke on 34.x
- [ ] After merge: `python -m rag.index`
- [ ] Optional later: AutoMapper ≥15.1.1 (GHSA) tracked in action-items