### PR TITLE
fix: address Reports review findings

### DIFF
--- a/BusBuddy.Core/Services/GrokGlobalAPI.cs
+++ b/BusBuddy.Core/Services/GrokGlobalAPI.cs
@@ -128,7 +128,7 @@ namespace BusBuddy.Core.Services
                     MaxTokens = 120
                 };
 
-                var response = await CallGrokAPI(CHAT_COMPLETIONS_ENDPOINT, request);
+                var response = await CallGrokAPI(CHAT_COMPLETIONS_ENDPOINT, request).ConfigureAwait(false);
                 if (IsFailedApiResponse(response))
                 {
                     return $"Mock insight for {topic}: {facts}";

--- a/BusBuddy.Core/Services/OperationalReportKindParser.cs
+++ b/BusBuddy.Core/Services/OperationalReportKindParser.cs
@@ -28,8 +28,8 @@ namespace BusBuddy.Core.Services
             {
                 "roster" or "studentlist" or "studentlists" => OperationalReportKind.StudentRoster,
                 "routemanifest" or "routesummary" or "routemap" or "routemaps" => OperationalReportKind.RouteSummary,
-                "driverschedule" or "driverroster" or "schedule" or "schedules" => OperationalReportKind.DriverRoster,
-                "dailyschedule" => OperationalReportKind.DailySchedule,
+                "driverschedule" or "driverroster" => OperationalReportKind.DriverRoster,
+                "schedule" or "schedules" or "dailyschedule" => OperationalReportKind.DailySchedule,
                 "csv" or "csvexport" => OperationalReportKind.CsvExport,
                 "excel" or "excelexport" or "xlsx" => OperationalReportKind.ExcelExport,
                 "pdf" or "pdfexport" => OperationalReportKind.PdfExport,

--- a/BusBuddy.Core/Services/OperationalReportService.cs
+++ b/BusBuddy.Core/Services/OperationalReportService.cs
@@ -53,37 +53,46 @@ namespace BusBuddy.Core.Services
         {
             ArgumentNullException.ThrowIfNull(request);
             var kind = request.Kind;
-            var students = await _students.GetAllStudentsAsync() ?? new List<Student>();
-            var routesResult = await _routes.GetAllActiveRoutesAsync();
+            var students = await _students.GetAllStudentsAsync().ConfigureAwait(false) ?? new List<Student>();
+            var routesResult = await _routes.GetAllActiveRoutesAsync().ConfigureAwait(false);
             var routes = routesResult.IsSuccess && routesResult.Value is not null
                 ? routesResult.Value.ToList()
                 : new List<Route>();
-            var drivers = _drivers is null ? new List<Driver>() : await _drivers.GetAllDriversAsync() ?? new List<Driver>();
-            var buses = _buses is null
-                ? new List<Bus>()
-                : (await _buses.GetAllBusesAsync())?.ToList() ?? new List<Bus>();
-            var fuel = _fuel is null
-                ? new List<Fuel>()
-                : (await _fuel.GetAllFuelRecordsAsync())?.ToList() ?? new List<Fuel>();
-            var maintenance = _maintenance is null
-                ? new List<Maintenance>()
-                : (await _maintenance.GetAllMaintenanceRecordsAsync())?.ToList() ?? new List<Maintenance>();
-
-            var title = DisplayName(kind);
-            var (headers, rows, facts) = BuildTable(kind, students, routes, drivers, buses, fuel, maintenance);
-            var ai = await TryCommentaryAsync(title, facts);
-            var isCsv = request.AsCsv || kind is OperationalReportKind.CsvExport or OperationalReportKind.ExcelExport;
             var route = SelectRoute(routes, request.RouteId);
             if (request.RouteId.HasValue && route is null)
             {
                 throw new InvalidOperationException($"No active route with RouteId {request.RouteId.Value}.");
             }
 
+            var drivers = _drivers is null ? new List<Driver>() : await _drivers.GetAllDriversAsync().ConfigureAwait(false) ?? new List<Driver>();
+            var buses = _buses is null
+                ? new List<Bus>()
+                : (await _buses.GetAllBusesAsync().ConfigureAwait(false))?.ToList() ?? new List<Bus>();
+            var fuel = _fuel is null
+                ? new List<Fuel>()
+                : (await _fuel.GetAllFuelRecordsAsync().ConfigureAwait(false))?.ToList() ?? new List<Fuel>();
+            var maintenance = _maintenance is null
+                ? new List<Maintenance>()
+                : (await _maintenance.GetAllMaintenanceRecordsAsync().ConfigureAwait(false))?.ToList() ?? new List<Maintenance>();
+
+            var title = DisplayName(kind);
+            var (headers, rows, facts) = BuildTable(kind, students, routes, drivers, buses, fuel, maintenance);
+            var ai = await TryCommentaryAsync(title, facts).ConfigureAwait(false);
+            var isCsv = request.AsCsv || kind is OperationalReportKind.CsvExport or OperationalReportKind.ExcelExport;
+            var writeSingleRoutePdf = !isCsv
+                && kind == OperationalReportKind.RouteSummary
+                && request.RouteId.HasValue
+                && route is not null;
             var bytes = isCsv
                 ? Encoding.UTF8.GetBytes(ToCsv(headers, rows))
-                : kind == OperationalReportKind.RouteSummary && route is not null
-                    ? BuildRouteSummaryPdf(route, students, buses, drivers, ai.Text)
+                : writeSingleRoutePdf
+                    ? BuildRouteSummaryPdf(route!, students, buses, drivers, ai.Text)
                     : _pdf.GenerateTabularReport(title, headers, rows, ai.Text);
+            var reportedRows = writeSingleRoutePdf
+                ? students.Count(s =>
+                    string.Equals(s.AMRoute, route!.RouteName, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(s.PMRoute, route.RouteName, StringComparison.OrdinalIgnoreCase))
+                : rows.Count;
 
             var path = ResolveOutputPath(request, kind, isCsv);
             var dir = Path.GetDirectoryName(path);
@@ -92,10 +101,11 @@ namespace BusBuddy.Core.Services
                 Directory.CreateDirectory(dir);
             }
 
-            await File.WriteAllBytesAsync(path, bytes);
+            await File.WriteAllBytesAsync(path, bytes).ConfigureAwait(false);
 
-            var prefix = kind.ToString().StartsWith("Print", StringComparison.Ordinal) ? "Saved for print" : "Wrote";
-            var status = $"{prefix} {title} ({rows.Count} row(s), {bytes.Length} bytes) → {path}";
+            var prefix = kind.ToString().StartsWith("Print", StringComparison.Ordinal) ? "Saved PDF for print" : "Wrote";
+            var routeNote = writeSingleRoutePdf ? $", route {route!.RouteName}" : string.Empty;
+            var status = $"{prefix} {title} ({reportedRows} row(s){routeNote}, {bytes.Length} bytes) → {path}";
             Logger.Information("Operational report {Kind} written to {Path} bytes={Bytes}", kind, path, bytes.Length);
 
             return new OperationalReportResult
@@ -120,16 +130,16 @@ namespace BusBuddy.Core.Services
 
         private static string ResolveOutputPath(OperationalReportRequest request, OperationalReportKind kind, bool isCsv)
         {
+            var ext = isCsv ? ".csv" : ".pdf";
             if (!string.IsNullOrWhiteSpace(request.OutputFilePath))
             {
-                return request.OutputFilePath;
+                return Path.ChangeExtension(request.OutputFilePath, ext);
             }
 
             var dir = string.IsNullOrWhiteSpace(request.OutputDirectory)
                 ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "BusBuddy", "Reports")
                 : request.OutputDirectory;
-            var ext = isCsv ? "csv" : "pdf";
-            return Path.Combine(dir, $"{kind}-{DateTime.Now:yyyyMMdd-HHmmss}.{ext}");
+            return Path.Combine(dir, $"{kind}-{DateTime.Now:yyyyMMdd-HHmmss}{ext}");
         }
 
         private byte[] BuildRouteSummaryPdf(
@@ -358,7 +368,7 @@ namespace BusBuddy.Core.Services
             OperationalReportKind.PdfExport => "PDF Export",
             OperationalReportKind.ExcelExport => "Excel-ready CSV",
             OperationalReportKind.PrintStudentLists => "Student Lists",
-            OperationalReportKind.PrintRouteMaps => "Route Maps",
+            OperationalReportKind.PrintRouteMaps => "Route List",
             OperationalReportKind.PrintSchedules => "Schedules",
             _ => kind.ToString()
         };
@@ -395,7 +405,7 @@ namespace BusBuddy.Core.Services
 
             try
             {
-                var text = await _grok.GetShortCommentaryAsync(topic, facts);
+                var text = await _grok.GetShortCommentaryAsync(topic, facts).ConfigureAwait(false);
                 var mock = text.StartsWith("Mock insight", StringComparison.OrdinalIgnoreCase);
                 return (text, mock);
             }

--- a/BusBuddy.Core/Services/PdfReportService.cs
+++ b/BusBuddy.Core/Services/PdfReportService.cs
@@ -588,24 +588,68 @@ namespace BusBuddy.Core.Services
             rows ??= Array.Empty<IReadOnlyList<string>>();
 
             using var document = new PdfDocument();
-            var page = document.Pages.Add();
-            var g = page.Graphics;
             var titleFont = new PdfStandardFont(PdfFontFamily.Helvetica, 16, PdfFontStyle.Bold);
             var labelFont = new PdfStandardFont(PdfFontFamily.Helvetica, 9, PdfFontStyle.Bold);
             var bodyFont = new PdfStandardFont(PdfFontFamily.Helvetica, 9);
             var accent = new PdfSolidBrush(new PdfColor(11, 126, 200));
-            var pageWidth = page.GetClientSize().Width;
 
+            var page = document.Pages.Add();
+            var g = page.Graphics;
+            var pageWidth = page.GetClientSize().Width;
+            var pageHeight = page.GetClientSize().Height;
+            var colCount = Math.Max(1, headers.Count);
+            var colWidth = (pageWidth - 32f) / colCount;
+            var y = DrawTableChrome(g, title, notes, rows.Count, headers, titleFont, labelFont, bodyFont, accent, pageWidth, includeNotes: true);
+
+            foreach (var row in rows)
+            {
+                if (y > pageHeight - 36f)
+                {
+                    page = document.Pages.Add();
+                    g = page.Graphics;
+                    pageWidth = page.GetClientSize().Width;
+                    pageHeight = page.GetClientSize().Height;
+                    colWidth = (pageWidth - 32f) / colCount;
+                    y = DrawTableChrome(g, title, notes, rows.Count, headers, titleFont, labelFont, bodyFont, accent, pageWidth, includeNotes: false);
+                }
+
+                for (var i = 0; i < colCount && i < row.Count; i++)
+                {
+                    var cell = FitCell(bodyFont, row[i] ?? string.Empty, colWidth - 4f);
+                    g.DrawString(cell, bodyFont, PdfBrushes.Black, new PointF(16 + (i * colWidth), y));
+                }
+
+                y += 13f;
+            }
+
+            using var ms = new MemoryStream();
+            document.Save(ms);
+            return ms.ToArray();
+        }
+
+        private static float DrawTableChrome(
+            PdfGraphics g,
+            string title,
+            string? notes,
+            int rowCount,
+            IReadOnlyList<string> headers,
+            PdfFont titleFont,
+            PdfFont labelFont,
+            PdfFont bodyFont,
+            PdfBrush accent,
+            float pageWidth,
+            bool includeNotes)
+        {
             g.DrawRectangle(accent, new RectangleF(0, 0, pageWidth, 44));
             g.DrawString($"Bus Buddy — {title}", titleFont, PdfBrushes.White, new PointF(16, 12));
 
             float y = 56f;
-            g.DrawString($"Generated {DateTime.Now:yyyy-MM-dd HH:mm}    Rows: {rows.Count}", bodyFont, PdfBrushes.Black, new PointF(16, y));
+            g.DrawString($"Generated {DateTime.Now:yyyy-MM-dd HH:mm}    Rows: {rowCount}", bodyFont, PdfBrushes.Black, new PointF(16, y));
             y += 18f;
 
-            if (!string.IsNullOrWhiteSpace(notes))
+            if (includeNotes && !string.IsNullOrWhiteSpace(notes))
             {
-                g.DrawString(notes.Length > 220 ? notes[..217] + "..." : notes, bodyFont, PdfBrushes.Black, new PointF(16, y));
+                g.DrawString(FitCell(bodyFont, notes, pageWidth - 32f), bodyFont, PdfBrushes.Black, new PointF(16, y));
                 y += 16f;
             }
 
@@ -613,33 +657,43 @@ namespace BusBuddy.Core.Services
             var colWidth = (pageWidth - 32f) / colCount;
             for (var i = 0; i < headers.Count; i++)
             {
-                g.DrawString(headers[i], labelFont, PdfBrushes.Black, new PointF(16 + (i * colWidth), y));
+                g.DrawString(FitCell(labelFont, headers[i], colWidth - 4f), labelFont, PdfBrushes.Black, new PointF(16 + (i * colWidth), y));
             }
 
-            y += 14f;
-            foreach (var row in rows.Take(42))
+            return y + 14f;
+        }
+
+        private static string FitCell(PdfFont font, string text, float maxWidth)
+        {
+            if (string.IsNullOrEmpty(text) || font.MeasureString(text).Width <= maxWidth)
             {
-                for (var i = 0; i < colCount && i < row.Count; i++)
-                {
-                    var cell = row[i] ?? string.Empty;
-                    if (cell.Length > 28)
-                    {
-                        cell = cell[..25] + "...";
-                    }
+                return text;
+            }
 
-                    g.DrawString(cell, bodyFont, PdfBrushes.Black, new PointF(16 + (i * colWidth), y));
+            const string ellipsis = "...";
+            var ellipsisWidth = font.MeasureString(ellipsis).Width;
+            if (ellipsisWidth >= maxWidth)
+            {
+                return ellipsis;
+            }
+
+            var available = maxWidth - ellipsisWidth;
+            var lo = 0;
+            var hi = text.Length;
+            while (lo < hi)
+            {
+                var mid = (lo + hi + 1) / 2;
+                if (font.MeasureString(text[..mid]).Width <= available)
+                {
+                    lo = mid;
                 }
-
-                y += 13f;
-                if (y > page.GetClientSize().Height - 36f)
+                else
                 {
-                    break;
+                    hi = mid - 1;
                 }
             }
 
-            using var ms = new MemoryStream();
-            document.Save(ms);
-            return ms.ToArray();
+            return lo == 0 ? ellipsis : text[..lo] + ellipsis;
         }
 
         #endregion

--- a/BusBuddy.Tests/Core/OperationalReportServiceTests.cs
+++ b/BusBuddy.Tests/Core/OperationalReportServiceTests.cs
@@ -116,6 +116,61 @@ namespace BusBuddy.Tests.Core
 
             Assert.That(async () => await _service.GenerateAsync(request), Throws.InvalidOperationException);
         }
+
+        [Test]
+        public async Task GenerateAsync_RouteSummaryWithoutRouteId_UsesAllRoutesTable()
+        {
+            _routes.Setup(r => r.GetAllActiveRoutesAsync()).ReturnsAsync(
+                Result.SuccessResult<IEnumerable<Route>>(new[]
+                {
+                    new Route { RouteId = 1, RouteName = "North", Date = DateTime.Today, IsActive = true, School = "Wiley" },
+                    new Route { RouteId = 2, RouteName = "South", Date = DateTime.Today, IsActive = true, School = "Wiley" }
+                }));
+
+            var result = await _service.GenerateAsync(OperationalReportKind.RouteSummary, _dir);
+
+            Assert.That(result.Status, Does.Contain("2 row"));
+            Assert.That(result.Status, Does.Not.Contain("route North"));
+            Assert.That(result.FileBytes[0], Is.EqualTo((byte)'%'));
+        }
+
+        [Test]
+        public async Task GenerateAsync_RouteSummaryWithRouteId_NamesThatRoute()
+        {
+            _routes.Setup(r => r.GetAllActiveRoutesAsync()).ReturnsAsync(
+                Result.SuccessResult<IEnumerable<Route>>(new[]
+                {
+                    new Route { RouteId = 1, RouteName = "North", Date = DateTime.Today, IsActive = true, School = "Wiley" },
+                    new Route { RouteId = 2, RouteName = "South", Date = DateTime.Today, IsActive = true, School = "Wiley" }
+                }));
+
+            var result = await _service.GenerateAsync(new OperationalReportRequest
+            {
+                Kind = OperationalReportKind.RouteSummary,
+                OutputDirectory = _dir,
+                RouteId = 2
+            });
+
+            Assert.That(result.Status, Does.Contain("route South"));
+        }
+
+        [Test]
+        public async Task GenerateAsync_CsvFormat_RewritesPdfExtension()
+        {
+            var requested = Path.Combine(_dir, "roster.pdf");
+
+            var result = await _service.GenerateAsync(new OperationalReportRequest
+            {
+                Kind = OperationalReportKind.StudentRoster,
+                OutputFilePath = requested,
+                AsCsv = true
+            });
+
+            Assert.That(result.FilePath, Does.EndWith(".csv"));
+            Assert.That(File.Exists(result.FilePath), Is.True);
+            Assert.That(File.Exists(requested), Is.False);
+            Assert.That(await File.ReadAllTextAsync(result.FilePath), Does.StartWith("Name,"));
+        }
     }
 
     [TestFixture]
