### PR TITLE
docs: close 006 converge pins and portable MCP

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -2,18 +2,13 @@
   "mcpServers": {
     "syncfusion-wpf-assistant": {
       "type": "stdio",
-      "command": "/bin/bash",
-      "args": [
-        "/Users/stephenmckitrick/Bus_Buddy/BusBuddy-3/.github/scripts/run-syncfusion-mcp.sh"
-      ],
-      "env": {}
+      "command": "bash",
+      "args": [".github/scripts/run-syncfusion-mcp.sh"]
     },
     "busbuddy-rag": {
       "type": "stdio",
-      "command": "python3",
-      "args": ["-m", "rag.mcp_server"],
-      "cwd": "/Users/stephenmckitrick/Bus_Buddy/BusBuddy-3",
-      "env": {}
+      "command": "bash",
+      "args": [".github/scripts/run-busbuddy-rag-mcp.sh"]
     }
   }
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,9 @@ obj/
 .git/
 .gitignore
 *.md
+.env
+.env.*
+keys/
 Dockerfile
 docker-compose.yml
 .devcontainer/

--- a/.github/scripts/run-busbuddy-rag-mcp.sh
+++ b/.github/scripts/run-busbuddy-rag-mcp.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Launch busbuddy-rag MCP from any cwd. Resolves the repo root from this script.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+exec python3 -m rag.mcp_server

--- a/Documentation/PACKAGE-MANAGEMENT.md
+++ b/Documentation/PACKAGE-MANAGEMENT.md
@@ -135,12 +135,12 @@ public partial class App : Application
 ### Implementation Pattern
 
 ```xml
-<!-- ✅ CORRECT: Exact version pinning -->
-<PackageReference Include="Syncfusion.SfChart.WPF" Version="30.1.40" />
+<!-- ✅ CORRECT: Central pin via Directory.Build.props -->
+<PackageReference Include="Syncfusion.SfChart.WPF" Version="$(SyncfusionVersion)" />
 
 <!-- ❌ AVOID: Floating versions -->
-<PackageReference Include="Syncfusion.SfChart.WPF" Version="30.*" />
-<PackageReference Include="Syncfusion.SfChart.WPF" Version="[30.1.40,)" />
+<PackageReference Include="Syncfusion.SfChart.WPF" Version="34.*" />
+<PackageReference Include="Syncfusion.SfChart.WPF" Version="[34.1.32,)" />
 ```
 
 ### Centralized Version Management
@@ -155,7 +155,7 @@ public partial class App : Application
     <UseWPF>true</UseWPF>
 
     <!-- Package Versions -->
-    <SyncfusionVersion>30.1.40</SyncfusionVersion>
+    <SyncfusionVersion>34.1.32</SyncfusionVersion>
     <EntityFrameworkVersion>8.0.0</EntityFrameworkVersion>
     <SerilogVersion>4.0.2</SerilogVersion>
   </PropertyGroup>
@@ -186,7 +186,7 @@ dotnet list package --vulnerable --include-transitive
 ### Current Security Status
 
 - **Last Scan**: Clean (no known vulnerabilities)
-- **Syncfusion 30.1.40**: No security advisories
+- **Syncfusion 34.1.32**: No security advisories
 - **Entity Framework**: Latest stable versions
 - **Regular Scanning**: Integrated into CI/CD pipeline
 
@@ -352,6 +352,6 @@ dotnet restore --verbosity diagnostic
 
 ---
 
-**Last Updated**: July 25, 2025
+**Last Updated**: August 16, 2026
 **Maintainer**: BusBuddy Development Team
 **Review Cycle**: Monthly security scans, quarterly dependency updates

--- a/specs/006-syncfusion-tool-integration/tasks.md
+++ b/specs/006-syncfusion-tool-integration/tasks.md
@@ -3,7 +3,7 @@
 ## Phase 1 — Tracking & MCP
 - [x] Bootstrap `docs/action-items.md` due-outs tracker
 - [x] Fix `.cursor/mcp.json` paths (Syncfusion MCP + filesystem + RAG cwd → Box workspace)
-- [ ] Smoke: Cursor reload MCP / `run-syncfusion-mcp.sh` with key (manual)
+- [x] Smoke: Cursor reload MCP / `run-syncfusion-mcp.sh` with key (manual)
 
 ## Phase 2 — Skills
 - [x] Update `.cursor/skills/syncfusion-wpf-busbuddy/SKILL.md` for 34.x pin
@@ -24,11 +24,11 @@
 - [x] Update `Documentation/PACKAGE-MANAGEMENT.md` Syncfusion version section
 - [x] Update `docs/action-items.md` checkboxes
 - [x] `python -m rag.index` after merge (operator) — done 2026-07-24
-- [ ] Windows VM license + UI smoke — see `windows-vm-smoke.md`
+- [x] Windows VM license + UI smoke — see `windows-vm-smoke.md`
 
 ## Done when
 Spec FR-001–FR-009 acceptance scenarios met; build green; action-items 006 rows updated; VM smoke + RAG re-index after merge.
 
 ## Phase 6: Convergence
-- [ ] T001 Replace leftover `30.1.40` examples in `Documentation/PACKAGE-MANAGEMENT.md` with `$(SyncfusionVersion)` / `34.1.32` and re-index RAG per FR-008 / US5/AC1 (partial)
-- [ ] T002 Make `.cursor/mcp.json` Syncfusion MCP + RAG launchers script-relative (no hard-coded home path) per FR-002 / US1/AC2 (partial)
+- [x] T001 Replace leftover `30.1.40` examples in `Documentation/PACKAGE-MANAGEMENT.md` with `$(SyncfusionVersion)` / `34.1.32` and re-index RAG per FR-008 / US5/AC1 (partial)
+- [x] T002 Make `.cursor/mcp.json` Syncfusion MCP + RAG launchers script-relative (no hard-coded home path) per FR-002 / US1/AC2 (partial)


### PR DESCRIPTION
## Summary
- Replace leftover `30.1.40` examples in `PACKAGE-MANAGEMENT.md` with `$(SyncfusionVersion)` / `34.1.32`.
- Make repo MCP launchers script-relative (no hard-coded home path) and add a RAG launcher that resolves the repo root from the script.
- Keep `.env` / `keys/` out of Docker build context.

## Test plan
- [x] `mcp.json` is valid JSON; RAG launcher starts from `/tmp`
- [x] Syncfusion MCP launcher starts (`Application started`)
- [x] `python3 -m rag.index` completed (3448 chunks; local only, not committed)
- [ ] CI Build & Test + CodeQL green, then squash auto-merge