### PR TITLE
fix: even FluentDark and FluentLight across panels

### DIFF
--- a/BusBuddy.Tests/WPF/SyncfusionThemeManagerTests.cs
+++ b/BusBuddy.Tests/WPF/SyncfusionThemeManagerTests.cs
@@ -1,0 +1,29 @@
+using BusBuddy.WPF.Utilities;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.WPF
+{
+    [TestFixture]
+    [Category("WPF")]
+    public class SyncfusionThemeManagerTests
+    {
+        [TestCase(null, "FluentDark")]
+        [TestCase("", "FluentDark")]
+        [TestCase("FluentDark", "FluentDark")]
+        [TestCase("fluentdark", "FluentDark")]
+        [TestCase("FluentLight", "FluentLight")]
+        [TestCase("light", "FluentLight")]
+        [TestCase("FluentWhite", "FluentLight")]
+        public void NormalizeThemeName_MapsAliases(string? input, string expected)
+        {
+            Assert.That(SyncfusionThemeManager.NormalizeThemeName(input), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ThemeDictionaryPath_MatchesActiveTheme()
+        {
+            Assert.That(SyncfusionThemeManager.ThemeDictionaryPath("FluentDark"), Does.Contain("FluentDarkTheme.xaml"));
+            Assert.That(SyncfusionThemeManager.ThemeDictionaryPath("FluentLight"), Does.Contain("FluentLightTheme.xaml"));
+        }
+    }
+}

--- a/BusBuddy.WPF/App.xaml
+++ b/BusBuddy.WPF/App.xaml
@@ -16,13 +16,8 @@
                 <!-- Load Syncfusion styles (no duplicate brushes, minimal control styles) -->
                 <ResourceDictionary Source="Resources/SyncfusionStyles.xaml" />
 
-                <!-- Load theme-specific resources -->
-                <!-- Note: Only load one theme at a time to avoid duplicate implicit styles -->
-                <!-- FluentDark is primary theme; FluentLight can be loaded dynamically via SfSkinManager -->
+                <!-- One Fluent brush dictionary at a time; SyncfusionThemeManager swaps this on theme change -->
                 <ResourceDictionary Source="Resources/Themes/FluentDarkTheme.xaml"/>
-
-                <!-- Custom brush overrides for enhanced form contrast -->
-                <ResourceDictionary Source="Resources/Themes/CustomBrushes.xaml"/>
 
                 <!-- Phase 1: Basic styling without complex theme conflicts -->
                 <!-- Note: Syncfusion themes are applied programmatically via SfSkinManager in App.xaml.cs -->

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -21,8 +21,7 @@ using Serilog.Formatting.Json;
 using Serilog.Settings.Configuration;
 using System.Threading.Tasks;
 using Syncfusion.SfSkinManager;
-using Syncfusion.Themes.FluentDark.WPF;
-using Syncfusion.Themes.FluentLight.WPF;
+using BusBuddy.WPF.Utilities;
 
 namespace BusBuddy.WPF
 {
@@ -1228,41 +1227,8 @@ Examples:
         /// </summary>
         private void InitializeSyncfusionThemes()
         {
-            try
-            {
-                Log.Information("🎨 Initializing SyncFusion themes for v30.1.42...");
-
-                // Enable theme application as default style (required for v30.1.42)
-                SfSkinManager.ApplyStylesOnApplication = true;
-
-                // Register FluentDark theme settings
-                SfSkinManager.RegisterThemeSettings("FluentDark", new FluentDarkThemeSettings());
-                Log.Debug("✅ FluentDark theme settings registered");
-
-                // Register FluentLight theme settings (fallback)
-                SfSkinManager.RegisterThemeSettings("FluentLight", new FluentLightThemeSettings());
-                Log.Debug("✅ FluentLight theme settings registered");
-
-                // Apply FluentDark as the application theme
-                SfSkinManager.ApplicationTheme = new Theme("FluentDark");
-                Log.Information("🎨 FluentDark theme applied as application default");
-
-                Log.Information("✅ SyncFusion theme initialization completed successfully");
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "⚠️ Failed to initialize FluentDark theme, falling back to FluentLight");
-                try
-                {
-                    // Fallback to FluentLight
-                    SfSkinManager.ApplicationTheme = new Theme("FluentLight");
-                    Log.Information("🎨 FluentLight fallback theme applied");
-                }
-                catch (Exception fallbackEx)
-                {
-                    Log.Error(fallbackEx, "❌ Failed to apply any SyncFusion theme - using default styling");
-                }
-            }
+            Log.Information("Initializing Syncfusion Fluent themes");
+            SyncfusionThemeManager.ApplyApplicationTheme(SyncfusionThemeManager.PRIMARY_THEME);
         }
     }
 }

--- a/BusBuddy.WPF/Resources/Themes/FluentDarkTheme.xaml
+++ b/BusBuddy.WPF/Resources/Themes/FluentDarkTheme.xaml
@@ -178,4 +178,23 @@
         </Style.Triggers>
     </Style>
 
