### PR TITLE
fix: close remaining DriversViewModel stubs (#11)

### DIFF
--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -482,6 +482,7 @@ namespace BusBuddy.WPF
                 services.AddTransient<BusBuddy.WPF.ViewModels.Student.StudentsViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Route.RouteManagementViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Driver.DriverFormViewModel>();
+                services.AddTransient<BusBuddy.WPF.ViewModels.Driver.DriversViewModel>();
                 // Shared map VM: singleton + IServiceScopeFactory so scoped student/bus services are not captured
                 services.AddSingleton<BusBuddy.WPF.ViewModels.GoogleEarth.GoogleEarthViewModel>(sp =>
                     new BusBuddy.WPF.ViewModels.GoogleEarth.GoogleEarthViewModel(

--- a/BusBuddy.WPF/ViewModels/Driver/DriversViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Driver/DriversViewModel.cs
@@ -1,13 +1,17 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using BusBuddy.Core.Models;
 using BusBuddy.Core.Services;
 using BusBuddy.Core.Data;
+using BusBuddy.WPF;
 using BusBuddy.WPF.ViewModels;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
 
@@ -23,6 +27,7 @@ namespace BusBuddy.WPF.ViewModels.Driver
 
         private readonly IBusBuddyDbContextFactory _contextFactory;
         private readonly IDriverService? _driverService;
+        private readonly IOperationalReportService? _reportService;
 
     private Core.Models.Driver? _selectedDriver;
         private string _searchText = string.Empty;
@@ -176,53 +181,43 @@ namespace BusBuddy.WPF.ViewModels.Driver
         #region Constructor
 
         /// <summary>
-        /// Constructor for production use
+        /// Constructor for production use — resolves services from App DI when available.
         /// </summary>
         public DriversViewModel()
+            : this(
+                App.ServiceProvider?.GetService<IBusBuddyDbContextFactory>() ?? new BusBuddyDbContextFactory(),
+                App.ServiceProvider?.GetService<IDriverService>(),
+                App.ServiceProvider?.GetService<IOperationalReportService>())
         {
-            _contextFactory = new BusBuddyDbContextFactory();
-
-            // Initialize commands
-            LoadDriversCommand = new AsyncRelayCommand(LoadDriversAsync);
-            AddDriverCommand = new RelayCommand(ExecuteAddDriver);
-            EditDriverCommand = new RelayCommand(ExecuteEditDriver, () => HasSelectedDriver);
-            DeleteDriverCommand = new AsyncRelayCommand(ExecuteDeleteDriverAsync, () => HasSelectedDriver);
-            RefreshCommand = new AsyncRelayCommand(LoadDriversAsync);
-            ClearSearchCommand = new RelayCommand(ExecuteClearSearch, () => !string.IsNullOrEmpty(SearchText));
-            GenerateReportsCommand = new RelayCommand(ExecuteGenerateReports);
-            LicenseCheckCommand = new RelayCommand(ExecuteLicenseCheck);
-            TrainingRecordsCommand = new RelayCommand(ExecuteTrainingRecords);
-            AssignRouteCommand = new RelayCommand(ExecuteAssignRoute, () => HasSelectedDriver);
-            EditDetailsCommand = new RelayCommand(ExecuteEditDetails, () => HasSelectedDriver);
-            ViewLicenseCommand = new RelayCommand(ExecuteViewLicense, () => HasSelectedDriver);
-            TrainingHistoryCommand = new RelayCommand(ExecuteTrainingHistory, () => HasSelectedDriver);
-
-            // Load initial data
-            _ = LoadDriversAsync();
         }
 
         /// <summary>
-        /// Constructor for testing (dependency injection)
+        /// Constructor for testing / DI
         /// </summary>
-        public DriversViewModel(IBusBuddyDbContextFactory contextFactory, IDriverService? driverService = null)
+        public DriversViewModel(
+            IBusBuddyDbContextFactory contextFactory,
+            IDriverService? driverService = null,
+            IOperationalReportService? reportService = null)
         {
             _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
             _driverService = driverService;
+            _reportService = reportService;
 
-            // Initialize commands (same as above)
             LoadDriversCommand = new AsyncRelayCommand(LoadDriversAsync);
             AddDriverCommand = new RelayCommand(ExecuteAddDriver);
             EditDriverCommand = new RelayCommand(ExecuteEditDriver, () => HasSelectedDriver);
             DeleteDriverCommand = new AsyncRelayCommand(ExecuteDeleteDriverAsync, () => HasSelectedDriver);
             RefreshCommand = new AsyncRelayCommand(LoadDriversAsync);
             ClearSearchCommand = new RelayCommand(ExecuteClearSearch, () => !string.IsNullOrEmpty(SearchText));
-            GenerateReportsCommand = new RelayCommand(ExecuteGenerateReports);
-            LicenseCheckCommand = new RelayCommand(ExecuteLicenseCheck);
-            TrainingRecordsCommand = new RelayCommand(ExecuteTrainingRecords);
-            AssignRouteCommand = new RelayCommand(ExecuteAssignRoute, () => HasSelectedDriver);
+            GenerateReportsCommand = new AsyncRelayCommand(ExecuteGenerateReportsAsync);
+            LicenseCheckCommand = new AsyncRelayCommand(ExecuteLicenseCheckAsync);
+            TrainingRecordsCommand = new AsyncRelayCommand(ExecuteTrainingRecordsAsync);
+            AssignRouteCommand = new AsyncRelayCommand(ExecuteAssignRouteAsync, () => HasSelectedDriver);
             EditDetailsCommand = new RelayCommand(ExecuteEditDetails, () => HasSelectedDriver);
             ViewLicenseCommand = new RelayCommand(ExecuteViewLicense, () => HasSelectedDriver);
             TrainingHistoryCommand = new RelayCommand(ExecuteTrainingHistory, () => HasSelectedDriver);
+
+            _ = LoadDriversAsync();
         }
 
         #endregion
@@ -369,33 +364,77 @@ namespace BusBuddy.WPF.ViewModels.Driver
             base.StatusMessage = "Search cleared";
         }
 
-        private void ExecuteGenerateReports()
+        private async Task ExecuteGenerateReportsAsync()
         {
-            Logger.Information("Generate reports command executed");
-            base.StatusMessage = "Generating driver reports (MVP placeholder)";
+            await GenerateDriverReportAsync(OperationalReportKind.DriverRoster, "Driver roster");
         }
 
-        private void ExecuteLicenseCheck()
+        private async Task ExecuteLicenseCheckAsync()
         {
-            Logger.Information("License check command executed");
-            base.StatusMessage = "Checking license expirations (MVP placeholder)";
+            SelectedStatusFilter = "License Expiring";
+            var needing = _driverService != null
+                ? await _driverService.GetDriversNeedingRenewalAsync()
+                : Drivers.Where(d =>
+                    d.LicenseExpiryDate.HasValue &&
+                    d.LicenseExpiryDate.Value.Date <= DateTime.Today.AddDays(30)).ToList();
+
+            Logger.Information("License check: {Count} drivers needing renewal within 30 days", needing.Count);
+            base.StatusMessage = needing.Count == 0
+                ? "No licenses expiring within 30 days"
+                : $"{needing.Count} license(s) due within 30 days — generating report";
+
+            await GenerateDriverReportAsync(OperationalReportKind.LicenseExpiration, "License expiration");
         }
 
-        private void ExecuteTrainingRecords()
+        private async Task ExecuteTrainingRecordsAsync()
         {
-            Logger.Information("Training records command executed");
-            base.StatusMessage = "Opening training records (MVP placeholder)";
+            SelectedStatusFilter = "Training";
+            var incomplete = Drivers.Count(d => !d.TrainingComplete);
+            Logger.Information("Training records: {Incomplete} incomplete of {Total}", incomplete, Drivers.Count);
+            base.StatusMessage = incomplete == 0
+                ? "All drivers have training marked complete — generating status report"
+                : $"{incomplete} driver(s) with incomplete training — generating report";
+
+            await GenerateDriverReportAsync(OperationalReportKind.TrainingStatus, "Training status");
         }
 
-        private void ExecuteAssignRoute()
+        private async Task ExecuteAssignRouteAsync()
         {
             if (SelectedDriver is null)
             {
                 return;
             }
 
-            Logger.Information("Assign route command executed for driver {DriverId}", SelectedDriver.DriverId);
-            base.StatusMessage = $"Assign route to {SelectedDriver.DriverName} (MVP placeholder)";
+            try
+            {
+                if (_driverService is null)
+                {
+                    base.StatusMessage = "Driver service unavailable — cannot load route assignments";
+                    Logger.Warning("AssignRoute skipped — IDriverService not registered");
+                    return;
+                }
+
+                var routes = await _driverService.GetDriverRoutesAsync(SelectedDriver.DriverId);
+                var names = routes
+                    .Select(r => string.IsNullOrWhiteSpace(r.RouteName) ? $"Route {r.RouteId}" : r.RouteName)
+                    .Take(5)
+                    .ToList();
+
+                Logger.Information(
+                    "Driver {DriverId} has {RouteCount} assigned route(s)",
+                    SelectedDriver.DriverId,
+                    routes.Count);
+
+                base.StatusMessage = routes.Count == 0
+                    ? $"{SelectedDriver.DriverName}: no routes assigned (use Route Assignment to assign)"
+                    : $"{SelectedDriver.DriverName}: {routes.Count} route(s) — {string.Join(", ", names)}"
+                      + (routes.Count > 5 ? "…" : string.Empty);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed loading routes for driver {DriverId}", SelectedDriver.DriverId);
+                base.StatusMessage = $"Error loading routes: {ex.Message}";
+            }
         }
 
         private void ExecuteEditDetails()
@@ -416,8 +455,21 @@ namespace BusBuddy.WPF.ViewModels.Driver
                 return;
             }
 
-            Logger.Information("View license command executed for driver {DriverId}", SelectedDriver.DriverId);
-            base.StatusMessage = $"Viewing license for {SelectedDriver.DriverName} (MVP placeholder)";
+            var d = SelectedDriver;
+            var expiry = d.LicenseExpiryDate?.ToString("yyyy-MM-dd") ?? "not set";
+            var days = d.LicenseExpiryDate.HasValue
+                ? (d.LicenseExpiryDate.Value.Date - DateTime.Today).Days.ToString()
+                : "n/a";
+
+            Logger.Information(
+                "View license DriverId={DriverId} Number={LicenseNumber} Expiry={Expiry}",
+                d.DriverId,
+                d.LicenseNumber,
+                expiry);
+
+            base.StatusMessage =
+                $"{d.DriverName}: license {d.LicenseNumber ?? "(none)"} class {d.LicenseClass ?? "?"} " +
+                $"status {d.LicenseStatus ?? "?"} expires {expiry} ({days} days)";
         }
 
         private void ExecuteTrainingHistory()