@@ -126,6 +181,7 @@ namespace BusBuddy.Tests.Core
         [TestCase("student-list", OperationalReportKind.StudentRoster)]
         [TestCase("RouteManifest", OperationalReportKind.RouteSummary)]
         [TestCase("DriverSchedule", OperationalReportKind.DriverRoster)]
+        [TestCase("schedule", OperationalReportKind.DailySchedule)]
         [TestCase("UnassignedStudents", OperationalReportKind.UnassignedStudents)]
         public void TryParse_AliasesAndEnumNames_Succeed(string input, OperationalReportKind expected)
         {

--- a/BusBuddy.Tests/Core/PdfReportServiceTests.cs
+++ b/BusBuddy.Tests/Core/PdfReportServiceTests.cs
@@ -77,6 +77,25 @@ namespace BusBuddy.Tests.Core
         }
 
         [Test]
+        public void GenerateTabularReport_FiftyRows_IsLargerThanTwoRows()
+        {
+            var two = _service.GenerateTabularReport(
+                "Roster",
+                new[] { "Name" },
+                new[] { (IReadOnlyList<string>)new[] { "Ada" }, new[] { "Ben" } });
+            var manyRows = new List<IReadOnlyList<string>>();
+            for (var i = 0; i < 50; i++)
+            {
+                manyRows.Add(new[] { $"Student {i:00} with a long home address that should still appear" });
+            }
+
+            var fifty = _service.GenerateTabularReport("Roster", new[] { "Name" }, manyRows);
+
+            Assert.That(fifty[0], Is.EqualTo((byte)'%'));
+            Assert.That(fifty.Length, Is.GreaterThan(two.Length));
+        }
+
+        [Test]
         public async Task GenerateRouteReport_WithGrokAI_MocksAndVerifies()
         {
             // Arrange - for Reports + AI/Grok (item 5), boosts coverage for finish/reports integration

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -374,10 +374,9 @@ namespace BusBuddy.WPF
                 // Removed redundant explicit Wiley seeding. Seeding now handled via EF Core 9 UseSeeding/UseAsyncSeeding
 
                 // Handle command line arguments for PowerShell integration
-                if (e.Args.Length > 0 && HandleCommandLineArgs(e.Args))
+                if (e.Args.Length > 0 && TryHandleCommandLineArgs(e.Args) is int exitCode)
                 {
-                    // Command line operation completed, exit gracefully
-                    Environment.Exit(0);
+                    Environment.Exit(exitCode);
                     return;
                 }
 
@@ -740,7 +739,10 @@ namespace BusBuddy.WPF
         /// <summary>
         /// Handle command line arguments for PowerShell integration
         /// </summary>
-        private bool HandleCommandLineArgs(string[] args)
+        /// <summary>
+        /// Returns an exit code when a CLI command was handled; null means start the GUI.
+        /// </summary>
+        private int? TryHandleCommandLineArgs(string[] args)
         {
             try
             {
@@ -757,23 +759,23 @@ namespace BusBuddy.WPF
                         case "--help":
                         case "-h":
                             ShowCommandLineHelp();
-                            return true;
+                            return 0;
                     }
                 }
-                return false;
+                return null;
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Error handling command line arguments");
                 Console.WriteLine($"Error: {ex.Message}");
-                return true; // Exit to prevent GUI startup on error
+                return 1;
             }
         }
 
         /// <summary>
         /// Handle route optimization command line operation
         /// </summary>