+    <!-- Surface / text tokens used by docking panels. LightMode key names are historical; values follow FluentDark. -->
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Background" Color="#1E1E1E"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Surface" Color="#252526"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Border" Color="#3F3F46"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Accent" Color="#2D2D30"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Primary" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Secondary" Color="#E5E5E5"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.Primary" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.Secondary" Color="#E5E5E5"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Background" Color="#1A1A1A"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Content" Color="#252526"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Header" Color="#2D2D30"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Border" Color="#404040"/>
+    <SolidColorBrush x:Key="FormLabelForegroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="FormInputForegroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="FormInputBackgroundBrush" Color="#2B2B2B"/>
+    <SolidColorBrush x:Key="FormInputBorderBrush" Color="#555555"/>
+    <SolidColorBrush x:Key="FormSectionHeaderBrush" Color="#333333"/>
+
 </ResourceDictionary>

--- a/BusBuddy.WPF/Resources/Themes/FluentLightTheme.xaml
+++ b/BusBuddy.WPF/Resources/Themes/FluentLightTheme.xaml
@@ -199,4 +199,28 @@
             </Trigger>
         </Style.Triggers>
     </Style>
+
+    <SolidColorBrush x:Key="HighContrastTextBrush" Color="#201F1E"/>
+    <SolidColorBrush x:Key="ErrorTextBrush" Color="#A80000"/>
+    <SolidColorBrush x:Key="WarningTextBrush" Color="#8A6D00"/>
+    <SolidColorBrush x:Key="SuccessTextBrush" Color="#107C10"/>
+
+    <!-- Same token keys as FluentDark so DynamicResource updates when the dictionary is swapped. -->
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Background" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Surface" Color="#F3F2F1"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Border" Color="#E1DFDD"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Accent" Color="#FAFAFA"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Primary" Color="#201F1E"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Secondary" Color="#323130"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.Primary" Color="#201F1E"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.Secondary" Color="#605E5C"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Background" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Content" Color="#FAFAFA"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Header" Color="#F3F2F1"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Border" Color="#D2D0CE"/>
+    <SolidColorBrush x:Key="FormLabelForegroundBrush" Color="#201F1E"/>
+    <SolidColorBrush x:Key="FormInputForegroundBrush" Color="#201F1E"/>
+    <SolidColorBrush x:Key="FormInputBackgroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="FormInputBorderBrush" Color="#D2D0CE"/>
+    <SolidColorBrush x:Key="FormSectionHeaderBrush" Color="#F3F2F1"/>
 </ResourceDictionary>

--- a/BusBuddy.WPF/Services/SkinManagerService.cs
+++ b/BusBuddy.WPF/Services/SkinManagerService.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Windows;
-using Syncfusion.SfSkinManager;
-using Syncfusion.Themes.FluentDark.WPF;
-using Syncfusion.Themes.FluentLight.WPF;
+using BusBuddy.WPF.Utilities;
 using Serilog;
 
 namespace BusBuddy.WPF.Services
@@ -12,7 +9,7 @@ namespace BusBuddy.WPF.Services
         void ApplyTheme(string themeName);
         void ApplyFluentDark();
         void ApplyFluentLight();
-    void ApplyThemeToElement(FrameworkElement? element, string? themeName = null);
+        void ApplyThemeToElement(System.Windows.FrameworkElement? element, string? themeName = null);
         string CurrentTheme { get; }
         bool IsThemeApplied { get; }
     }