@@ -427,8 +479,68 @@ namespace BusBuddy.WPF.ViewModels.Driver
                 return;
             }
 
-            Logger.Information("Training history command executed for driver {DriverId}", SelectedDriver.DriverId);
-            base.StatusMessage = $"Viewing training history for {SelectedDriver.DriverName} (MVP placeholder)";
+            var d = SelectedDriver;
+            var training = d.TrainingComplete ? "complete" : "incomplete";
+            var bg = d.BackgroundCheckDate?.ToString("yyyy-MM-dd") ?? "not set";
+            var hire = d.HireDate?.ToString("yyyy-MM-dd") ?? "not set";
+
+            Logger.Information(
+                "Training history DriverId={DriverId} TrainingComplete={TrainingComplete}",
+                d.DriverId,
+                d.TrainingComplete);
+
+            base.StatusMessage =
+                $"{d.DriverName}: training {training}; hire {hire}; background check {bg}";
+        }
+
+        private async Task GenerateDriverReportAsync(OperationalReportKind kind, string label)
+        {
+            if (_reportService is null)
+            {
+                base.StatusMessage = $"Report service unavailable — cannot generate {label}";
+                Logger.Warning("Driver report {Kind} skipped — IOperationalReportService not registered", kind);
+                return;
+            }
+
+            try
+            {
+                IsLoading = true;
+                base.StatusMessage = $"Generating {label} report...";
+                var result = await _reportService.GenerateAsync(kind);
+                base.StatusMessage = result.Status;
+                TryOpenReportFile(result.FilePath);
+                Logger.Information("Driver report {Kind} written to {Path}", kind, result.FilePath);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Driver report {Kind} failed", kind);
+                base.StatusMessage = $"Error generating {label}: {ex.Message}";
+            }
+            finally
+            {
+                IsLoading = false;
+            }
+        }
+
+        private static void TryOpenReportFile(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = path,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.ForContext<DriversViewModel>().Warning(ex, "Could not open report file {Path}", path);
+            }
         }
 
         #endregion
