### PR TITLE
fix: wire CLI --generate-report to live PDFs

### DIFF
--- a/BusBuddy.Core/Services/IOperationalReportService.cs
+++ b/BusBuddy.Core/Services/IOperationalReportService.cs
@@ -37,8 +37,18 @@ namespace BusBuddy.Core.Services
         public bool UsedMockAi { get; init; }
     }
 
+    public sealed class OperationalReportRequest
+    {
+        public OperationalReportKind Kind { get; init; }
+        public string? OutputDirectory { get; init; }
+        public string? OutputFilePath { get; init; }
+        public bool AsCsv { get; init; }
+        public int? RouteId { get; init; }
+    }
+
     public interface IOperationalReportService
     {
         Task<OperationalReportResult> GenerateAsync(OperationalReportKind kind, string? outputDirectory = null);
+        Task<OperationalReportResult> GenerateAsync(OperationalReportRequest request);
     }
 }

--- a/BusBuddy.Core/Services/OperationalReportKindParser.cs
+++ b/BusBuddy.Core/Services/OperationalReportKindParser.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace BusBuddy.Core.Services
+{
+    /// <summary>
+    /// Maps CLI / help aliases (Roster, RouteManifest, …) and enum names to <see cref="OperationalReportKind"/>.
+    /// </summary>
+    public static class OperationalReportKindParser
+    {
+        public static bool TryParse(string? value, out OperationalReportKind kind)
+        {
+            kind = default;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var key = value.Trim().Replace("-", string.Empty, StringComparison.Ordinal)
+                .Replace("_", string.Empty, StringComparison.Ordinal)
+                .Replace(" ", string.Empty, StringComparison.Ordinal);
+
+            if (Enum.TryParse(key, ignoreCase: true, out kind))
+            {
+                return true;
+            }
+
+            kind = key.ToLowerInvariant() switch
+            {
+                "roster" or "studentlist" or "studentlists" => OperationalReportKind.StudentRoster,
+                "routemanifest" or "routesummary" or "routemap" or "routemaps" => OperationalReportKind.RouteSummary,
+                "driverschedule" or "driverroster" or "schedule" or "schedules" => OperationalReportKind.DriverRoster,
+                "dailyschedule" => OperationalReportKind.DailySchedule,
+                "csv" or "csvexport" => OperationalReportKind.CsvExport,
+                "excel" or "excelexport" or "xlsx" => OperationalReportKind.ExcelExport,
+                "pdf" or "pdfexport" => OperationalReportKind.PdfExport,
+                _ => (OperationalReportKind)(-1)
+            };
+
+            return (int)kind >= 0;
+        }
+
+        public static bool IsCsvFormat(string? format) =>
+            format is not null &&
+            (format.Equals("csv", StringComparison.OrdinalIgnoreCase)
+             || format.Equals("excel", StringComparison.OrdinalIgnoreCase)
+             || format.Equals("xlsx", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/BusBuddy.Core/Services/OperationalReportService.cs
+++ b/BusBuddy.Core/Services/OperationalReportService.cs
@@ -46,8 +46,13 @@ namespace BusBuddy.Core.Services
             _grok = grok;
         }
 
-        public async Task<OperationalReportResult> GenerateAsync(OperationalReportKind kind, string? outputDirectory = null)
+        public Task<OperationalReportResult> GenerateAsync(OperationalReportKind kind, string? outputDirectory = null) =>
+            GenerateAsync(new OperationalReportRequest { Kind = kind, OutputDirectory = outputDirectory });
+
+        public async Task<OperationalReportResult> GenerateAsync(OperationalReportRequest request)
         {
+            ArgumentNullException.ThrowIfNull(request);
+            var kind = request.Kind;
             var students = await _students.GetAllStudentsAsync() ?? new List<Student>();
             var routesResult = await _routes.GetAllActiveRoutesAsync();
             var routes = routesResult.IsSuccess && routesResult.Value is not null
@@ -67,19 +72,26 @@ namespace BusBuddy.Core.Services
             var title = DisplayName(kind);
             var (headers, rows, facts) = BuildTable(kind, students, routes, drivers, buses, fuel, maintenance);
             var ai = await TryCommentaryAsync(title, facts);
-            var isCsv = kind is OperationalReportKind.CsvExport or OperationalReportKind.ExcelExport;
+            var isCsv = request.AsCsv || kind is OperationalReportKind.CsvExport or OperationalReportKind.ExcelExport;
+            var route = SelectRoute(routes, request.RouteId);
+            if (request.RouteId.HasValue && route is null)
+            {
+                throw new InvalidOperationException($"No active route with RouteId {request.RouteId.Value}.");
+            }
+
             var bytes = isCsv
                 ? Encoding.UTF8.GetBytes(ToCsv(headers, rows))
-                : kind == OperationalReportKind.RouteSummary && routes.Count > 0
-                    ? BuildRouteSummaryPdf(routes[0], students, buses, drivers, ai.Text)
+                : kind == OperationalReportKind.RouteSummary && route is not null
+                    ? BuildRouteSummaryPdf(route, students, buses, drivers, ai.Text)
                     : _pdf.GenerateTabularReport(title, headers, rows, ai.Text);
 
-            var dir = string.IsNullOrWhiteSpace(outputDirectory)
-                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "BusBuddy", "Reports")
-                : outputDirectory;
-            Directory.CreateDirectory(dir);
-            var ext = isCsv ? "csv" : "pdf";
-            var path = Path.Combine(dir, $"{kind}-{DateTime.Now:yyyyMMdd-HHmmss}.{ext}");
+            var path = ResolveOutputPath(request, kind, isCsv);
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
             await File.WriteAllBytesAsync(path, bytes);
 
             var prefix = kind.ToString().StartsWith("Print", StringComparison.Ordinal) ? "Saved for print" : "Wrote";
@@ -94,6 +106,30 @@ namespace BusBuddy.Core.Services
                 AiSummary = ai.Text,
                 UsedMockAi = ai.Mock
             };
+        }
+
+        private static Route? SelectRoute(IReadOnlyList<Route> routes, int? routeId)
+        {
+            if (routeId.HasValue)
+            {
+                return routes.FirstOrDefault(r => r.RouteId == routeId.Value);
+            }
+
+            return routes.Count > 0 ? routes[0] : null;
+        }
+
+        private static string ResolveOutputPath(OperationalReportRequest request, OperationalReportKind kind, bool isCsv)
+        {
+            if (!string.IsNullOrWhiteSpace(request.OutputFilePath))
+            {
+                return request.OutputFilePath;
+            }
+
+            var dir = string.IsNullOrWhiteSpace(request.OutputDirectory)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "BusBuddy", "Reports")
+                : request.OutputDirectory;
+            var ext = isCsv ? "csv" : "pdf";
+            return Path.Combine(dir, $"{kind}-{DateTime.Now:yyyyMMdd-HHmmss}.{ext}");
         }
 
         private byte[] BuildRouteSummaryPdf(

--- a/BusBuddy.Tests/Core/OperationalReportServiceTests.cs
+++ b/BusBuddy.Tests/Core/OperationalReportServiceTests.cs
@@ -87,5 +87,64 @@ namespace BusBuddy.Tests.Core
             Assert.That(text, Does.Contain("Ada Rider"));
             Assert.That(text, Does.StartWith("Name,"));
         }
