### PR TITLE
feat: wire Reports UI to PdfReportService and Ollama

### DIFF
--- a/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
@@ -108,6 +108,8 @@ namespace BusBuddy.Core.Extensions
             services.AddScoped<IActivityService, ActivityService>();
             services.AddScoped<IRouteService, RouteService>();
             services.AddScoped<IStudentRouteOptimizer, StudentRouteOptimizer>();
+            services.AddSingleton<PdfReportService>();
+            services.AddScoped<IOperationalReportService, OperationalReportService>();
             services.AddScoped<IStudentService, StudentService>();
             services.AddScoped<IFuelService, FuelService>();
             services.AddScoped<IMaintenanceService, MaintenanceService>();

--- a/BusBuddy.Core/Services/GrokGlobalAPI.cs
+++ b/BusBuddy.Core/Services/GrokGlobalAPI.cs
@@ -86,6 +86,65 @@ namespace BusBuddy.Core.Services
         public bool IsConfigured => _isConfigured;
 
         /// <summary>
+        /// Short operator-facing commentary for reports. Uses Ollama when configured; otherwise a mock line.
+        /// </summary>
+        public async Task<string> GetShortCommentaryAsync(string topic, string facts)
+        {
+            if (string.IsNullOrWhiteSpace(topic))
+            {
+                topic = "report";
+            }
+
+            facts ??= string.Empty;
+            if (!_isConfigured)
+            {
+                return $"Mock insight for {topic}: {facts}";
+            }
+
+            try
+            {
+                var provider = _configuration["XAI:Provider"] ?? "Ollama";
+                var isOllama = string.Equals(provider, "Ollama", StringComparison.OrdinalIgnoreCase);
+                var model = isOllama
+                    ? (_configuration["XAI:OllamaModel"] ?? "llama3.2")
+                    : (_configuration["XAI:DefaultModel"] ?? DEFAULT_MODEL);
+                var request = new XAIRequest
+                {
+                    Model = model,
+                    Messages = new[]
+                    {
+                        new XAIMessage
+                        {
+                            Role = "system",
+                            Content = "You are a school transportation coordinator assistant. Reply in one or two short sentences."
+                        },
+                        new XAIMessage
+                        {
+                            Role = "user",
+                            Content = $"Topic: {topic}\nFacts: {facts}"
+                        }
+                    },
+                    Temperature = 0.2,
+                    MaxTokens = 120
+                };
+
+                var response = await CallGrokAPI(CHAT_COMPLETIONS_ENDPOINT, request);
+                if (IsFailedApiResponse(response))
+                {
+                    return $"Mock insight for {topic}: {facts}";
+                }
+
+                var content = response.Choices[0].Message.Content?.Trim();
+                return string.IsNullOrWhiteSpace(content) ? $"Mock insight for {topic}: {facts}" : content;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Report commentary fell back to mock for {Topic}", topic);
+                return $"Mock insight for {topic}: {facts}";
+            }
+        }
+
+        /// <summary>
         /// Call bb-routes for optimization using xAI Grok intelligence
         /// This is the main method requested in the user requirements
         /// </summary>

--- a/BusBuddy.Core/Services/IOperationalReportService.cs
+++ b/BusBuddy.Core/Services/IOperationalReportService.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+
+namespace BusBuddy.Core.Services
+{
+    public enum OperationalReportKind
+    {
+        StudentRoster,
+        StudentRouteAssignment,
+        EnrollmentSummary,
+        UnassignedStudents,
+        RouteSummary,
+        DailySchedule,
+        VehicleAssignment,
+        RouteEfficiency,
+        DriverRoster,
+        LicenseExpiration,
+        TrainingStatus,
+        Compliance,
+        FleetInventory,
+        MaintenanceSchedule,
+        FuelUsage,
+        FleetUtilization,
+        CsvExport,
+        PdfExport,
+        ExcelExport,
+        PrintStudentLists,
+        PrintRouteMaps,
+        PrintSchedules
+    }
+
+    public sealed class OperationalReportResult
+    {
+        public byte[] FileBytes { get; init; } = [];
+        public string FilePath { get; init; } = string.Empty;
+        public string Status { get; init; } = string.Empty;
+        public string AiSummary { get; init; } = string.Empty;
+        public bool UsedMockAi { get; init; }
+    }
+
+    public interface IOperationalReportService
+    {
+        Task<OperationalReportResult> GenerateAsync(OperationalReportKind kind, string? outputDirectory = null);
+    }
+}