@@ -20,141 +17,34 @@ namespace BusBuddy.WPF.Services
     public class SkinManagerService : ISkinManagerService
     {
         private static readonly ILogger Logger = Log.ForContext<SkinManagerService>();
-        private string _currentTheme = "FluentDark";
-        private bool _isThemeApplied;
 
-        public string CurrentTheme => _currentTheme;
-        public bool IsThemeApplied => _isThemeApplied;
+        public string CurrentTheme => SyncfusionThemeManager.CurrentThemeName;
+        public bool IsThemeApplied => !string.IsNullOrWhiteSpace(CurrentTheme);
 
         public void ApplyTheme(string themeName)
         {
-            try
-            {
-                Logger.Information("Applying theme {ThemeName}", themeName);
-
-                switch (themeName?.ToLower())
-                {
-                    case "fluentdark":
-                        ApplyFluentDark();
-                        break;
-                    case "fluentlight":
-                    case "fluentwhite":
-                        ApplyFluentLight();
-                        break;
-                    default:
-                        Logger.Warning("Unknown theme {ThemeName}, applying FluentDark as default", themeName);
-                        ApplyFluentDark();
-                        break;
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to apply theme {ThemeName}, falling back to FluentLight", themeName);
-                ApplyFluentLight();
-            }
+            Logger.Information("Applying theme {ThemeName}", themeName);
+            SyncfusionThemeManager.ApplyApplicationTheme(themeName);
         }
 
-        public void ApplyFluentDark()
+        public void ApplyFluentDark() => ApplyTheme(SyncfusionThemeManager.PRIMARY_THEME);
+
+        public void ApplyFluentLight() => ApplyTheme(SyncfusionThemeManager.FALLBACK_THEME);
+
+        public void ApplyThemeToElement(System.Windows.FrameworkElement? element, string? themeName = null)
         {
-            try
-            {
-                Logger.Debug("Registering FluentDark theme settings");
-
-                // Register Fluent Dark theme following official Syncfusion documentation
-                SfSkinManager.RegisterThemeSettings("FluentDark", new FluentDarkThemeSettings());
-
-                // Set as application-wide theme
-                SfSkinManager.ApplyStylesOnApplication = true;
-
-                // Apply to main window if available
-                if (Application.Current?.MainWindow != null)
-                {
-                    using var theme = new Theme("FluentDark");
-                    SfSkinManager.SetTheme(Application.Current.MainWindow, theme);
-                    Logger.Debug("Applied FluentDark theme to MainWindow");
-                }
-
-                _currentTheme = "FluentDark";
-                _isThemeApplied = true;
-
-                Logger.Information("Successfully applied FluentDark theme");
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to apply FluentDark theme, attempting FluentLight fallback");
-                ApplyFluentLight();
-            }
-        }
-
-        public void ApplyFluentLight()
-        {
-            try
-            {
-                Logger.Debug("Registering FluentLight theme settings");
-
-                // Register Fluent Light theme following official Syncfusion documentation
-                SfSkinManager.RegisterThemeSettings("FluentLight", new FluentLightThemeSettings());
-
-                // Set as application-wide theme
-                SfSkinManager.ApplyStylesOnApplication = true;
-
-                // Apply to main window if available
-                if (Application.Current?.MainWindow != null)
-                {
-                    using var theme = new Theme("FluentLight");
-                    SfSkinManager.SetTheme(Application.Current.MainWindow, theme);
-                    Logger.Debug("Applied FluentLight theme to MainWindow");
-                }
-
-                _currentTheme = "FluentLight";
-                _isThemeApplied = true;
-
-                Logger.Information("Successfully applied FluentLight theme");
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to apply FluentLight theme, continuing with default styling");
-                _currentTheme = "Default";
-                _isThemeApplied = false;
-            }
-        }
-
-        public void ApplyThemeToElement(FrameworkElement? element, string? themeName = null)
-        {
-            if (element == null)
+            if (element is null)
             {
                 Logger.Warning("Cannot apply theme to null element");
                 return;
             }
 
-            var themeToApply = themeName ?? _currentTheme;
-
-            try
+            if (!string.IsNullOrWhiteSpace(themeName))
             {
-                using var theme = new Theme(themeToApply);
-                SfSkinManager.SetTheme(element, theme);
-
-                Logger.Debug("Applied {ThemeName} theme to {ElementType}", themeToApply, element.GetType().Name);
+                SyncfusionThemeManager.ApplyApplicationTheme(themeName);
             }
-            catch (Exception ex)
-            {
-                Logger.Warning(ex, "Failed to apply {ThemeName} theme to {ElementType}, trying fallback",
-                    themeToApply, element.GetType().Name);
 
-                try
-                {
-                    var fallbackTheme = themeToApply == "FluentDark" ? "FluentLight" : "FluentDark";
-                    using var theme = new Theme(fallbackTheme);
-                    SfSkinManager.SetTheme(element, theme);
-
-                    Logger.Debug("Applied fallback {FallbackTheme} theme to {ElementType}",
-                        fallbackTheme, element.GetType().Name);
-                }
-                catch (Exception fallbackEx)
-                {
-                    Logger.Error(fallbackEx, "Failed to apply any theme to {ElementType}", element.GetType().Name);
-                }
-            }
+            SyncfusionThemeManager.ApplyTheme(element);
         }
     }
 }

--- a/BusBuddy.WPF/Utilities/SyncfusionThemeManager.cs
+++ b/BusBuddy.WPF/Utilities/SyncfusionThemeManager.cs
@@ -2,85 +2,147 @@ using System;
 using System.Windows;
 using Serilog;
 using Syncfusion.SfSkinManager;