+
+        [Test]
+        public async Task GenerateAsync_Request_WritesExactOutputPathAsCsv()
+        {
+            var path = Path.Combine(_dir, "cli-roster.csv");
+
+            var result = await _service.GenerateAsync(new OperationalReportRequest
+            {
+                Kind = OperationalReportKind.StudentRoster,
+                OutputFilePath = path,
+                AsCsv = true
+            });
+
+            Assert.That(result.FilePath, Is.EqualTo(path));
+            Assert.That(await File.ReadAllTextAsync(path), Does.Contain("Ben Rider"));
+        }
+
+        [Test]
+        public void GenerateAsync_UnknownRouteId_Throws()
+        {
+            var request = new OperationalReportRequest
+            {
+                Kind = OperationalReportKind.RouteSummary,
+                OutputDirectory = _dir,
+                RouteId = 999
+            };
+
+            Assert.That(async () => await _service.GenerateAsync(request), Throws.InvalidOperationException);
+        }
+    }
+
+    [TestFixture]
+    [Category("Core")]
+    public class OperationalReportKindParserTests
+    {
+        [TestCase("Roster", OperationalReportKind.StudentRoster)]
+        [TestCase("student-list", OperationalReportKind.StudentRoster)]
+        [TestCase("RouteManifest", OperationalReportKind.RouteSummary)]
+        [TestCase("DriverSchedule", OperationalReportKind.DriverRoster)]
+        [TestCase("UnassignedStudents", OperationalReportKind.UnassignedStudents)]
+        public void TryParse_AliasesAndEnumNames_Succeed(string input, OperationalReportKind expected)
+        {
+            Assert.That(OperationalReportKindParser.TryParse(input, out var kind), Is.True);
+            Assert.That(kind, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TryParse_Unknown_Fails()
+        {
+            Assert.That(OperationalReportKindParser.TryParse("not-a-report", out _), Is.False);
+        }
+
+        [TestCase("csv", true)]
+        [TestCase("Excel", true)]
+        [TestCase("pdf", false)]
+        public void IsCsvFormat_MatchesHelpAliases(string format, bool expected)
+        {
+            Assert.That(OperationalReportKindParser.IsCsvFormat(format), Is.EqualTo(expected));
+        }
     }
 }

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -920,41 +920,52 @@ IMPLEMENTATION STEPS:
 
                 Log.Information("Starting command line report generation: {ReportType} -> {OutputPath}", reportType, outputPath);
 
-                // TODO: Implement actual PdfReportService call
-                // For now, create a mock PDF/report file
-                var reportContent = $@"BusBuddy {reportType} Report
-Generated: {DateTime.Now:yyyy-MM-dd HH:mm:ss}
-Format: {format}
-{(routeId != null ? $"Route ID: {routeId}" : "")}
-
-This is a mock {reportType.ToLower()} report generated via command line.
-In the full implementation, this would use Syncfusion PDF tools to generate a proper {format} report.
-
-Sample data would include:
-- Student information
-- Route details
-- Driver schedules
-- Safety protocols
-- Performance metrics";
-
-                // Create output directory if needed
-                var directory = Path.GetDirectoryName(outputPath);
-                if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                if (!OperationalReportKindParser.TryParse(reportType, out var kind))
                 {
-                    Directory.CreateDirectory(directory);
+                    Console.WriteLine($"Error: unknown --report-type '{reportType}'. Use an OperationalReportKind name or Roster, RouteManifest, StudentList, DriverSchedule.");
+                    return true;
                 }
 
-                File.WriteAllText(outputPath, reportContent);
-                Log.Information("Report generated successfully: {OutputPath}", outputPath);
+                if (ServiceProvider is null)
+                {
+                    Console.WriteLine("Error: application services are not initialized");
+                    return true;
+                }
+
+                int? parsedRouteId = null;
+                if (!string.IsNullOrWhiteSpace(routeId))
+                {
+                    if (!int.TryParse(routeId, out var id))
+                    {
+                        Console.WriteLine("Error: --route-id must be an integer RouteId");
+                        return true;
+                    }
+
+                    parsedRouteId = id;
+                }
+
+                using var scope = ServiceProvider.CreateScope();
+                var reports = scope.ServiceProvider.GetRequiredService<IOperationalReportService>();
+                var generated = reports.GenerateAsync(new OperationalReportRequest
+                {
+                    Kind = kind,
+                    OutputFilePath = outputPath,
+                    AsCsv = OperationalReportKindParser.IsCsvFormat(format),
+                    RouteId = parsedRouteId
+                }).GetAwaiter().GetResult();
+
+                Log.Information("Report generated successfully: {OutputPath}", generated.FilePath);
 
                 var result = new
                 {
-                    ReportType = reportType,
-                    OutputPath = outputPath,
-                    Format = format,
+                    ReportType = kind.ToString(),
+                    OutputPath = generated.FilePath,
+                    Format = generated.FilePath.EndsWith(".csv", StringComparison.OrdinalIgnoreCase) ? "CSV" : "PDF",
                     RouteId = routeId,
                     GeneratedAt = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
-                    FileSize = new FileInfo(outputPath).Length
+                    FileSize = generated.FileBytes.Length,
+                    Status = generated.Status,
+                    AiSummary = generated.AiSummary
                 };
 
                 var json = System.Text.Json.JsonSerializer.Serialize(result, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
@@ -989,9 +1000,9 @@ Route Optimization:
 
 Report Generation:
   --generate-report --report-type <type> --output <path> [options]
-    --report-type <type>         Report type: Roster, RouteManifest, StudentList, DriverSchedule
+    --report-type <type>         Roster, RouteManifest, StudentList, DriverSchedule, or any OperationalReportKind
     --output <path>              Output file path (required)
-    --route-id <id>              Route ID for route-specific reports
+    --route-id <id>              RouteId for Route Summary (integer)
     --format <format>            Output format: PDF, Excel, CSV (default: PDF)
 
 General:

--- a/BusBuddy.WPF/Views/Dashboard/DashboardView.xaml.cs
+++ b/BusBuddy.WPF/Views/Dashboard/DashboardView.xaml.cs
@@ -423,47 +423,5 @@ namespace BusBuddy.WPF.Views.Dashboard
             }
         }
 