-        private bool HandleRouteOptimization(string[] args, int startIndex)
+        private int HandleRouteOptimization(string[] args, int startIndex)
         {
             try
             {
@@ -814,7 +816,7 @@ namespace BusBuddy.WPF
                 if (string.IsNullOrEmpty(routeId))
                 {
                     Console.WriteLine("Error: --route-id is required for route optimization");
-                    return true;
+                    return 1;
                 }
 
                 Log.Information("Starting command line route optimization for route {RouteId}", routeId);
@@ -865,20 +867,20 @@ IMPLEMENTATION STEPS:
                 }
 
                 Console.WriteLine(json);
-                return true;
+                return 0;
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Error in route optimization");
                 Console.WriteLine($"Route optimization error: {ex.Message}");
-                return true;
+                return 1;
             }
         }
 
         /// <summary>
         /// Handle report generation command line operation
         /// </summary>
-        private bool HandleReportGeneration(string[] args, int startIndex)
+        private int HandleReportGeneration(string[] args, int startIndex)
         {
             try
             {
@@ -915,7 +917,7 @@ IMPLEMENTATION STEPS:
                 if (string.IsNullOrEmpty(reportType) || string.IsNullOrEmpty(outputPath))
                 {
                     Console.WriteLine("Error: --report-type and --output are required for report generation");
-                    return true;
+                    return 1;
                 }
 
                 Log.Information("Starting command line report generation: {ReportType} -> {OutputPath}", reportType, outputPath);
@@ -923,13 +925,13 @@ IMPLEMENTATION STEPS:
                 if (!OperationalReportKindParser.TryParse(reportType, out var kind))
                 {
                     Console.WriteLine($"Error: unknown --report-type '{reportType}'. Use an OperationalReportKind name or Roster, RouteManifest, StudentList, DriverSchedule.");
-                    return true;
+                    return 1;
                 }
 
                 if (ServiceProvider is null)
                 {
                     Console.WriteLine("Error: application services are not initialized");
-                    return true;
+                    return 1;
                 }
 
                 int? parsedRouteId = null;
@@ -938,7 +940,7 @@ IMPLEMENTATION STEPS:
                     if (!int.TryParse(routeId, out var id))
                     {
                         Console.WriteLine("Error: --route-id must be an integer RouteId");
-                        return true;
+                        return 1;
                     }
 
                     parsedRouteId = id;
@@ -946,13 +948,14 @@ IMPLEMENTATION STEPS:
 
                 using var scope = ServiceProvider.CreateScope();
                 var reports = scope.ServiceProvider.GetRequiredService<IOperationalReportService>();
-                var generated = reports.GenerateAsync(new OperationalReportRequest
+                var request = new OperationalReportRequest
                 {
                     Kind = kind,
                     OutputFilePath = outputPath,
                     AsCsv = OperationalReportKindParser.IsCsvFormat(format),
                     RouteId = parsedRouteId
-                }).GetAwaiter().GetResult();
+                };
+                var generated = Task.Run(() => reports.GenerateAsync(request)).GetAwaiter().GetResult();
 
                 Log.Information("Report generated successfully: {OutputPath}", generated.FilePath);
 
@@ -970,13 +973,13 @@ IMPLEMENTATION STEPS:
 
                 var json = System.Text.Json.JsonSerializer.Serialize(result, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
                 Console.WriteLine(json);
-                return true;
+                return 0;
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Error in report generation");
                 Console.WriteLine($"Report generation error: {ex.Message}");
-                return true;
+                return 1;
             }
         }
 