+using Syncfusion.Themes.FluentDark.WPF;
+using Syncfusion.Themes.FluentLight.WPF;
 
 namespace BusBuddy.WPF.Utilities
 {
     /// <summary>
-    /// Helper utility for consistent Syncfusion theme application across all views
+    /// Single source of truth for FluentDark / FluentLight. Views inherit
+    /// <see cref="SfSkinManager.ApplicationTheme"/>; windows/dialogs take the current theme.
     /// </summary>
     public static class SyncfusionThemeManager
     {
         private static readonly ILogger Logger = Log.ForContext(typeof(SyncfusionThemeManager));
 
-        /// <summary>
-        /// Default primary theme (FluentDark)
-        /// </summary>
         public const string PRIMARY_THEME = "FluentDark";
-
-        /// <summary>
-        /// Fallback theme (FluentLight)
-        /// </summary>
         public const string FALLBACK_THEME = "FluentLight";
 
+        public static string CurrentThemeName { get; private set; } = PRIMARY_THEME;
+
+        public static string NormalizeThemeName(string? themeName)
+        {
+            if (string.IsNullOrWhiteSpace(themeName))
+            {
+                return PRIMARY_THEME;
+            }
+
+            var key = themeName.Trim();
+            if (key.Equals(FALLBACK_THEME, StringComparison.OrdinalIgnoreCase)
+                || key.Equals("FluentWhite", StringComparison.OrdinalIgnoreCase)
+                || key.Equals("Light", StringComparison.OrdinalIgnoreCase))
+            {
+                return FALLBACK_THEME;
+            }
+
+            return PRIMARY_THEME;
+        }
+
         /// <summary>
-        /// Apply theme to a view with proper error handling and fallback
+        /// Apply the active application theme to a window or dialog.
+        /// UserControls inherit <see cref="SfSkinManager.ApplicationTheme"/> so docking panels stay even.
         /// </summary>
-        /// <param name="view">The view to apply the theme to</param>
         public static void ApplyTheme(DependencyObject view)
         {
+            if (view is null)
+            {
+                return;
+            }
+
             try
             {
-                Logger.Debug("[Theme] Applying {Theme} theme to {ViewType}", PRIMARY_THEME, view.GetType().Name);
+                SfSkinManager.ApplyStylesOnApplication = true;
+                SfSkinManager.ApplyThemeAsDefaultStyle = true;
 
-                // Use a using statement for proper disposal of the Theme object
-                using (var theme = new Theme(PRIMARY_THEME))
+                if (view is not Window)
                 {
-                    SfSkinManager.SetTheme(view, theme);
-                    Logger.Information("Theme changed to {ThemeName} for {Component}", PRIMARY_THEME, view.GetType().Name);
+                    Logger.Debug("[Theme] {ViewType} inherits application theme {Theme}", view.GetType().Name, CurrentThemeName);
+                    return;
                 }
+
+                var theme = new Theme(CurrentThemeName);
+                SfSkinManager.SetTheme(view, theme);
+                Logger.Information("Theme changed to {ThemeName} for {Component}", CurrentThemeName, view.GetType().Name);
             }
             catch (Exception ex)
             {
-                Logger.Warning(ex, "[Theme] Failed to apply {PrimaryTheme}, attempting fallback to {FallbackTheme}",
-                    PRIMARY_THEME, FALLBACK_THEME);
-
+                Logger.Warning(ex, "[Theme] Failed to apply {Theme} to {ViewType}, trying {Fallback}",
+                    CurrentThemeName, view.GetType().Name, FALLBACK_THEME);
                 try
                 {
-                    // Try fallback theme if primary fails
-                    using (var fallbackTheme = new Theme(FALLBACK_THEME))
-                    {
-                        SfSkinManager.SetTheme(view, fallbackTheme);
-                    }
-                    Logger.Information("[Theme] Successfully applied fallback theme {FallbackTheme} to {ViewType}",
-                        FALLBACK_THEME, view.GetType().Name);
+                    var fallback = new Theme(FALLBACK_THEME);
+                    SfSkinManager.SetTheme(view, fallback);
                 }
                 catch (Exception fallbackEx)
                 {
-                    // If both themes fail, log error but don't crash the application
-                    Logger.Error(fallbackEx, "[Theme] Failed to apply both primary and fallback themes to {ViewType}",
-                        view.GetType().Name);
+                    Logger.Error(fallbackEx, "[Theme] Failed to apply both themes to {ViewType}", view.GetType().Name);
                 }
             }
         }
 
         /// <summary>
-        /// Validates that critical theme resources are available
+        /// Switch FluentDark / FluentLight for the whole app, including custom brush dictionaries.
         /// </summary>
+        public static void ApplyApplicationTheme(string? themeName)
+        {
+            var name = NormalizeThemeName(themeName);
+            try
+            {
+                SfSkinManager.ApplyStylesOnApplication = true;
+                SfSkinManager.ApplyThemeAsDefaultStyle = true;
+
+                if (name == FALLBACK_THEME)
+                {
+                    SfSkinManager.RegisterThemeSettings(FALLBACK_THEME, new FluentLightThemeSettings());
+                }
+                else
+                {
+                    SfSkinManager.RegisterThemeSettings(PRIMARY_THEME, new FluentDarkThemeSettings());
+                }
+
+                var theme = new Theme(name);
+                SfSkinManager.ApplicationTheme = theme;
+                CurrentThemeName = name;
+                SwapThemeBrushDictionary(name);
+
+                if (Application.Current is not null)
+                {
+                    foreach (Window win in Application.Current.Windows)
+                    {
+                        try
+                        {
+                            SfSkinManager.SetTheme(win, theme);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Warning(ex, "[Theme] Could not apply {Theme} to {Window}", name, win.GetType().Name);
+                        }
+                    }
+                }
+
+                Logger.Information("Theme changed to {ThemeName} at application scope", name);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "[Theme] Failed to apply {Theme}, falling back to {Fallback}", name, FALLBACK_THEME);
+                if (!name.Equals(FALLBACK_THEME, StringComparison.Ordinal))
+                {
+                    ApplyApplicationTheme(FALLBACK_THEME);
+                }
+            }
+        }
+
         public static bool ValidateThemeResources()
         {
             if (Application.Current == null)
             {
-
                 return false;
             }
 
-
             var resources = Application.Current.Resources;
             string[] criticalResources = { "MenuItemStyle", "MenuSeparatorStyle", "ContextMenuStyle" };
-
-            bool allResourcesAvailable = true;
-
-            foreach (string resource in criticalResources)
+            var allResourcesAvailable = true;
+            foreach (var resource in criticalResources)
             {
                 if (resources[resource] == null)
                 {
@@ -90,6 +152,45 @@ namespace BusBuddy.WPF.Utilities
             }
 
             return allResourcesAvailable;
+        }
+
+        public static string ThemeDictionaryPath(string themeName) =>
+            NormalizeThemeName(themeName) == FALLBACK_THEME
+                ? "Resources/Themes/FluentLightTheme.xaml"
+                : "Resources/Themes/FluentDarkTheme.xaml";
+
+        private static void SwapThemeBrushDictionary(string themeName)
+        {
+            var app = Application.Current;
+            if (app?.Resources?.MergedDictionaries is null)
+            {
+                return;
+            }
+
+            var path = ThemeDictionaryPath(themeName);
+            var uri = new Uri($"/BusBuddy.WPF;component/{path}", UriKind.Relative);
+            ResourceDictionary? existing = null;
+            foreach (var dictionary in app.Resources.MergedDictionaries)
+            {
+                var source = dictionary.Source?.OriginalString ?? string.Empty;
+                if (source.Contains("FluentDarkTheme.xaml", StringComparison.OrdinalIgnoreCase)
+                    || source.Contains("FluentLightTheme.xaml", StringComparison.OrdinalIgnoreCase))
+                {
+                    existing = dictionary;
+                    break;
+                }
+            }
+
+            var next = new ResourceDictionary { Source = uri };
+            if (existing is not null)
+            {
+                var index = app.Resources.MergedDictionaries.IndexOf(existing);
+                app.Resources.MergedDictionaries[index] = next;
+            }
+            else
+            {
+                app.Resources.MergedDictionaries.Add(next);
+            }
         }
     }
 }