@@ -442,10 +554,23 @@ namespace BusBuddy.WPF.ViewModels.Driver
         {
             var query = Drivers.AsEnumerable();
 
-            // Status filter
+            // Status / attention filter
             if (!string.IsNullOrWhiteSpace(SelectedStatusFilter) && !SelectedStatusFilter.Equals("All Status", StringComparison.OrdinalIgnoreCase))
             {
-                query = query.Where(d => string.Equals(d.Status ?? string.Empty, SelectedStatusFilter, StringComparison.OrdinalIgnoreCase));
+                if (SelectedStatusFilter.Equals("License Expiring", StringComparison.OrdinalIgnoreCase))
+                {
+                    query = query.Where(d =>
+                        d.LicenseExpiryDate.HasValue &&
+                        d.LicenseExpiryDate.Value.Date <= DateTime.Today.AddDays(30));
+                }
+                else if (SelectedStatusFilter.Equals("Training", StringComparison.OrdinalIgnoreCase))
+                {
+                    query = query.Where(d => !d.TrainingComplete);
+                }
+                else
+                {
+                    query = query.Where(d => string.Equals(d.Status ?? string.Empty, SelectedStatusFilter, StringComparison.OrdinalIgnoreCase));
+                }
             }
 
             // Search filter

--- a/BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs
@@ -98,7 +98,7 @@ namespace BusBuddy.WPF.ViewModels.GoogleEarth
             ZoomInCommand = new RelayCommand(_ => ZoomIn());
             ZoomOutCommand = new RelayCommand(_ => ZoomOut());
 
-            // Commands referenced by XAML — MVP stubs with logging
+            // Commands referenced by XAML (map toolbar)
             CenterOnFleetCommand = new RelayCommand(_ => CenterOnFleet());
             ShowAllBusesCommand = new RelayCommand(_ => ShowAllBuses());
             ShowRoutesCommand = new RelayCommand(_ => ShowRoutes());
@@ -645,7 +645,7 @@ namespace BusBuddy.WPF.ViewModels.GoogleEarth
             try { ZoomOutRequested?.Invoke(this, EventArgs.Empty); } catch (Exception ex) { Logger.Warning(ex, "ZoomOut event dispatch failed"); }
         }
 