@@ -1003,7 +1006,7 @@ Report Generation:
     --report-type <type>         Roster, RouteManifest, StudentList, DriverSchedule, or any OperationalReportKind
     --output <path>              Output file path (required)
     --route-id <id>              RouteId for Route Summary (integer)
-    --format <format>            Output format: PDF, Excel, CSV (default: PDF)
+    --format <format>            PDF (default) or CSV/Excel (writes .csv; extension is corrected)
 
 General:
   --help, -h                     Show this help message

--- a/BusBuddy.WPF/ViewModels/Reports/ReportsViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Reports/ReportsViewModel.cs
@@ -36,17 +36,9 @@ namespace BusBuddy.WPF.ViewModels.Reports
 
         private static IOperationalReportService CreateDefaultReportService()
         {
-            var sp = App.ServiceProvider;
-            return sp?.GetService<IOperationalReportService>()
-                ?? new OperationalReportService(
-                    new PdfReportService(),
-                    sp?.GetService<IStudentService>() ?? new StudentService(new BusBuddy.Core.Data.BusBuddyDbContextFactory()),
-                    sp?.GetService<IRouteService>() ?? new RouteService(new BusBuddy.Core.Data.BusBuddyDbContextFactory()),
-                    sp?.GetService<IDriverService>(),
-                    sp?.GetService<BusBuddy.Core.Services.Interfaces.IBusService>(),
-                    sp?.GetService<IFuelService>(),
-                    sp?.GetService<IMaintenanceService>(),
-                    sp?.GetService<GrokGlobalAPI>());
+            return App.ServiceProvider?.GetService<IOperationalReportService>()
+                ?? throw new InvalidOperationException(
+                    "IOperationalReportService is not registered. Open Reports after the application finishes starting.");
         }
 
         #region Properties