--- a/BusBuddy.Core/Services/OperationalReportService.cs
+++ b/BusBuddy.Core/Services/OperationalReportService.cs
@@ -1,0 +1,373 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BusBuddy.Core.Models;
+using BusBuddy.Core.Services.Interfaces;
+using Serilog;
+
+namespace BusBuddy.Core.Services
+{
+    /// <summary>
+    /// Builds operational PDFs/CSVs from live services and optional Ollama commentary.
+    /// </summary>
+    public sealed class OperationalReportService : IOperationalReportService
+    {
+        private static readonly ILogger Logger = Log.ForContext<OperationalReportService>();
+        private readonly PdfReportService _pdf;
+        private readonly IStudentService _students;
+        private readonly IRouteService _routes;
+        private readonly IDriverService? _drivers;
+        private readonly IBusService? _buses;
+        private readonly IFuelService? _fuel;
+        private readonly IMaintenanceService? _maintenance;
+        private readonly GrokGlobalAPI? _grok;
+
+        public OperationalReportService(
+            PdfReportService pdf,
+            IStudentService students,
+            IRouteService routes,
+            IDriverService? drivers = null,
+            IBusService? buses = null,
+            IFuelService? fuel = null,
+            IMaintenanceService? maintenance = null,
+            GrokGlobalAPI? grok = null)
+        {
+            _pdf = pdf ?? throw new ArgumentNullException(nameof(pdf));
+            _students = students ?? throw new ArgumentNullException(nameof(students));
+            _routes = routes ?? throw new ArgumentNullException(nameof(routes));
+            _drivers = drivers;
+            _buses = buses;
+            _fuel = fuel;
+            _maintenance = maintenance;
+            _grok = grok;
+        }
+
+        public async Task<OperationalReportResult> GenerateAsync(OperationalReportKind kind, string? outputDirectory = null)
+        {
+            var students = await _students.GetAllStudentsAsync() ?? new List<Student>();
+            var routesResult = await _routes.GetAllActiveRoutesAsync();
+            var routes = routesResult.IsSuccess && routesResult.Value is not null
+                ? routesResult.Value.ToList()
+                : new List<Route>();
+            var drivers = _drivers is null ? new List<Driver>() : await _drivers.GetAllDriversAsync() ?? new List<Driver>();
+            var buses = _buses is null
+                ? new List<Bus>()
+                : (await _buses.GetAllBusesAsync())?.ToList() ?? new List<Bus>();
+            var fuel = _fuel is null
+                ? new List<Fuel>()
+                : (await _fuel.GetAllFuelRecordsAsync())?.ToList() ?? new List<Fuel>();
+            var maintenance = _maintenance is null
+                ? new List<Maintenance>()
+                : (await _maintenance.GetAllMaintenanceRecordsAsync())?.ToList() ?? new List<Maintenance>();
+
+            var title = DisplayName(kind);
+            var (headers, rows, facts) = BuildTable(kind, students, routes, drivers, buses, fuel, maintenance);
+            var ai = await TryCommentaryAsync(title, facts);
+            var isCsv = kind is OperationalReportKind.CsvExport or OperationalReportKind.ExcelExport;
+            var bytes = isCsv
+                ? Encoding.UTF8.GetBytes(ToCsv(headers, rows))
+                : kind == OperationalReportKind.RouteSummary && routes.Count > 0
+                    ? BuildRouteSummaryPdf(routes[0], students, buses, drivers, ai.Text)
+                    : _pdf.GenerateTabularReport(title, headers, rows, ai.Text);
+
+            var dir = string.IsNullOrWhiteSpace(outputDirectory)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "BusBuddy", "Reports")
+                : outputDirectory;
+            Directory.CreateDirectory(dir);
+            var ext = isCsv ? "csv" : "pdf";
+            var path = Path.Combine(dir, $"{kind}-{DateTime.Now:yyyyMMdd-HHmmss}.{ext}");
+            await File.WriteAllBytesAsync(path, bytes);
+
+            var prefix = kind.ToString().StartsWith("Print", StringComparison.Ordinal) ? "Saved for print" : "Wrote";
+            var status = $"{prefix} {title} ({rows.Count} row(s), {bytes.Length} bytes) → {path}";
+            Logger.Information("Operational report {Kind} written to {Path} bytes={Bytes}", kind, path, bytes.Length);
+
+            return new OperationalReportResult
+            {
+                FileBytes = bytes,
+                FilePath = path,
+                Status = status,
+                AiSummary = ai.Text,
+                UsedMockAi = ai.Mock
+            };
+        }
+
+        private byte[] BuildRouteSummaryPdf(
+            Route route,
+            IReadOnlyList<Student> students,
+            IReadOnlyList<Bus> buses,
+            IReadOnlyList<Driver> drivers,
+            string? notes)
+        {
+            var assigned = students
+                .Where(s => string.Equals(s.AMRoute, route.RouteName, StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(s.PMRoute, route.RouteName, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var bus = route.AMVehicleId.HasValue
+                ? buses.FirstOrDefault(b => b.BusId == route.AMVehicleId.Value)
+                : null;
+            var driver = route.AMDriverId.HasValue
+                ? drivers.FirstOrDefault(d => d.DriverId == route.AMDriverId.Value)
+                : null;
+            var pdf = _pdf.GenerateRouteSummaryReport(
+                route,
+                Array.Empty<RouteStop>(),
+                assigned,
+                bus,
+                driver,
+                RouteTimeSlot.AM);
+            if (pdf.Length > 0)
+            {
+                return pdf;
+            }
+
+            return _pdf.GenerateTabularReport(
+                "Route Summary",
+                new[] { "Student", "AM", "PM" },
+                assigned.Select(s => (IReadOnlyList<string>)new[] { s.StudentName, s.AMRoute ?? "", s.PMRoute ?? "" }).ToList(),
+                notes);
+        }
+
+        private static (IReadOnlyList<string> Headers, IReadOnlyList<IReadOnlyList<string>> Rows, string Facts) BuildTable(
+            OperationalReportKind kind,
+            IReadOnlyList<Student> students,
+            IReadOnlyList<Route> routes,
+            IReadOnlyList<Driver> drivers,
+            IReadOnlyList<Bus> buses,
+            IReadOnlyList<Fuel> fuel,
+            IReadOnlyList<Maintenance> maintenance)
+        {
+            var unassigned = students.Where(s =>
+                string.IsNullOrWhiteSpace(s.AMRoute) && string.IsNullOrWhiteSpace(s.PMRoute)).ToList();
+
+            return kind switch
+            {
+                OperationalReportKind.StudentRoster or OperationalReportKind.PdfExport
+                    or OperationalReportKind.PrintStudentLists or OperationalReportKind.CsvExport
+                    or OperationalReportKind.ExcelExport => (
+                    new[] { "Name", "Grade", "AM", "PM", "School" },
+                    students.Select(s => (IReadOnlyList<string>)new[]
+                    {
+                        s.StudentName, s.Grade ?? "", s.AMRoute ?? "", s.PMRoute ?? "", s.School ?? ""
+                    }).ToList(),
+                    $"{students.Count} students; {unassigned.Count} unassigned"),
+
+                OperationalReportKind.StudentRouteAssignment => (
+                    new[] { "Name", "AM Route", "PM Route" },
+                    students.Select(s => (IReadOnlyList<string>)new[]
+                    {
+                        s.StudentName, s.AMRoute ?? "(none)", s.PMRoute ?? "(none)"
+                    }).ToList(),
+                    $"{students.Count(s => !string.IsNullOrWhiteSpace(s.AMRoute) || !string.IsNullOrWhiteSpace(s.PMRoute))} assigned of {students.Count}"),
+
+                OperationalReportKind.EnrollmentSummary => (
+                    new[] { "Grade", "Count" },
+                    students.GroupBy(s => string.IsNullOrWhiteSpace(s.Grade) ? "(none)" : s.Grade!)
+                        .OrderBy(g => g.Key)
+                        .Select(g => (IReadOnlyList<string>)new[] { g.Key, g.Count().ToString(CultureInfo.InvariantCulture) })
+                        .ToList(),
+                    $"{students.Count} enrolled across {students.Select(s => s.Grade).Distinct().Count()} grades"),
+
+                OperationalReportKind.UnassignedStudents => (
+                    new[] { "Name", "Grade", "Address" },
+                    unassigned.Select(s => (IReadOnlyList<string>)new[]
+                    {
+                        s.StudentName, s.Grade ?? "", s.HomeAddress ?? ""
+                    }).ToList(),
+                    $"{unassigned.Count} students missing AM and PM routes"),
+
+                OperationalReportKind.RouteSummary or OperationalReportKind.DailySchedule
+                    or OperationalReportKind.PrintSchedules or OperationalReportKind.PrintRouteMaps => (
+                    new[] { "Route", "School", "AM riders", "PM riders" },
+                    routes.Select(r => (IReadOnlyList<string>)new[]
+                    {
+                        r.RouteName ?? "",
+                        r.School ?? "",
+                        students.Count(s => string.Equals(s.AMRoute, r.RouteName, StringComparison.OrdinalIgnoreCase))
+                            .ToString(CultureInfo.InvariantCulture),
+                        students.Count(s => string.Equals(s.PMRoute, r.RouteName, StringComparison.OrdinalIgnoreCase))
+                            .ToString(CultureInfo.InvariantCulture)
+                    }).ToList(),
+                    $"{routes.Count} active routes"),
+
+                OperationalReportKind.VehicleAssignment => (
+                    new[] { "Route", "AM bus", "PM bus" },
+                    routes.Select(r => (IReadOnlyList<string>)new[]
+                    {
+                        r.RouteName ?? "",
+                        BusNumber(buses, r.AMVehicleId),
+                        BusNumber(buses, r.PMVehicleId)
+                    }).ToList(),
+                    $"{routes.Count(r => r.AMVehicleId.HasValue || r.PMVehicleId.HasValue)} routes with a vehicle"),
+
+                OperationalReportKind.RouteEfficiency => (
+                    new[] { "Route", "Assigned", "Notes" },
+                    routes.Select(r =>
+                    {
+                        var count = students.Count(s =>
+                            string.Equals(s.AMRoute, r.RouteName, StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(s.PMRoute, r.RouteName, StringComparison.OrdinalIgnoreCase));
+                        return (IReadOnlyList<string>)new[]
+                        {
+                            r.RouteName ?? "",
+                            count.ToString(CultureInfo.InvariantCulture),
+                            count == 0 ? "empty" : "in service"
+                        };
+                    }).ToList(),
+                    $"{routes.Count} routes; {unassigned.Count} still unassigned"),
+
+                OperationalReportKind.DriverRoster or OperationalReportKind.Compliance => (
+                    new[] { "Driver", "Status", "Training", "License" },
+                    drivers.Select(d => (IReadOnlyList<string>)new[]
+                    {
+                        d.DriverName,
+                        d.Status ?? "",
+                        d.TrainingComplete ? "Complete" : "Incomplete",
+                        d.LicenseExpiryDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? ""
+                    }).ToList(),
+                    $"{drivers.Count} drivers; {drivers.Count(d => d.NeedsAttention)} need attention"),
+
+                OperationalReportKind.LicenseExpiration => (
+                    new[] { "Driver", "Expires", "Status" },
+                    drivers.OrderBy(d => d.LicenseExpiryDate ?? DateTime.MaxValue)
+                        .Select(d => (IReadOnlyList<string>)new[]
+                        {
+                            d.DriverName,
+                            d.LicenseExpiryDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "(none)",
+                            d.LicenseStatus ?? ""
+                        }).ToList(),
+                    $"{drivers.Count(d => d.LicenseExpiryDate.HasValue && d.LicenseExpiryDate.Value < DateTime.Today.AddDays(30))} licenses due in 30 days"),
+
+                OperationalReportKind.TrainingStatus => (
+                    new[] { "Driver", "Training" },
+                    drivers.Select(d => (IReadOnlyList<string>)new[]
+                    {
+                        d.DriverName,
+                        d.TrainingComplete ? "Complete" : "Incomplete"
+                    }).ToList(),
+                    $"{drivers.Count(d => !d.TrainingComplete)} drivers missing training"),
+
+                OperationalReportKind.FleetInventory or OperationalReportKind.FleetUtilization => (
+                    new[] { "Bus", "Status", "Seats", "Year" },
+                    buses.Select(b => (IReadOnlyList<string>)new[]
+                    {
+                        b.BusNumber ?? "",
+                        b.Status ?? "",
+                        b.SeatingCapacity.ToString(CultureInfo.InvariantCulture),
+                        b.Year.ToString(CultureInfo.InvariantCulture)
+                    }).ToList(),
+                    $"{buses.Count} buses; {buses.Count(b => string.Equals(b.Status, "Active", StringComparison.OrdinalIgnoreCase))} active"),
+
+                OperationalReportKind.MaintenanceSchedule => (
+                    new[] { "Date", "Vehicle", "Work", "Priority" },
+                    maintenance.OrderByDescending(m => m.Date).Take(40)
+                        .Select(m => (IReadOnlyList<string>)new[]
+                        {
+                            m.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                            m.VehicleId.ToString(CultureInfo.InvariantCulture),
+                            m.MaintenanceCompleted ?? "",
+                            m.Priority ?? ""
+                        }).ToList(),
+                    $"{maintenance.Count} maintenance records"),
+
+                OperationalReportKind.FuelUsage => (
+                    new[] { "Date", "Vehicle", "Gallons", "Cost" },
+                    fuel.OrderByDescending(f => f.FuelDate).Take(40)
+                        .Select(f => (IReadOnlyList<string>)new[]
+                        {
+                            f.FuelDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                            f.VehicleFueledId.ToString(CultureInfo.InvariantCulture),
+                            (f.Gallons ?? 0).ToString("0.0", CultureInfo.InvariantCulture),
+                            (f.TotalCost ?? 0).ToString("0.00", CultureInfo.InvariantCulture)
+                        }).ToList(),
+                    $"{fuel.Count} fuel records"),
+
+                _ => (
+                    new[] { "Item", "Value" },
+                    new List<IReadOnlyList<string>>
+                    {
+                        new[] { "Students", students.Count.ToString(CultureInfo.InvariantCulture) },
+                        new[] { "Routes", routes.Count.ToString(CultureInfo.InvariantCulture) }
+                    },
+                    $"{students.Count} students, {routes.Count} routes")
+            };
+        }
+
+        private static string BusNumber(IReadOnlyList<Bus> buses, int? id) =>
+            id.HasValue ? buses.FirstOrDefault(b => b.BusId == id.Value)?.BusNumber ?? id.Value.ToString(CultureInfo.InvariantCulture) : "(none)";
+
+        private static string DisplayName(OperationalReportKind kind) => kind switch
+        {
+            OperationalReportKind.StudentRoster => "Student Roster",
+            OperationalReportKind.StudentRouteAssignment => "Student Route Assignments",
+            OperationalReportKind.EnrollmentSummary => "Enrollment Summary",
+            OperationalReportKind.UnassignedStudents => "Unassigned Students",
+            OperationalReportKind.RouteSummary => "Route Summary",
+            OperationalReportKind.DailySchedule => "Daily Schedule",
+            OperationalReportKind.VehicleAssignment => "Vehicle Assignment",
+            OperationalReportKind.RouteEfficiency => "Route Efficiency",
+            OperationalReportKind.DriverRoster => "Driver Roster",
+            OperationalReportKind.LicenseExpiration => "License Expiration",
+            OperationalReportKind.TrainingStatus => "Training Status",
+            OperationalReportKind.Compliance => "Compliance",
+            OperationalReportKind.FleetInventory => "Fleet Inventory",
+            OperationalReportKind.MaintenanceSchedule => "Maintenance Schedule",
+            OperationalReportKind.FuelUsage => "Fuel Usage",
+            OperationalReportKind.FleetUtilization => "Fleet Utilization",
+            OperationalReportKind.CsvExport => "CSV Export",
+            OperationalReportKind.PdfExport => "PDF Export",
+            OperationalReportKind.ExcelExport => "Excel-ready CSV",
+            OperationalReportKind.PrintStudentLists => "Student Lists",
+            OperationalReportKind.PrintRouteMaps => "Route Maps",
+            OperationalReportKind.PrintSchedules => "Schedules",
+            _ => kind.ToString()
+        };
+
+        private static string ToCsv(IReadOnlyList<string> headers, IReadOnlyList<IReadOnlyList<string>> rows)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(string.Join(',', headers.Select(Csv)));
+            foreach (var row in rows)
+            {
+                sb.AppendLine(string.Join(',', row.Select(Csv)));
+            }
+
+            return sb.ToString();
+        }
+
+        private static string Csv(string? value)
+        {
+            value ??= string.Empty;
+            if (value.Contains(',') || value.Contains('"') || value.Contains('\n'))
+            {
+                return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+            }
+
+            return value;
+        }
+
+        private async Task<(string Text, bool Mock)> TryCommentaryAsync(string topic, string facts)
+        {
+            if (_grok is null)
+            {
+                return ($"{topic}: {facts}", true);
+            }
+
+            try
+            {
+                var text = await _grok.GetShortCommentaryAsync(topic, facts);
+                var mock = text.StartsWith("Mock insight", StringComparison.OrdinalIgnoreCase);
+                return (text, mock);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "AI commentary skipped for {Topic}", topic);
+                return ($"{topic}: {facts}", true);
+            }
+        }
+    }
+}

--- a/BusBuddy.Core/Services/PdfReportService.cs
+++ b/BusBuddy.Core/Services/PdfReportService.cs
@@ -574,6 +574,74 @@ namespace BusBuddy.Core.Services
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Generic tabular PDF used by operational reports (roster, fleet, drivers, etc.).
+        /// </summary>
+        public byte[] GenerateTabularReport(
+            string title,
+            IReadOnlyList<string> headers,
+            IReadOnlyList<IReadOnlyList<string>> rows,
+            string? notes = null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(title);
+            headers ??= Array.Empty<string>();
+            rows ??= Array.Empty<IReadOnlyList<string>>();
+
+            using var document = new PdfDocument();
+            var page = document.Pages.Add();
+            var g = page.Graphics;
+            var titleFont = new PdfStandardFont(PdfFontFamily.Helvetica, 16, PdfFontStyle.Bold);
+            var labelFont = new PdfStandardFont(PdfFontFamily.Helvetica, 9, PdfFontStyle.Bold);
+            var bodyFont = new PdfStandardFont(PdfFontFamily.Helvetica, 9);
+            var accent = new PdfSolidBrush(new PdfColor(11, 126, 200));
+            var pageWidth = page.GetClientSize().Width;
+
+            g.DrawRectangle(accent, new RectangleF(0, 0, pageWidth, 44));
+            g.DrawString($"Bus Buddy — {title}", titleFont, PdfBrushes.White, new PointF(16, 12));
+
+            float y = 56f;
+            g.DrawString($"Generated {DateTime.Now:yyyy-MM-dd HH:mm}    Rows: {rows.Count}", bodyFont, PdfBrushes.Black, new PointF(16, y));
+            y += 18f;
+
+            if (!string.IsNullOrWhiteSpace(notes))
+            {
+                g.DrawString(notes.Length > 220 ? notes[..217] + "..." : notes, bodyFont, PdfBrushes.Black, new PointF(16, y));
+                y += 16f;
+            }
+
+            var colCount = Math.Max(1, headers.Count);
+            var colWidth = (pageWidth - 32f) / colCount;
+            for (var i = 0; i < headers.Count; i++)
+            {
+                g.DrawString(headers[i], labelFont, PdfBrushes.Black, new PointF(16 + (i * colWidth), y));
+            }
+
+            y += 14f;
+            foreach (var row in rows.Take(42))
+            {
+                for (var i = 0; i < colCount && i < row.Count; i++)
+                {
+                    var cell = row[i] ?? string.Empty;
+                    if (cell.Length > 28)
+                    {
+                        cell = cell[..25] + "...";
+                    }
+
+                    g.DrawString(cell, bodyFont, PdfBrushes.Black, new PointF(16 + (i * colWidth), y));
+                }
+
+                y += 13f;
+                if (y > page.GetClientSize().Height - 36f)
+                {
+                    break;
+                }
+            }
+
+            using var ms = new MemoryStream();
+            document.Save(ms);
+            return ms.ToArray();
+        }
+
         #endregion
     }
 }

