### PR TITLE
docs: 006 post-merge hygiene (RAG note, VM smoke, GCP auth doc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -689,6 +689,8 @@ nunit-*.xml
 **/*secret*
 **/*credential*
 **/*password*
+# Canonical auth guide (name matches *secret* ignore — keep tracked)
+!Documentation/GCP-GEE-SECRETS-AND-AUTH.md
 
 # Database connection files with hardcoded credentials
 *-connection-test.ps1

--- a/Documentation/GCP-GEE-SECRETS-AND-AUTH.md
+++ b/Documentation/GCP-GEE-SECRETS-AND-AUTH.md
@@ -1,0 +1,67 @@
+# GCP / Google Earth Engine — Secrets & Authentication
+
+Canonical reference for BusBuddy-3 Earth Engine and related secrets.  
+Keep in sync with `AGENTS.md`, `README.md` (Environment Variables), and `.specify/memory/constitution.md`.
+
+## Projects (do not invent IDs)
+
+| Project ID | Role |
+|------------|------|
+| `ee-bigessfour` | Earth Engine API + service account |
+| `new-coursera-490518` | GCP console / billing / `gcloud` default |
+| ~~`busbuddy-465000`~~ | **Invalid** — removed; never invent |
+
+Service account (typical): `bus-buddy-gee@ee-bigessfour.iam.gserviceaccount.com`
+
+## macOS (dev) — Passwords app
+
+Entry **Name** = env var name. Loaded at startup by `LoadApiKeysFromMacPasswords()` then `BootstrapGcpCredentialsForProduction()` in `BusBuddy.WPF/App.xaml.cs`.
+
+| Env var | Purpose |
+|---------|---------|
+| `SYNCFUSION_LICENSE_KEY` | Syncfusion WPF |
+| `Syncfusion_API_Key` | Syncfusion MCP assistant (`run-syncfusion-mcp.sh`) |
+| `XAI_API_KEY` / `GROK_API_KEY` | Optional legacy cloud xAI (`XAI:Provider=Xai`); default AI is local Ollama |
+| `GEE_PROJECT_ID` | `ee-bigessfour` |
+| `GEE_SERVICE_ACCOUNT_EMAIL` | SA email |
+| `GEE_SERVICE_ACCOUNT_JSON` | Full SA key JSON → materialized by `GcpCredentialBootstrap` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Optional path to key file |
+| `GCP_BILLING_PROJECT` / `GOOGLE_CLOUD_PROJECT` | `new-coursera-490518` |
+
+Setup helpers:
+
+```bash
+.github/scripts/setup-gcp-gee.sh      # gcloud: SA + keys/bus-buddy-gee-key.json
+.github/scripts/store-gcp-passwords.sh # macOS Passwords
+source .github/scripts/gcp-gee.env    # dev shell
+```
+
+## Production bootstrap (`GcpCredentialBootstrap`)
+
+- Path: `BusBuddy.Core/Configuration/GcpCredentialBootstrap.cs`
+- Materializes `GEE_SERVICE_ACCOUNT_JSON` to app data directory
+- Sets `GoogleEarthEngine__*` env overrides for `IConfiguration`
+- `IGeoDataService` gets live bearer token; `GoogleEarthEngineService` registered in WPF DI
+
+## Windows production / VM
+
+Set `GEE_SERVICE_ACCOUNT_JSON` or `GOOGLE_APPLICATION_CREDENTIALS` as machine/user env — no Keychain.  
+Shared `keys/` from Mac host is acceptable for VM smoke.
+
+## Services wired in DI
+
+| Type | Role |
+|------|------|
+| `GoogleEarthEngineService` | Full GEE export workflow (service account auth) |
+| `GeoDataService` | `IGeoDataService` — REST calls with bearer token |
+| `ShapefileEligibilityService` | Local Wiley district/town shapefiles (non-GEE) |
+
+## Never commit
+
+- Raw SA JSON, license keys, Passwords exports, or `.env` with secrets.
+
+## Related
+
+- Spec-Kit constitution: `.specify/memory/constitution.md`
+- Agent quick ref: `AGENTS.md`
+- Due-outs: `docs/action-items.md`

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -1,9 +1,10 @@
 # BusBuddy Action Items (Due-Outs Tracker)
 
-**Canonical due-outs file for agents and humans.**
-**Historical finish narrative:** [STEADY-STATE-AND-FINISH-ROADMAP.md](../STEADY-STATE-AND-FINISH-ROADMAP.md)
-**Spec-Kit features:** [specs/](../specs/) (each feature may also have `tasks.md`)
-**Generated inventory (optional):** run function-inventory scanner → `docs/function-inventory.generated.md`
+**Canonical due-outs file for agents and humans.**  
+**Historical finish narrative:** [STEADY-STATE-AND-FINISH-ROADMAP.md](../STEADY-STATE-AND-FINISH-ROADMAP.md)  
+**Spec-Kit features:** [specs/](../specs/) (each feature may also have `tasks.md`)  
+**Open GitHub issues:** https://github.com/Bigessfour/BusBuddy-3/issues  
+**Generated inventory (optional):** run function-inventory scanner → `docs/function-inventory.generated.md`  
 **Visual tree (optional):** [function-tree.md](./function-tree.md)
 
 **Update rule:** When starting or finishing work, check boxes here and link the PR/spec. Prefer this file for “what’s left”; use Spec-Kit `tasks.md` for implementation steps inside a feature.
@@ -12,20 +13,16 @@
 
 ## Priorities (now)
 
-### P0 — Platform / tooling in flight
+### P0 — Platform / tooling
 
 - [x] Spec-Kit brownfield bootstrap (001–005) — merged [PR #20](https://github.com/Bigessfour/BusBuddy-3/pull/20)
-- [ ] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) (branch `feature/006-syncfusion-tool-integration`)
-  - [x] Fix Syncfusion WPF MCP paths (`.cursor/mcp.json` → Box workspace path)
-  - [x] Refresh WPF skills overlay notes for 34.x (run `setup-syncfusion-skills.sh` locally after clone)
-  - [x] Bump `SyncfusionVersion` **33.2.10 → 34.1.32** (build green on Mac with EnableWindowsTargeting)
-  - [x] Core infra deps audit → [deps-audit.md](../specs/006-syncfusion-tool-integration/deps-audit.md) + safe bumps
-  - [ ] Docs/`AGENTS.md` + `python -m rag.index` after merge
-  - [ ] Windows VM: Syncfusion license + UI smoke on 34.x
-  - [ ] P2 follow-up: AutoMapper 12 → ≥15.1.1 (GHSA-rvv3-g6hj-g44x) — deferred in audit
-  - **Verification:** `dotnet build BusBuddy.sln -c Release -p:EnableWindowsTargeting=true`; MCP assistant starts; Windows VM smoke for license/UI
+- [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
+  - [x] MCP paths, skills overlay, Syncfusion **34.1.32**, deps audit
+  - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)
+  - [ ] Windows VM Syncfusion license + UI smoke — checklist: [windows-vm-smoke.md](../specs/006-syncfusion-tool-integration/windows-vm-smoke.md)
+  - [ ] P2: AutoMapper 12 → ≥15.1.1 (GHSA-rvv3-g6hj-g44x)
 
-### P1 — Finish / domain (from roadmap; Spec-Kit wave 2)
+### P1 — Finish / domain (Spec-Kit wave 2) — aligns with [issue #11](https://github.com/Bigessfour/BusBuddy-3/issues/11)
 
 - [ ] Student import / optimize end-to-end (UI + SeedDataService + tests)
 - [ ] Reports: PdfReportService + AI path fully wired in UI
@@ -38,29 +35,34 @@
 
 - [ ] Bootstrap function-inventory generated scan (`docs/function-inventory.generated.md`)
 - [ ] Resolve/exclude corrupted LFS noise on `TWN_CICD_Checklist_…pdf` if still dirty locally
-- [ ] AutoMapper 12.x advisory — upgrade or document risk acceptance (in 006 audit)
-- [ ] Ensure `Documentation/GCP-GEE-SECRETS-AND-AUTH.md` present or AGENTS links fixed (file was missing at Spec-Kit adopt)
+- [ ] AutoMapper 12.x advisory — upgrade or replace (see 006 deps-audit)
+- [x] Restore [Documentation/GCP-GEE-SECRETS-AND-AUTH.md](../Documentation/GCP-GEE-SECRETS-AND-AUTH.md) (was missing; AGENTS link)
+
+### GitHub issues triage (open as of 2026-07-24)
+
+| Issue | Topic | Suggested disposition |
+|-------|--------|------------------------|
+| [#13](https://github.com/Bigessfour/BusBuddy-3/issues/13) | ViewModel dedup | Largely done in hygiene/PR #16 (`BaseViewModelMvp` removed). Confirm no remaining flat VM refs → **close** |
+| [#14](https://github.com/Bigessfour/BusBuddy-3/issues/14) | CI + secrets/MCP | Mostly done (solo CI, Passwords, Syncfusion MCP). Re-check `ci-with-ai` / GH secrets → update or **close** |
+| [#15](https://github.com/Bigessfour/BusBuddy-3/issues/15) | Deprecate bb-* PS | Docs/deprecation done; residual archive refs OK → **close** or narrow remaining tasks |
+| [#11](https://github.com/Bigessfour/BusBuddy-3/issues/11) | Close stubs (Reports/Grok/Settings/Maintenance) | Still active — maps to **P1** above; keep open |
 
 ---
 
 ## Spec-Kit features — status
 
-| Spec | Title                              | Status                                                                       |
-| ---- | ---------------------------------- | ---------------------------------------------------------------------------- |
-| 001  | Spec-Kit Integration & Bootstrap   | Done (PR #20)                                                                |
-| 002  | RAG Formalization & Agent Contract | Done (PR #20)                                                                |
-| 003  | Project Constitution               | Done (PR #20)                                                                |
-| 004  | Local LLM (Ollama)                 | Done (PR #20)                                                                |
-| 005  | Hybrid Dev Environment Guardrails  | Done (PR #20)                                                                |
-| 006  | Syncfusion Tool Integration        | **Implementing** (NuGet + MCP + audit done; VM smoke + RAG re-index pending) |
+| Spec | Title | Status |
+|------|-------|--------|
+| 001–005 | Platform wave | Done (PR #20) |
+| 006 | Syncfusion Tool Integration | Done code (PR #21); **VM smoke pending** |
 
 ---
 
 ## AI / agent tooling
 
-- [x] `busbuddy-rag` MCP + mandatory RAG rule
-- [ ] Syncfusion WPF MCP path-correct + key documented (006)
-- [ ] Syncfusion WPF skills refresh for NuGet major (006)
+- [x] `busbuddy-rag` MCP + mandatory RAG rule (+ re-index after #21)
+- [x] Syncfusion WPF MCP path-correct (Box workspace) + key via Passwords / env
+- [x] Syncfusion WPF skills overlay updated for 34.x (vendor: `setup-syncfusion-skills.sh`)
 - [x] Spec-Kit `/speckit-*` skills committed
 
 ---
@@ -73,4 +75,4 @@
 
 ---
 
-*Bootstrapped 2026-07-24 to give BusBuddy a single due-outs checklist (function-inventory convention).*
+*Updated 2026-07-24 after PR #21 merge + RAG re-index.*

--- a/specs/006-syncfusion-tool-integration/tasks.md
+++ b/specs/006-syncfusion-tool-integration/tasks.md
@@ -23,8 +23,8 @@
 - [x] Update `AGENTS.md` (due-outs pointer + Syncfusion pin)
 - [x] Update `Documentation/PACKAGE-MANAGEMENT.md` Syncfusion version section
 - [x] Update `docs/action-items.md` checkboxes
-- [ ] `python -m rag.index` after merge (operator)
-- [ ] Windows VM license + UI smoke
+- [x] `python -m rag.index` after merge (operator) — done 2026-07-24
+- [ ] Windows VM license + UI smoke — see `windows-vm-smoke.md`
 
 ## Done when
 Spec FR-001–FR-009 acceptance scenarios met; build green; action-items 006 rows updated; VM smoke + RAG re-index after merge.

--- a/specs/006-syncfusion-tool-integration/windows-vm-smoke.md
+++ b/specs/006-syncfusion-tool-integration/windows-vm-smoke.md
@@ -1,0 +1,34 @@
+# Windows VM smoke checklist — Syncfusion 34.1.32 (Spec 006)
+
+Run inside the Windows guest after [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21) is on `master` (shared folder / `git pull`).
+
+## Prerequisites
+
+- .NET 9 SDK in the VM
+- `SYNCFUSION_LICENSE_KEY` set as user/machine env (or `SYNCFUSION_LICENSE_KEY.txt` drop-in used by `utm_run_in_vm.ps1`)
+- Optional: Ollama if testing local AI chat
+
+## Steps
+
+```powershell
+cd <path-to-BusBuddy-3>   # shared folder
+git pull origin master
+dotnet restore BusBuddy.sln -p:EnableWindowsTargeting=true
+dotnet build BusBuddy.sln -c Release -p:EnableWindowsTargeting=true
+# Launch:
+.\utm_run_in_vm.ps1
+# or:
+dotnet run --project BusBuddy.WPF/BusBuddy.WPF.csproj -c Release
+```
+
+## Pass criteria
+
+- [ ] Build succeeds in VM
+- [ ] App starts without Syncfusion trial watermark (license registered)
+- [ ] Main window: Dashboard / Students / Routes grids render (SfDataGrid)
+- [ ] Theme still FluentDark (or FluentLight) via SfSkinManager — no broken chrome
+- [ ] No crash on open of Google Earth / Reports shells
+
+## Record result
+
+Check the boxes above, then mark the VM smoke line in [docs/action-items.md](../../docs/action-items.md) and note date/operator in a PR comment or issue note.


### PR DESCRIPTION
## Summary
- Mark Spec **006** post-merge RAG re-index done in `docs/action-items.md` (ran locally after [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)).
- Add [windows-vm-smoke.md](specs/006-syncfusion-tool-integration/windows-vm-smoke.md) for the remaining Syncfusion 34.x UI/license check on Windows.
- Restore [Documentation/GCP-GEE-SECRETS-AND-AUTH.md](Documentation/GCP-GEE-SECRETS-AND-AUTH.md) (was missing; blocked by `**/*secret*` gitignore — exception added).
- Status comments on open issues [#11](https://github.com/Bigessfour/BusBuddy-3/issues/11)–[#15](https://github.com/Bigessfour/BusBuddy-3/issues/15).

## Test plan
- [x] `python -m rag.index` completed (~3399 chunks)
- [ ] Operator: run Windows VM smoke checklist
- [ ] Optionally close #13/#14/#15 if agreed