@@ -233,16 +225,16 @@ namespace BusBuddy.WPF.ViewModels.Reports
             ExecuteKindAsync(OperationalReportKind.PdfExport, "PDF Export");
 
         private Task ExecuteExportAllDataToExcelAsync() =>
-            ExecuteKindAsync(OperationalReportKind.ExcelExport, "Excel Export");
+            ExecuteKindAsync(OperationalReportKind.ExcelExport, "Excel-ready CSV");
 
         private Task ExecutePrintStudentListsAsync() =>
-            ExecuteKindAsync(OperationalReportKind.PrintStudentLists, "Print Student Lists");
+            ExecuteKindAsync(OperationalReportKind.PrintStudentLists, "Student Lists PDF");
 
         private Task ExecutePrintRouteMapsAsync() =>
-            ExecuteKindAsync(OperationalReportKind.PrintRouteMaps, "Print Route Maps");
+            ExecuteKindAsync(OperationalReportKind.PrintRouteMaps, "Route List PDF");
 
         private Task ExecutePrintSchedulesAsync() =>
-            ExecuteKindAsync(OperationalReportKind.PrintSchedules, "Print Schedules");
+            ExecuteKindAsync(OperationalReportKind.PrintSchedules, "Schedules PDF");
 
         #endregion
 