-        // MVP stub implementations for XAML-bound commands
+        // Map toolbar commands bound from XAML (center / buses / routes / schools)
         private void CenterOnFleet()
         {
             StatusMessage = "Centering map on fleet...";

--- a/BusBuddy.WPF/Views/Driver/DriversView.xaml.cs
+++ b/BusBuddy.WPF/Views/Driver/DriversView.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using Serilog; // Serilog per project standards
 using BusBuddy.WPF.ViewModels.Driver;
 using BusBuddy.WPF.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace BusBuddy.WPF.Views.Driver
 {
@@ -24,8 +25,8 @@ namespace BusBuddy.WPF.Views.Driver
             {
                 InitializeComponent();
 
-                // Set the ViewModel for data binding (simple instantiation Phase 1)
-                DataContext = new DriversViewModel(); // now from Driver subfolder after dedup
+                DataContext = App.ServiceProvider?.GetService<DriversViewModel>()
+                    ?? new DriversViewModel();
 
                 // Apply Syncfusion theme
                 SyncfusionThemeManager.ApplyTheme(this);

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -16,7 +16,7 @@
 ### P0 — Platform / tooling
 
 - [x] Spec-Kit brownfield bootstrap (001–005) — merged [PR #20](https://github.com/Bigessfour/BusBuddy-3/pull/20)
-- [ ] **007 Maps Platform Geo (retire Earth Engine)** — [spec](../specs/007-maps-platform-geo/spec.md) · [plan](../specs/007-maps-platform-geo/plan.md) · [tasks](../specs/007-maps-platform-geo/tasks.md)
+- [x] **007 Maps Platform Geo (retire Earth Engine)** — US2+docs merged [PR #31](https://github.com/Bigessfour/BusBuddy-3/pull/31) · [spec](../specs/007-maps-platform-geo/spec.md) · [tasks](../specs/007-maps-platform-geo/tasks.md)
   - [x] US2: Remove GEE DI, client, probe, unofficial Google tiles
   - [ ] US1: Address Validation + geocode onto SfMap (**paused**)
   - [ ] US3: Routes API drive polyline (P2)
@@ -54,10 +54,10 @@
 
 | Issue                                                     | Topic                                           | Suggested disposition                                                                                      |
 | --------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [#13](https://github.com/Bigessfour/BusBuddy-3/issues/13) | ViewModel dedup                                 | Largely done in hygiene/PR #16 (`BaseViewModelMvp` removed). Confirm no remaining flat VM refs → **close** |
-| [#14](https://github.com/Bigessfour/BusBuddy-3/issues/14) | CI + secrets/MCP                                | Mostly done (solo CI, Passwords, Syncfusion MCP). Re-check `ci-with-ai` / GH secrets → update or **close** |
-| [#15](https://github.com/Bigessfour/BusBuddy-3/issues/15) | Deprecate bb-* PS                               | Docs/deprecation done; residual archive refs OK → **close** or narrow remaining tasks                      |
-| [#11](https://github.com/Bigessfour/BusBuddy-3/issues/11) | Close stubs (Reports/Grok/Settings/Maintenance) | P1 items implemented; close after this PR merges                                                           |
+| [#13](https://github.com/Bigessfour/BusBuddy-3/issues/13) | ViewModel dedup                                 | **Closed** (hygiene / PR #16)                                                                                  |
+| [#14](https://github.com/Bigessfour/BusBuddy-3/issues/14) | CI + secrets/MCP                                | Solo CI + auto-merge done; Passwords for Syncfusion/Maps. Optional: GH Actions secrets / `ci-with-ai` cleanup → **close or narrow** |
+| [#15](https://github.com/Bigessfour/BusBuddy-3/issues/15) | Deprecate bb-* PS                               | Modules removed — open [PR #32](https://github.com/Bigessfour/BusBuddy-3/pull/32) (`Closes #15`)              |
+| [#11](https://github.com/Bigessfour/BusBuddy-3/issues/11) | Close stubs (Reports/Grok/Settings/Maintenance) | P1 done ([PR #30](https://github.com/Bigessfour/BusBuddy-3/pull/30)); Drivers MVP placeholders wired to live reports/services — close via follow-up PR |
 
 ---
 


### PR DESCRIPTION
## Summary
- Wires Drivers toolbar actions (roster / license check / training / routes / view license / training history) to `IOperationalReportService` and `IDriverService` instead of MVP placeholder status strings.
- Registers `DriversViewModel` in DI; `DriversView` resolves from `App.ServiceProvider`.
- Clears stale “MVP stub” comments on map toolbar commands (already implemented).
- Updates `docs/action-items.md` triage for #11 / #15 / #007.

Closes #11

## Test plan
- [ ] `dotnet build BusBuddy.WPF -c Release -p:EnableWindowsTargeting=true`
- [ ] VM: Drivers → Generate Reports / License / Training produce PDFs and status messages
- [ ] VM: View License / Training History show real driver fields
- [ ] VM: Assign Route shows assigned route names (or “none”) from `IDriverService`
- [ ] CI Build & Test + CodeQL