-        // Data export methods
-        private void ExportFleetReport()
-        {
-            Logger.Debug("ExportFleetReport method started");
-            try
-            {
-                // TODO: Implement fleet report export
-                Logger.Information("Fleet report exported successfully");
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Error exporting fleet report");
-            }
-        }
-
-        private void ExportRouteReport()
-        {
-            Logger.Debug("ExportRouteReport method started");
-            try
-            {
-                // TODO: Implement route report export
-                Logger.Information("Route report exported successfully");
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Error exporting route report");
-            }
-        }
-
-        private void ExportStudentReport()
-        {
-            Logger.Debug("ExportStudentReport method started");
-            try
-            {
-                // TODO: Implement student report export
-                Logger.Information("Student report exported successfully");
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Error exporting student report");
-            }
-        }
     }
 }

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -27,7 +27,7 @@
 - [x] Student import / optimize end-to-end (UI + SeedDataService + tests)
   - [x] CSV import wired: `ISeedDataService.ImportStudentsFromCsvAsync` + Students/StudentForm Import CSV buttons (Wiley-format file picker). Proof: parent address columns, next `WSD` number, Wiley header rejection, form import refreshes list via `StudentsImportedMessage`
   - [x] Optimize routes: `IStudentRouteOptimizer` fills active routes via `IRouteService.AutoAssignStudentsAsync`, then Ollama/`GrokGlobalAPI` commentary (mock fallback). Wired on Students + Dashboard. Proof: `StudentRouteOptimizerTests`