--- a/BusBuddy.Tests/Core/OperationalReportServiceTests.cs
+++ b/BusBuddy.Tests/Core/OperationalReportServiceTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using BusBuddy.Core.Models;
+using BusBuddy.Core.Services;
+using BusBuddy.Core.Utilities;
+using Moq;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core
+{
+    [TestFixture]
+    [Category("Core")]
+    public class OperationalReportServiceTests
+    {
+        private string _dir = null!;
+        private Mock<IStudentService> _students = null!;
+        private Mock<IRouteService> _routes = null!;
+        private OperationalReportService _service = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "BusBuddyReports", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _students = new Mock<IStudentService>();
+            _routes = new Mock<IRouteService>();
+            _students.Setup(s => s.GetAllStudentsAsync()).ReturnsAsync(new List<Student>
+            {
+                new() { StudentName = "Ada Rider", Grade = "4", School = "Wiley", AMRoute = "North", PMRoute = "North" },
+                new() { StudentName = "Ben Rider", Grade = "2", School = "Wiley" }
+            });
+            _routes.Setup(r => r.GetAllActiveRoutesAsync()).ReturnsAsync(
+                Result.SuccessResult<IEnumerable<Route>>(new[]
+                {
+                    new Route { RouteName = "North", Date = DateTime.Today, IsActive = true, School = "Wiley" }
+                }));
+            _service = new OperationalReportService(new PdfReportService(), _students.Object, _routes.Object);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                if (Directory.Exists(_dir))
+                {
+                    Directory.Delete(_dir, true);
+                }
+            }
+            catch
+            {
+                // ignore temp cleanup
+            }
+        }
+
+        [Test]
+        public async Task GenerateAsync_StudentRoster_WritesPdfWithTwoRows()
+        {
+            var result = await _service.GenerateAsync(OperationalReportKind.StudentRoster, _dir);
+
+            Assert.That(result.FileBytes.Length, Is.GreaterThan(100));
+            Assert.That(result.FileBytes[0], Is.EqualTo((byte)'%'));
+            Assert.That(File.Exists(result.FilePath), Is.True);
+            Assert.That(result.Status, Does.Contain("2 row"));
+            Assert.That(result.AiSummary, Does.Contain("unassigned"));
+        }
+
+        [Test]
+        public async Task GenerateAsync_UnassignedStudents_OnlyIncludesStudentsWithoutRoutes()
+        {
+            var result = await _service.GenerateAsync(OperationalReportKind.UnassignedStudents, _dir);
+
+            Assert.That(result.Status, Does.Contain("1 row"));
+            Assert.That(result.FileBytes[0], Is.EqualTo((byte)'%'));
+        }
+
+        [Test]
+        public async Task GenerateAsync_CsvExport_WritesCsvNotPdf()
+        {
+            var result = await _service.GenerateAsync(OperationalReportKind.CsvExport, _dir);
+
+            Assert.That(result.FilePath, Does.EndWith(".csv"));
+            var text = await File.ReadAllTextAsync(result.FilePath);
+            Assert.That(text, Does.Contain("Ada Rider"));
+            Assert.That(text, Does.StartWith("Name,"));
+        }
+    }
+}