--- a/BusBuddy.WPF/Views/Reports/ReportsView.xaml
+++ b/BusBuddy.WPF/Views/Reports/ReportsView.xaml
@@ -206,33 +206,33 @@
                                     AutomationProperties.Name="Export All Data to PDF"
                                     AutomationProperties.HelpText="Export formatted reports to PDF"/>
 
-                            <syncfusion:ButtonAdv Label="📈 Export to Excel"
+                            <syncfusion:ButtonAdv Label="📈 Export Excel-ready CSV"
                                     Command="{Binding ExportAllDataToExcelCommand}"
                                     Background="{DynamicResource BusBuddy.Brush.Semantic.Success}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" Margin="0,5"
-                                    AutomationProperties.Name="Export All Data to Excel"
-                                    AutomationProperties.HelpText="Export data to Excel workbook"/>
+                                    AutomationProperties.Name="Export Excel-ready CSV"
+                                    AutomationProperties.HelpText="Export data as a CSV file that opens in Excel"/>
                         </StackPanel>
 
                         <StackPanel Grid.Column="1" Margin="10,0,0,0">
-                            <TextBlock Text="Print Options" FontWeight="Bold" Margin="0,0,0,10"/>
+                            <TextBlock Text="Save for print (PDF)" FontWeight="Bold" Margin="0,0,0,10"/>
 