--- a/BusBuddy.WPF/Utilities/UIDebugManager.cs
+++ b/BusBuddy.WPF/Utilities/UIDebugManager.cs
@@ -228,16 +228,8 @@ namespace BusBuddy.WPF.Utilities
         {
             try
             {
-                if (Application.Current.MainWindow == null)
-                {
-                    return;
-                }
-
-                using (var theme = new Theme(CurrentTheme))
-                {
-                    SfSkinManager.SetTheme(Application.Current.MainWindow, theme);
-                }
-
+                SyncfusionThemeManager.ApplyApplicationTheme(CurrentTheme);
+                CurrentTheme = SyncfusionThemeManager.CurrentThemeName;
                 Logger.Debug("[UIDebug] Applied theme: {Theme}", CurrentTheme);
             }
             catch (Exception ex)

--- a/BusBuddy.WPF/Views/Activity/ActivityScheduleEditDialog.xaml.cs
+++ b/BusBuddy.WPF/Views/Activity/ActivityScheduleEditDialog.xaml.cs
@@ -23,17 +23,7 @@ namespace BusBuddy.WPF.Views.Activity
         {
             InitializeComponent();
 
-            // Apply Syncfusion theme — FluentDark default, FluentLight fallback
-            try
-            {
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-            }
-            catch
-            {
-                try { using var light = new Theme("FluentLight"); SfSkinManager.SetTheme(this, light); } catch { }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
 
             ViewModel = new ActivityScheduleEditDialogViewModel(activityToEdit);
             DataContext = ViewModel;

--- a/BusBuddy.WPF/Views/Bus/BusEditDialog.xaml.cs
+++ b/BusBuddy.WPF/Views/Bus/BusEditDialog.xaml.cs
@@ -16,22 +16,7 @@ namespace BusBuddy.WPF.Views.Bus
         {
             InitializeComponent();
             Bus = bus != null ? bus : new BusBuddy.Core.Models.Bus();
-            // Apply Syncfusion theme — FluentDark default, FluentLight fallback
-            try
-            {
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-            }
-            catch
-            {
-                try
-                {
-                    using var light = new Theme("FluentLight");
-                    SfSkinManager.SetTheme(this, light);
-                }
-                catch { }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
             // Load existing data into form controls
             LoadBusData();
 
@@ -47,22 +32,7 @@ namespace BusBuddy.WPF.Views.Bus
         {
             InitializeComponent();
             Bus = new BusBuddy.Core.Models.Bus(); // Initialize Bus property to fix CS8618
-            // Apply Syncfusion theme — FluentDark default, FluentLight fallback
-            try
-            {
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-            }
-            catch
-            {
-                try
-                {
-                    using var light = new Theme("FluentLight");
-                    SfSkinManager.SetTheme(this, light);
-                }
-                catch { }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
         }
 
         protected override void OnClosed(EventArgs e)

--- a/BusBuddy.WPF/Views/Bus/BusForm.xaml.cs
+++ b/BusBuddy.WPF/Views/Bus/BusForm.xaml.cs
@@ -69,26 +69,7 @@ namespace BusBuddy.WPF.Views.Bus
         /// </summary>
         private void ApplySyncfusionTheme()
         {
-            SfSkinManager.ApplyThemeAsDefaultStyle = true;
-            try
-            {
-                using var fluentDarkTheme = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, fluentDarkTheme);
-                Serilog.Log.Information("FluentDark theme applied to {ViewName}", GetType().Name);
-            }
-            catch
-            {
-                try
-                {
-                    using var fluentLightTheme = new Theme("FluentLight");
-                    SfSkinManager.SetTheme(this, fluentLightTheme);
-                    Serilog.Log.Information("Fallback to FluentLight theme for {ViewName}", GetType().Name);
-                }
-                catch
-                {
-                    // Continue without theme if both fail
-                }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
         }
 
         protected override void OnClosed(System.EventArgs e)

--- a/BusBuddy.WPF/Views/Bus/ConfirmationDialog.xaml.cs
+++ b/BusBuddy.WPF/Views/Bus/ConfirmationDialog.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using Syncfusion.SfSkinManager;
+using BusBuddy.WPF.Utilities;
 
 namespace BusBuddy.WPF.Views.Bus
 {
@@ -10,16 +11,7 @@ namespace BusBuddy.WPF.Views.Bus
         {
             InitializeComponent();
             Title = title;
-            try
-            {
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-            }
-            catch
-            {
-                try { using var light = new Theme("FluentLight"); SfSkinManager.SetTheme(this, light); } catch { }
-            }
+            SyncfusionThemeManager.ApplyTheme(this);
 
             // Find the MessageText element and set its content
             if (FindName("MessageText") is TextBlock messageTextBlock)
@@ -31,16 +23,7 @@ namespace BusBuddy.WPF.Views.Bus
         public ConfirmationDialog()
         {
             InitializeComponent();
-            try
-            {
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-            }
-            catch
-            {
-                try { using var light = new Theme("FluentLight"); SfSkinManager.SetTheme(this, light); } catch { }
-            }
+            SyncfusionThemeManager.ApplyTheme(this);
         }
 
         private void YesButton_Click(object sender, RoutedEventArgs e)

--- a/BusBuddy.WPF/Views/Bus/NotificationWindow.xaml.cs
+++ b/BusBuddy.WPF/Views/Bus/NotificationWindow.xaml.cs
@@ -18,31 +18,13 @@ namespace BusBuddy.WPF.Views.Bus
         public NotificationWindow()
         {
             InitializeComponent();
-            try
-            {
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-            }
-            catch
-            {
-                try { using var light = new Theme("FluentLight"); SfSkinManager.SetTheme(this, light); } catch { }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
         }
 
         public NotificationWindow(string message, string title = "Notification", NotificationType type = NotificationType.Information)
         {
             InitializeComponent();
-            try
-            {
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-            }
-            catch
-            {
-                try { using var light = new Theme("FluentLight"); SfSkinManager.SetTheme(this, light); } catch { }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
 
             // Find elements by name and set their properties
             if (FindName("TitleText") is TextBlock titleText)

--- a/BusBuddy.WPF/Views/Driver/DriverForm.xaml.cs
+++ b/BusBuddy.WPF/Views/Driver/DriverForm.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using Syncfusion.Windows.Shared;
 using Syncfusion.SfSkinManager;
+using BusBuddy.WPF.Utilities;
 using BusBuddy.WPF.ViewModels.Driver;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
@@ -23,21 +24,7 @@ namespace BusBuddy.WPF.Views.Driver
             Log.Information("Initializing {ViewName}", nameof(DriverForm));
             InitializeComponent();
 
-            // Apply Syncfusion theme — FluentDark default, FluentLight fallback
-            SfSkinManager.ApplyThemeAsDefaultStyle = true;
-            try
-            {
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-                Log.Information("FluentDark theme applied to DriverForm");
-            }
-            catch (System.Exception ex)
-            {
-                Log.Error("Failed to apply FluentDark theme to DriverForm: {Error}", ex.Message);
-                using var white = new Theme("FluentWhite");
-                SfSkinManager.SetTheme(this, white);
-                Log.Information("Fallback to FluentLight theme for DriverForm");
-            }
+            SyncfusionThemeManager.ApplyTheme(this);
 
             // Set DataContext to DriverFormViewModel using DI
             if (App.ServiceProvider != null)

--- a/BusBuddy.WPF/Views/Fuel/FuelDialog.xaml.cs
+++ b/BusBuddy.WPF/Views/Fuel/FuelDialog.xaml.cs
@@ -98,17 +98,7 @@ namespace BusBuddy.WPF.Views.Fuel
             DialogTitle = fuel.FuelId == 0 ? "Add Fuel Record" : "Edit Fuel Record";
 
             InitializeComponent();
-            // Apply Syncfusion theme — FluentDark default, FluentLight fallback
-            try
-            {
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                using var dark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, dark);
-            }
-            catch
-            {
-                try { using var light = new Theme("FluentLight"); SfSkinManager.SetTheme(this, light); } catch { }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
             DataContext = this;
 
             // Ensure the model has default values if it's new

--- a/BusBuddy.WPF/Views/Fuel/FuelReconciliationDialog.xaml.cs
+++ b/BusBuddy.WPF/Views/Fuel/FuelReconciliationDialog.xaml.cs
@@ -470,26 +470,7 @@ namespace BusBuddy.WPF.Views.Fuel
         /// </summary>
         private void ApplySyncfusionTheme()
         {
-            SfSkinManager.ApplyThemeAsDefaultStyle = true;
-            try
-            {
-                using var fluentDarkTheme = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, fluentDarkTheme);
-                Logger.Information("FluentDark theme applied to {ViewName}", GetType().Name);
-            }
-            catch
-            {
-                try
-                {
-                    using var fluentLightTheme = new Theme("FluentLight");
-                    SfSkinManager.SetTheme(this, fluentLightTheme);
-                    Logger.Information("Fallback to FluentLight theme for {ViewName}", GetType().Name);
-                }
-                catch
-                {
-                    // Continue without theme if both fail
-                }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
         }
 
         protected override void OnClosed(EventArgs e)

--- a/BusBuddy.WPF/Views/GoogleEarth/GoogleEarthView.xaml.cs
+++ b/BusBuddy.WPF/Views/GoogleEarth/GoogleEarthView.xaml.cs
@@ -134,26 +134,7 @@ namespace BusBuddy.WPF.Views.GoogleEarth
         /// </summary>
         private void ApplySyncfusionTheme()
         {
-            SfSkinManager.ApplyThemeAsDefaultStyle = true;
-            try
-            {
-                using var fluentDark = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, fluentDark);
-                Logger.Information("FluentDark theme applied to {ViewName}", GetType().Name);
-            }
-            catch
-            {
-                try
-                {
-                    using var fluentLight = new Theme("FluentLight");
-                    SfSkinManager.SetTheme(this, fluentLight);
-                    Logger.Information("Fallback to FluentLight theme for {ViewName}", GetType().Name);
-                }
-                catch
-                {
-                    // Continue without theme if both fail
-                }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
         }
 
     // Unloaded/Dispose implemented later in file with full dispose pattern

--- a/BusBuddy.WPF/Views/Main/MainWindow.xaml.cs
+++ b/BusBuddy.WPF/Views/Main/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using BusBuddy.WPF.Views.Settings;
 using BusBuddy.WPF.Views.Vehicle;
 using BusBuddy.WPF.Views.Reports;
 using BusBuddy.WPF.Views.Fuel;
+using BusBuddy.WPF.Utilities;
 using BusBuddy.Core.Services;
 using BusBuddy.Core.Data;
 using Syncfusion.SfSkinManager;
@@ -211,31 +212,17 @@ namespace BusBuddy.WPF.Views.Main
             Logger.Debug("ApplySyncfusionTheme method started");
             try
             {
-                Logger.Debug("Configuring Syncfusion SfSkinManager global settings");
-                // Apply FluentDark theme with FluentLight fallback
-                // Based on SYNCFUSION_API_REFERENCE.md validated patterns
-                SfSkinManager.ApplyStylesOnApplication = true;
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-
-                Logger.Debug("Creating FluentDark theme instance");
-                using var fluentDarkTheme = new Theme("FluentDark");
-                Logger.Debug("Applying FluentDark theme to MainWindow");
-                SfSkinManager.SetTheme(this, fluentDarkTheme);
-
-                Logger.Information("Applied FluentDark theme successfully");
-                Logger.Debug("ApplySyncfusionTheme completed with FluentDark");
+                SyncfusionThemeManager.ApplyTheme(this);
+                Logger.Information("Applied {Theme} theme to MainWindow", SyncfusionThemeManager.CurrentThemeName);
             }
             catch (Exception ex)
             {
-                Logger.Warning(ex, "Failed to apply FluentDark theme, trying FluentLight fallback");
+                Logger.Warning(ex, "Failed to apply current theme, trying FluentLight fallback");
 
                 try
                 {
-                    Logger.Debug("Attempting FluentLight fallback theme");
-                    using var fluentLightTheme = new Theme("FluentLight");
-                    SfSkinManager.SetTheme(this, fluentLightTheme);
+                    SyncfusionThemeManager.ApplyApplicationTheme(SyncfusionThemeManager.FALLBACK_THEME);
                     Logger.Information("Applied FluentLight fallback theme successfully");
-                    Logger.Debug("ApplySyncfusionTheme completed with FluentLight fallback");
                 }
                 catch (Exception fallbackEx)
                 {
@@ -674,47 +661,7 @@ namespace BusBuddy.WPF.Views.Main
         /// </summary>
     private static void ApplyThemeGlobally(string themeName)
         {
-            try
-            {
-                // Ensure global flags are set so styles flow to children
-                SfSkinManager.ApplyStylesOnApplication = true;
-                SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                var theme = new Theme(themeName);
-
-                // Set application-level theme so newly created windows get it automatically
-                SfSkinManager.ApplicationTheme = theme;
-                Logger.Information("Theme changed to {ThemeName} at application scope", themeName);
-
-                // Apply to each open window so the entire UI updates at runtime
-                foreach (Window win in Application.Current.Windows)
-                {
-                    try
-                    {
-                        SfSkinManager.SetTheme(win, theme);
-                        Logger.Information("Theme changed to {ThemeName} for {Component}", themeName, win.GetType().Name);
-                    }
-                    catch
-                    {
-                        // Continue applying theme to other windows even if one fails
-                    }
-                }
-
-                // Also apply to MainWindow explicitly (in case created after others)
-                if (Application.Current.MainWindow is not null)
-                {
-                    try
-                    {
-                        SfSkinManager.SetTheme(Application.Current.MainWindow, theme);
-                        Logger.Information("Theme changed to {ThemeName} for {Component}", themeName, Application.Current.MainWindow.GetType().Name);
-                    }
-                    catch { /* no-op */ }
-                }
-            }
-            catch (Exception)
-            {
-                // Swallow at this level; caller logs details and manages fallback
-                throw;
-            }
+            SyncfusionThemeManager.ApplyApplicationTheme(themeName);
         }
 
         /// <summary>

--- a/BusBuddy.WPF/Views/Route/RouteAssignmentView.xaml.cs
+++ b/BusBuddy.WPF/Views/Route/RouteAssignmentView.xaml.cs
@@ -122,30 +122,7 @@ namespace BusBuddy.WPF.Views.Route
                 }
                 catch
                 {
-                    // Fallback to direct theme application if utility path fails
-                    try
-                    {
-                        var window = Window.GetWindow(this);
-                        if (window != null)
-                        {
-                            SfSkinManager.ApplyThemeAsDefaultStyle = true;
-                            using var dark = new Theme("FluentDark");
-                            SfSkinManager.SetTheme(window, dark);
-                        }
-                    }
-                    catch
-                    {
-                        try
-                        {
-                            var window = Window.GetWindow(this);
-                            if (window != null)
-                            {
-                                using var light = new Theme("FluentLight");
-                                SfSkinManager.SetTheme(window, light);
-                            }
-                        }
-                        catch { }
-                    }
+                    // inherit ApplicationTheme
                 }
 
                 Logger.Information("Loaded {ViewName} with theme resource {ResourceKey}", GetType().Name, "BusBuddy.Brush.Primary");

--- a/BusBuddy.WPF/Views/Vehicle/VehicleForm.xaml.cs
+++ b/BusBuddy.WPF/Views/Vehicle/VehicleForm.xaml.cs
@@ -24,26 +24,7 @@ namespace BusBuddy.WPF.Views.Vehicle
         /// </summary>
         private void ApplySyncfusionTheme()
         {
-            SfSkinManager.ApplyThemeAsDefaultStyle = true;
-            try
-            {
-                using var fluentDarkTheme = new Theme("FluentDark");
-                SfSkinManager.SetTheme(this, fluentDarkTheme);
-                Log.Information("FluentDark theme applied to {ViewName}", GetType().Name);
-            }
-            catch
-            {
-                try
-                {
-                    using var fluentLightTheme = new Theme("FluentLight");
-                    SfSkinManager.SetTheme(this, fluentLightTheme);
-                    Log.Information("Fallback to FluentLight theme for {ViewName}", GetType().Name);
-                }
-                catch
-                {
-                    // Continue without theme if both fail
-                }
-            }
+            BusBuddy.WPF.Utilities.SyncfusionThemeManager.ApplyTheme(this);
         }
 
         protected override void OnClosed(System.EventArgs e)


### PR DESCRIPTION
## Summary
- `SyncfusionThemeManager` is the single theme switch: `ApplicationTheme` plus a swap of `FluentDarkTheme.xaml` / `FluentLightTheme.xaml`.
- UserControls (Reports, Routes, dashboard documents) inherit the app theme instead of each calling `SetTheme(FluentDark)`.
- Historical `BusBuddy.Brush.Surface.LightMode.*` and `Text.Primary` keys now have dark and light values, so panels are not pale islands in dark mode or white-on-white in light mode.
- Dialogs and Settings/`SkinManagerService` use the same current theme.

## Test plan
- [ ] Start the app in FluentDark: Reports, Routes, Dashboard, and a student/driver dialog should share the same dark surfaces and text
- [ ] Switch to FluentLight from the MainWindow sun button: those panels should all go light (no leftover dark chrome or white text on white)
- [ ] Switch back to FluentDark: no leftover light GroupBox/status bars
- [ ] Open a dialog after switching themes; it should match the current theme, not always dark