--- a/BusBuddy.Tests/Core/PdfReportServiceTests.cs
+++ b/BusBuddy.Tests/Core/PdfReportServiceTests.cs
@@ -58,6 +58,25 @@ namespace BusBuddy.Tests.Core
         }
 
         [Test]
+        public void GenerateTabularReport_ReturnsValidPdf()
+        {
+            var bytes = _service.GenerateTabularReport(
+                "Student Roster",
+                new[] { "Name", "Grade" },
+                new[]
+                {
+                    (IReadOnlyList<string>)new[] { "Ada Rider", "4" },
+                    new[] { "Ben Rider", "2" }
+                },
+                "2 students; 1 unassigned");
+
+            Assert.That(bytes, Is.Not.Null);
+            Assert.That(bytes.Length, Is.GreaterThan(100));
+            Assert.That(bytes[0], Is.EqualTo((byte)'%'));
+            Assert.That(bytes[1], Is.EqualTo((byte)'P'));
+        }
+
+        [Test]
         public async Task GenerateRouteReport_WithGrokAI_MocksAndVerifies()
         {
             // Arrange - for Reports + AI/Grok (item 5), boosts coverage for finish/reports integration

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -509,6 +509,8 @@ namespace BusBuddy.WPF
                 services.AddScoped<IMaintenanceService, MaintenanceService>();
                 services.AddScoped<ISeedDataService, SeedDataService>();
                 services.AddScoped<IStudentRouteOptimizer, StudentRouteOptimizer>();
+                services.AddSingleton<PdfReportService>();
+                services.AddScoped<IOperationalReportService, OperationalReportService>();
 
                 // Register ViewModels for dependency injection (standardized on subfolder organization for dedup)
                 services.AddTransient<BusBuddy.WPF.ViewModels.MainWindowViewModel>();
@@ -517,6 +519,7 @@ namespace BusBuddy.WPF
                 services.AddTransient<BusBuddy.WPF.ViewModels.Settings.SettingsViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Analytics.AnalyticsDashboardViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Fuel.FuelManagementViewModel>();
+                services.AddTransient<BusBuddy.WPF.ViewModels.Reports.ReportsViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Student.StudentsViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Route.RouteManagementViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Driver.DriverFormViewModel>();

--- a/BusBuddy.WPF/ViewModels/Dashboard/DashboardViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Dashboard/DashboardViewModel.cs
@@ -21,19 +21,22 @@ namespace BusBuddy.WPF.ViewModels.Dashboard
         private readonly IFleetMonitoringService _fleetMonitoringService;
         private readonly IBusService _busService;
         private readonly IStudentRouteOptimizer? _routeOptimizer;
+        private readonly IOperationalReportService? _reportService;
 
         public DashboardViewModel(
             IRouteService routeService,
             IDashboardMetricsService metricsService,
             IFleetMonitoringService fleetMonitoringService,
             IBusService busService,
-            IStudentRouteOptimizer? routeOptimizer = null)
+            IStudentRouteOptimizer? routeOptimizer = null,
+            IOperationalReportService? reportService = null)
         {
             _routeService = routeService ?? throw new ArgumentNullException(nameof(routeService));
             _metricsService = metricsService ?? throw new ArgumentNullException(nameof(metricsService));
             _fleetMonitoringService = fleetMonitoringService ?? throw new ArgumentNullException(nameof(fleetMonitoringService));
             _busService = busService ?? throw new ArgumentNullException(nameof(busService));
             _routeOptimizer = routeOptimizer;
+            _reportService = reportService;
 
             RefreshCommand = new RelayCommand(async () => await RefreshDataAsync());
             OptimizeCommand = new RelayCommand(async () => await OptimizeRoutesAsync());
@@ -180,8 +183,14 @@ namespace BusBuddy.WPF.ViewModels.Dashboard
             {
                 IsLoading = true;
                 SystemStatus = "Generating report...";
-                await Task.Delay(1500);
-                SystemStatus = "Report generated successfully";
+                if (_reportService is null)
+                {
+                    SystemStatus = "Report service is not available";
+                    return;
+                }
+
+                var result = await _reportService.GenerateAsync(OperationalReportKind.RouteSummary);
+                SystemStatus = result.Status;
             }
             catch (Exception ex)
             {

--- a/BusBuddy.WPF/ViewModels/Reports/ReportsViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Reports/ReportsViewModel.cs
@@ -1,14 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using BusBuddy.Core.Models;
 using BusBuddy.Core.Services;
+using BusBuddy.WPF;
 using BusBuddy.WPF.ViewModels;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 
 namespace BusBuddy.WPF.ViewModels.Reports
@@ -19,16 +17,36 @@ namespace BusBuddy.WPF.ViewModels.Reports
     /// </summary>
     public class ReportsViewModel : BaseViewModel
     {
-        private readonly PdfReportService _reportService;
+        private readonly IOperationalReportService _reportService;
         private bool _isGeneratingReport;
         private string _lastReportGenerated = "None";
+        private string _aiReportSummary = "Run a report to see local AI insights (Ollama, with mock fallback).";
 
         public ReportsViewModel()
+            : this(CreateDefaultReportService())
         {
-            _reportService = new PdfReportService();
+        }
 
+        public ReportsViewModel(IOperationalReportService reportService)
+        {
+            _reportService = reportService ?? throw new ArgumentNullException(nameof(reportService));
             InitializeCommands();
             StatusMessage = "Ready to generate reports";
+        }
+
+        private static IOperationalReportService CreateDefaultReportService()
+        {
+            var sp = App.ServiceProvider;
+            return sp?.GetService<IOperationalReportService>()
+                ?? new OperationalReportService(
+                    new PdfReportService(),
+                    sp?.GetService<IStudentService>() ?? new StudentService(new BusBuddy.Core.Data.BusBuddyDbContextFactory()),
+                    sp?.GetService<IRouteService>() ?? new RouteService(new BusBuddy.Core.Data.BusBuddyDbContextFactory()),
+                    sp?.GetService<IDriverService>(),
+                    sp?.GetService<BusBuddy.Core.Services.Interfaces.IBusService>(),
+                    sp?.GetService<IFuelService>(),
+                    sp?.GetService<IMaintenanceService>(),
+                    sp?.GetService<GrokGlobalAPI>());
         }
 
         #region Properties
@@ -57,9 +75,13 @@ namespace BusBuddy.WPF.ViewModels.Reports
         public ObservableCollection<ReportEntry> GeneratedReports { get; } = new ObservableCollection<ReportEntry>();
 
         /// <summary>
-        /// AI-powered summary from Grok (wired for Reports + AI finish item)
+        /// AI-powered summary from Ollama / GrokGlobalAPI (mock fallback when offline).
         /// </summary>
-        public string AIReportSummary { get; private set; } = "Run a report to see Grok AI insights (e.g. optimization suggestions).";
+        public string AIReportSummary
+        {
+            get => _aiReportSummary;
+            private set => SetProperty(ref _aiReportSummary, value);
+        }
 
         #endregion
 
@@ -140,274 +162,105 @@ namespace BusBuddy.WPF.ViewModels.Reports
 
         #region Student Report Commands
 
-        private async Task ExecuteGenerateStudentRosterAsync()
-        {
-            await ExecuteReportGeneration("Student Roster Report", async () =>
-            {
-                Logger.Information("Generating student roster report");
-                // Real call to PdfReportService (Finish Reports UI + AI); empty list avoids model prop variance, proves integration + PDF bytes returned
-                var pdfBytes = _reportService.GenerateActivityCalendarReport(new List<BusBuddy.Core.Models.Activity>(), DateTime.Today.AddDays(-1), DateTime.Today.AddDays(1));
-                return $"Student roster report generated (PDF {pdfBytes.Length} bytes via PdfReportService + Grok AI insight applied)";
-            });
-        }
+        private Task ExecuteGenerateStudentRosterAsync() =>
+            ExecuteKindAsync(OperationalReportKind.StudentRoster, "Student Roster Report");
 
-        private async Task ExecuteGenerateStudentRouteReportAsync()
-        {
-            await ExecuteReportGeneration("Student Route Assignment Report", async () =>
-            {
-                Logger.Information("Generating student route assignment report");
-                // TODO: Implement student route assignment report
-                await Task.Delay(1500);
-                return "Student route assignment report generated";
-            });
-        }
+        private Task ExecuteGenerateStudentRouteReportAsync() =>
+            ExecuteKindAsync(OperationalReportKind.StudentRouteAssignment, "Student Route Assignment Report");
 
-        private async Task ExecuteGenerateEnrollmentSummaryAsync()
-        {
-            await ExecuteReportGeneration("Enrollment Summary Report", async () =>
-            {
-                Logger.Information("Generating enrollment summary report");
-                // TODO: Implement enrollment summary report
-                await Task.Delay(1500);
-                return "Enrollment summary report generated";
-            });
-        }
+        private Task ExecuteGenerateEnrollmentSummaryAsync() =>
+            ExecuteKindAsync(OperationalReportKind.EnrollmentSummary, "Enrollment Summary Report");
 
-        private async Task ExecuteGenerateUnassignedStudentsAsync()
-        {
-            await ExecuteReportGeneration("Unassigned Students Report", async () =>
-            {
-                Logger.Information("Generating unassigned students report");
-                // TODO: Implement unassigned students report
-                await Task.Delay(1500);
-                return "Unassigned students report generated";
-            });
-        }
+        private Task ExecuteGenerateUnassignedStudentsAsync() =>
+            ExecuteKindAsync(OperationalReportKind.UnassignedStudents, "Unassigned Students Report");
 
         #endregion
 
         #region Route Report Commands
 
-        private async Task ExecuteGenerateRouteSummaryAsync()
-        {
-            await ExecuteReportGeneration("Route Summary Report", async () =>
-            {
-                Logger.Information("Generating route summary report");
-                // Real PDF via service (Finish #5); RouteSummary overload shape varies by model version - using activity calendar for demo
-                var pdf = _reportService.GenerateActivityCalendarReport(new List<BusBuddy.Core.Models.Activity>(), DateTime.Today.AddDays(-1), DateTime.Today);
-                return $"Route summary report generated (PDF {pdf.Length} bytes via PdfReportService + Grok AI: efficiency +8%)";
-            });
-        }
+        private Task ExecuteGenerateRouteSummaryAsync() =>
+            ExecuteKindAsync(OperationalReportKind.RouteSummary, "Route Summary Report");
 
-        private async Task ExecuteGenerateDailyScheduleAsync()
-        {
-            await ExecuteReportGeneration("Daily Schedule Report", async () =>
-            {
-                Logger.Information("Generating daily schedule report");
-                // TODO: Implement daily schedule report
-                await Task.Delay(1500);
-                return "Daily schedule report generated";
-            });
-        }
+        private Task ExecuteGenerateDailyScheduleAsync() =>
+            ExecuteKindAsync(OperationalReportKind.DailySchedule, "Daily Schedule Report");
 
-        private async Task ExecuteGenerateVehicleAssignmentAsync()
-        {
-            await ExecuteReportGeneration("Vehicle Assignment Report", async () =>
-            {
-                Logger.Information("Generating vehicle assignment report");
-                // TODO: Implement vehicle assignment report
-                await Task.Delay(1500);
-                return "Vehicle assignment report generated";
-            });
-        }
+        private Task ExecuteGenerateVehicleAssignmentAsync() =>
+            ExecuteKindAsync(OperationalReportKind.VehicleAssignment, "Vehicle Assignment Report");
 
-        private async Task ExecuteGenerateRouteEfficiencyAsync()
-        {
-            await ExecuteReportGeneration("Route Efficiency Report", async () =>
-            {
-                Logger.Information("Generating route efficiency report");
-                // TODO: Implement route efficiency analysis
-                await Task.Delay(2000);
-                return "Route efficiency report generated";
-            });
-        }
+        private Task ExecuteGenerateRouteEfficiencyAsync() =>
+            ExecuteKindAsync(OperationalReportKind.RouteEfficiency, "Route Efficiency Report");
 
         #endregion
 
         #region Driver Report Commands
 
-        private async Task ExecuteGenerateDriverRosterAsync()
-        {
-            await ExecuteReportGeneration("Driver Roster Report", async () =>
-            {
-                Logger.Information("Generating driver roster report");
-                // TODO: Implement driver roster report
-                await Task.Delay(1500);
-                return "Driver roster report generated";
-            });
-        }
+        private Task ExecuteGenerateDriverRosterAsync() =>
+            ExecuteKindAsync(OperationalReportKind.DriverRoster, "Driver Roster Report");
 
-        private async Task ExecuteGenerateLicenseExpirationAsync()
-        {
-            await ExecuteReportGeneration("License Expiration Report", async () =>
-            {
-                Logger.Information("Generating license expiration report");
-                // TODO: Implement license expiration tracking
-                await Task.Delay(1500);
-                return "License expiration report generated";
-            });
-        }
+        private Task ExecuteGenerateLicenseExpirationAsync() =>
+            ExecuteKindAsync(OperationalReportKind.LicenseExpiration, "License Expiration Report");
 
-        private async Task ExecuteGenerateTrainingStatusAsync()
-        {
-            await ExecuteReportGeneration("Training Status Report", async () =>
-            {
-                Logger.Information("Generating training status report");
-                // TODO: Implement training status tracking
-                await Task.Delay(1500);
-                return "Training status report generated";
-            });
-        }
+        private Task ExecuteGenerateTrainingStatusAsync() =>
+            ExecuteKindAsync(OperationalReportKind.TrainingStatus, "Training Status Report");
 
-        private async Task ExecuteGenerateComplianceReportAsync()
-        {
-            await ExecuteReportGeneration("Compliance Report", async () =>
-            {
-                Logger.Information("Generating compliance report");
-                // TODO: Implement compliance tracking
-                await Task.Delay(1500);
-                return "Compliance report generated";
-            });
-        }
+        private Task ExecuteGenerateComplianceReportAsync() =>
+            ExecuteKindAsync(OperationalReportKind.Compliance, "Compliance Report");
 
         #endregion
 
         #region Fleet Report Commands
 
-        private async Task ExecuteGenerateFleetInventoryAsync()
-        {
-            await ExecuteReportGeneration("Fleet Inventory Report", async () =>
-            {
-                Logger.Information("Generating fleet inventory report");
-                // TODO: Implement fleet inventory report
-                await Task.Delay(1500);
-                return "Fleet inventory report generated";
-            });
-        }
+        private Task ExecuteGenerateFleetInventoryAsync() =>
+            ExecuteKindAsync(OperationalReportKind.FleetInventory, "Fleet Inventory Report");
 
-        private async Task ExecuteGenerateMaintenanceScheduleAsync()
-        {
-            await ExecuteReportGeneration("Maintenance Schedule Report", async () =>
-            {
-                Logger.Information("Generating maintenance schedule report");
-                // TODO: Implement maintenance scheduling
-                await Task.Delay(1500);
-                return "Maintenance schedule report generated";
-            });
-        }
+        private Task ExecuteGenerateMaintenanceScheduleAsync() =>
+            ExecuteKindAsync(OperationalReportKind.MaintenanceSchedule, "Maintenance Schedule Report");
 
-        private async Task ExecuteGenerateFuelUsageAsync()
-        {
-            await ExecuteReportGeneration("Fuel Usage Report", async () =>
-            {
-                Logger.Information("Generating fuel usage report");
-                // TODO: Implement fuel usage tracking
-                await Task.Delay(1500);
-                return "Fuel usage report generated";
-            });
-        }
+        private Task ExecuteGenerateFuelUsageAsync() =>
+            ExecuteKindAsync(OperationalReportKind.FuelUsage, "Fuel Usage Report");
 
-        private async Task ExecuteGenerateFleetUtilizationAsync()
-        {
-            await ExecuteReportGeneration("Fleet Utilization Report", async () =>
-            {
-                Logger.Information("Generating fleet utilization report");
-                // TODO: Implement fleet utilization analysis
-                await Task.Delay(1500);
-                return "Fleet utilization report generated";
-            });
-        }
+        private Task ExecuteGenerateFleetUtilizationAsync() =>
+            ExecuteKindAsync(OperationalReportKind.FleetUtilization, "Fleet Utilization Report");
 
         #endregion
 
         #region Export and Print Commands
 
-        private async Task ExecuteExportAllDataToCsvAsync()
-        {
-            await ExecuteReportGeneration("CSV Export", async () =>
-            {
-                Logger.Information("Exporting all data to CSV");
-                // TODO: Implement CSV export functionality
-                await Task.Delay(1500);
-                return "Data exported to CSV successfully";
-            });
-        }
+        private Task ExecuteExportAllDataToCsvAsync() =>
+            ExecuteKindAsync(OperationalReportKind.CsvExport, "CSV Export");
 
-        private async Task ExecuteExportAllDataToPdfAsync()
-        {
-            await ExecuteReportGeneration("PDF Export", async () =>
-            {
-                Logger.Information("Exporting all data to PDF");
-                // TODO: Use PdfReportService for comprehensive PDF export
-                await Task.Delay(2000);
-                return "Data exported to PDF successfully";
-            });
-        }
+        private Task ExecuteExportAllDataToPdfAsync() =>
+            ExecuteKindAsync(OperationalReportKind.PdfExport, "PDF Export");
 
-        private async Task ExecuteExportAllDataToExcelAsync()
-        {
-            await ExecuteReportGeneration("Excel Export", async () =>
-            {
-                Logger.Information("Exporting all data to Excel");
-                // TODO: Implement Excel export functionality
-                await Task.Delay(2000);
-                return "Data exported to Excel successfully";
-            });
-        }
+        private Task ExecuteExportAllDataToExcelAsync() =>
+            ExecuteKindAsync(OperationalReportKind.ExcelExport, "Excel Export");
 
-        private async Task ExecutePrintStudentListsAsync()
-        {
-            await ExecuteReportGeneration("Print Student Lists", async () =>
-            {
-                Logger.Information("Printing student lists");
-                // TODO: Implement student list printing
-                await Task.Delay(1500);
-                return "Student lists sent to printer";
-            });
-        }
+        private Task ExecutePrintStudentListsAsync() =>
+            ExecuteKindAsync(OperationalReportKind.PrintStudentLists, "Print Student Lists");
 
-        private async Task ExecutePrintRouteMapsAsync()
-        {
-            await ExecuteReportGeneration("Print Route Maps", async () =>
-            {
-                Logger.Information("Printing route maps");
-                // TODO: Implement route map printing
-                await Task.Delay(2000);
-                return "Route maps sent to printer";
-            });
-        }
+        private Task ExecutePrintRouteMapsAsync() =>
+            ExecuteKindAsync(OperationalReportKind.PrintRouteMaps, "Print Route Maps");
 
-        private async Task ExecutePrintSchedulesAsync()
-        {
-            await ExecuteReportGeneration("Print Schedules", async () =>
-            {
-                Logger.Information("Printing schedules");
-                // TODO: Implement schedule printing
-                await Task.Delay(1500);
-                return "Schedules sent to printer";
-            });
-        }
+        private Task ExecutePrintSchedulesAsync() =>
+            ExecuteKindAsync(OperationalReportKind.PrintSchedules, "Print Schedules");
 
         #endregion
 
         #region Helper Methods
 
-    private async Task ExecuteReportGeneration(string reportName, Func<Task<string>> reportAction)
+        private Task ExecuteKindAsync(OperationalReportKind kind, string reportName) =>
+            ExecuteReportGeneration(reportName, async () =>
+            {
+                var generated = await _reportService.GenerateAsync(kind);
+                AIReportSummary = generated.AiSummary;
+                return generated.Status;
+            });
+
+        private async Task ExecuteReportGeneration(string reportName, Func<Task<string>> reportAction)
         {
             try
             {
-        Logger.Debug("CanExecute for {Report} assumed true at execution time (AsyncRelayCommand)", reportName);
-        Logger.Information("Starting execution of report command: {Report}", reportName);
+                Logger.Information("Starting execution of report command: {Report}", reportName);
                 IsGeneratingReport = true;
                 StatusMessage = $"Generating {reportName}...";
 
@@ -415,14 +268,16 @@ namespace BusBuddy.WPF.ViewModels.Reports
 
                 StatusMessage = result;
                 LastReportGenerated = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
-                Logger.Information("Report generation completed: {ReportName}", reportName);
-
-                // Populate SfDataGrid history (UI element for Finish reports)
-                GeneratedReports.Insert(0, new ReportEntry { Name = reportName, GeneratedAt = DateTime.Now.ToString("HH:mm:ss"), Result = result });
-                if (GeneratedReports.Count > 8) GeneratedReports.RemoveAt(GeneratedReports.Count - 1);
-
-                // AI insight (Grok tie-in per roadmap #5 Reports + AI)
-                AIReportSummary = result + " | Grok AI: Review high-mileage routes for optimization opportunities (+5-12% potential efficiency).";
+                GeneratedReports.Insert(0, new ReportEntry
+                {
+                    Name = reportName,
+                    GeneratedAt = DateTime.Now.ToString("HH:mm:ss"),
+                    Result = result
+                });
+                if (GeneratedReports.Count > 8)
+                {
+                    GeneratedReports.RemoveAt(GeneratedReports.Count - 1);
+                }
             }
             catch (Exception ex)
             {
@@ -432,7 +287,6 @@ namespace BusBuddy.WPF.ViewModels.Reports
             finally
             {
                 IsGeneratingReport = false;
-                Logger.Debug("Finished execution of report command: {Report}", reportName);
             }
         }
 

--- a/BusBuddy.WPF/Views/Reports/ReportsView.xaml.cs
+++ b/BusBuddy.WPF/Views/Reports/ReportsView.xaml.cs
@@ -1,11 +1,13 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using BusBuddy.WPF;
+using BusBuddy.WPF.Utilities;
+using BusBuddy.WPF.ViewModels.Reports;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Syncfusion.SfSkinManager;
 using Syncfusion.Windows.Tools.Controls;
-using BusBuddy.WPF.Utilities;
-using BusBuddy.WPF.ViewModels.Reports;
 
 namespace BusBuddy.WPF.Views.Reports
 {
@@ -26,7 +28,8 @@ namespace BusBuddy.WPF.Views.Reports
             {
                 if (this.DataContext is not ReportsViewModel)
                 {
-                    this.DataContext = new ReportsViewModel();
+                    this.DataContext = App.ServiceProvider?.GetService<ReportsViewModel>()
+                        ?? new ReportsViewModel();
                     Log.Information("{ViewName}: DataContext set to ReportsViewModel", nameof(ReportsView));
                 }
             }

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -27,7 +27,7 @@
 - [x] Student import / optimize end-to-end (UI + SeedDataService + tests)
   - [x] CSV import wired: `ISeedDataService.ImportStudentsFromCsvAsync` + Students/StudentForm Import CSV buttons (Wiley-format file picker). Proof: parent address columns, next `WSD` number, Wiley header rejection, form import refreshes list via `StudentsImportedMessage`
   - [x] Optimize routes: `IStudentRouteOptimizer` fills active routes via `IRouteService.AutoAssignStudentsAsync`, then Ollama/`GrokGlobalAPI` commentary (mock fallback). Wired on Students + Dashboard. Proof: `StudentRouteOptimizerTests`
-- [ ] Reports: PdfReportService + AI path fully wired in UI
+- [x] Reports: `IOperationalReportService` writes live PDFs/CSVs via `PdfReportService.GenerateTabularReport` + Ollama/`GrokGlobalAPI.GetShortCommentaryAsync` (mock fallback). All Reports buttons + Dashboard Generate Report. Proof: `OperationalReportServiceTests`, `PdfReportServiceTests.GenerateTabularReport_ReturnsValidPdf`
 - [ ] Driver availability + SfScheduler
 - [ ] Maintenance UI polish
 - [ ] Google Earth Engine enhancements (beyond current DI/auth)
@@ -77,4 +77,4 @@
 
 ---
 
-*Updated 2026-08-16: VM Syncfusion smoke passed; student CSV import + route optimize wired.*
+*Updated 2026-08-16: Reports UI writes live PDFs/CSVs with Ollama commentary.*


### PR DESCRIPTION
## Summary
- Add `IOperationalReportService` so Reports buttons load live students, routes, drivers, and fleet data instead of `Task.Delay` stubs.
- Write PDFs through `PdfReportService.GenerateTabularReport` (route summary still uses the existing route PDF) and CSVs for export; save under Documents/BusBuddy/Reports.
- Add `GrokGlobalAPI.GetShortCommentaryAsync` for Ollama notes with the existing mock fallback. Dashboard Generate Report uses the same path.

## Test plan
- [ ] `dotnet test --filter FullyQualifiedName~OperationalReportServiceTests|GenerateTabularReport` on Windows
- [ ] Open Reports and generate Student Roster, Unassigned Students, and Route Summary; confirm files appear and the SfDataGrid history updates
- [ ] Confirm AI summary text updates (Ollama if running, otherwise mock insight)
- [ ] Dashboard Generate Report writes a route summary PDF
- [ ] CSV / Excel export writes a `.csv` that opens in Excel