-- [x] Reports: `IOperationalReportService` writes live PDFs/CSVs via `PdfReportService.GenerateTabularReport` + Ollama/`GrokGlobalAPI.GetShortCommentaryAsync` (mock fallback). All Reports buttons + Dashboard Generate Report. Proof: `OperationalReportServiceTests`, `PdfReportServiceTests.GenerateTabularReport_ReturnsValidPdf`
+- [x] Reports: `IOperationalReportService` writes live PDFs/CSVs via `PdfReportService.GenerateTabularReport` + Ollama/`GrokGlobalAPI.GetShortCommentaryAsync` (mock fallback). All Reports buttons + Dashboard Generate Report. Proof: `OperationalReportServiceTests`, `PdfReportServiceTests.GenerateTabularReport_ReturnsValidPdf`. Merged [PR #24](https://github.com/Bigessfour/BusBuddy-3/pull/24). CLI `--generate-report` uses the same service (aliases: Roster, RouteManifest, StudentList, DriverSchedule)
 - [ ] Driver availability + SfScheduler
 - [ ] Maintenance UI polish
 - [ ] Google Earth Engine enhancements (beyond current DI/auth)
@@ -77,4 +77,4 @@
 
 ---
 
-*Updated 2026-08-16: Reports UI writes live PDFs/CSVs with Ollama commentary.*
+*Updated 2026-08-16: Reports UI + CLI `--generate-report` write live PDFs/CSVs (PR #24 + leftovers).*


### PR DESCRIPTION
## Summary
- Replace the `HandleReportGeneration` mock text file with `IOperationalReportService` so `--generate-report` writes a real PDF or CSV to `--output`.
- Accept help aliases (`Roster`, `RouteManifest`, `StudentList`, `DriverSchedule`) plus enum names; honor `--format csv|excel` and integer `--route-id`.
- Remove unused Dashboard export stubs that claimed success without generating a file.

## Test plan
- [ ] `dotnet test --filter FullyQualifiedName~OperationalReport` on Windows
- [ ] `BusBuddy.exe --generate-report --report-type Roster --output reports/roster.pdf` writes a PDF (`%PDF`)
- [ ] Same with `--format csv` writes a CSV that opens in Excel
- [ ] Unknown `--report-type` and non-integer `--route-id` print an error and do not start the GUI
- [ ] Dashboard Generate Report still writes a route summary PDF