-                            <syncfusion:ButtonAdv Label="🖨️ Print Student Lists"
+                            <syncfusion:ButtonAdv Label="🖨️ Save student lists (PDF)"
                                     Command="{Binding PrintStudentListsCommand}"
                                     Background="{DynamicResource BusBuddy.Brush.Primary}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" Margin="0,5"
-                                    AutomationProperties.Name="Print Student Lists"
-                                    AutomationProperties.HelpText="Print formatted student lists by route"/>
+                                    AutomationProperties.Name="Save Student Lists PDF"
+                                    AutomationProperties.HelpText="Save a student-list PDF for printing"/>
 
-                            <syncfusion:ButtonAdv Label="🗺️ Print Route Maps"
+                            <syncfusion:ButtonAdv Label="🗺️ Save route list (PDF)"
                                     Command="{Binding PrintRouteMapsCommand}"
                                     Background="{DynamicResource BusBuddy.Brush.Semantic.Warning}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" Margin="0,5"
-                                    AutomationProperties.Name="Print Route Maps"
-                                    AutomationProperties.HelpText="Print route maps and directions"/>
+                                    AutomationProperties.Name="Save Route List PDF"
+                                    AutomationProperties.HelpText="Save a route-list PDF for printing (not a map image)"/>
 
-                            <syncfusion:ButtonAdv Label="📅 Print Schedules"
+                            <syncfusion:ButtonAdv Label="📅 Save schedules (PDF)"
                                     Command="{Binding PrintSchedulesCommand}"
                                     Background="{DynamicResource BusBuddy.Brush.Semantic.Warning}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" Margin="0,5"
-                                    AutomationProperties.Name="Print Schedules"
-                                    AutomationProperties.HelpText="Print transportation schedules"/>
+                                    AutomationProperties.Name="Save Schedules PDF"
+                                    AutomationProperties.HelpText="Save a schedule PDF for printing"/>
                         </StackPanel>
                     </Grid>
                 </GroupBox>

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -77,4 +77,4 @@
 
 ---
 
-*Updated 2026-08-16: Reports UI + CLI `--generate-report` write live PDFs/CSVs (PR #24 + leftovers).*
+*Updated 2026-08-16: Reports CLI leftovers — real PDFs, exit codes, paginated tables (PR #25).*


### PR DESCRIPTION
## Summary
- Follow-up to [PR #25](https://github.com/Bigessfour/BusBuddy-3/pull/25), which auto-merged before these review fixes were pushed.
- CLI `--generate-report` now runs off the UI thread (`Task.Run`) and returns exit code 1 on failure.
- Route Summary writes the all-routes table unless `--route-id` is set; tabular PDFs paginate instead of dropping rows after 42; `--format csv` rewrites a `.pdf` path to `.csv`.
- Reports no longer constructs a second `DbContext` on DI miss; Print/Excel labels match what the files actually are.

## Test plan
- [ ] `dotnet test --filter FullyQualifiedName~OperationalReport|GenerateTabularReport` on Windows
- [ ] Route Summary without a route id: status says N rows for N routes
- [ ] `--format csv --output roster.pdf` writes `roster.csv`
- [ ] Unknown `--report-type` exits 1
- [ ] 50-row roster PDF is larger than a 2-row PDF