### PR TITLE
feat: student contacts, school destinations, and inter-district transfers

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/007-maps-platform-geo"
+  "feature_directory": "specs/008-route-determination"
 }

--- a/BusBuddy.Core/Data/BusBuddyDbContext.cs
+++ b/BusBuddy.Core/Data/BusBuddyDbContext.cs
@@ -79,6 +79,7 @@ public class BusBuddyDbContext : DbContext
     public virtual DbSet<ActivitySchedule> ActivitySchedule { get; set; } = null!;
     public virtual DbSet<Destination> Destinations { get; set; } = null!;
     public virtual DbSet<StudentSchoolTransfer> StudentSchoolTransfers { get; set; } = null!;
+    public virtual DbSet<DriverTrainingRecord> DriverTrainingRecords { get; set; } = null!;
     public virtual DbSet<RouteAssignment> RouteAssignments { get; set; } = null!;
 
     public virtual DbSet<AIInsight> AIInsights { get; set; } = null!;
@@ -403,6 +404,32 @@ public class BusBuddyDbContext : DbContext
             entity.Property(e => e.HomeLatitude).HasColumnType("decimal(10,8)");
             entity.Property(e => e.HomeLongitude).HasColumnType("decimal(11,8)");
             entity.HasIndex(e => new { e.HomeLatitude, e.HomeLongitude }).HasDatabaseName("IX_Drivers_HomeLocation");
+
+            entity.Property(e => e.EmployingDistrict).HasMaxLength(150);
+            entity.Property(e => e.DutyCategory).HasMaxLength(20);
+            entity.Property(e => e.VehicleCategory).HasMaxLength(60);
+            entity.Property(e => e.CdlRestrictions).HasMaxLength(50);
+            entity.Property(e => e.MedicalFormType).HasMaxLength(40);
+
+            entity.HasMany(e => e.TrainingRecords)
+                .WithOne(t => t.Driver)
+                .HasForeignKey(t => t.DriverId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<DriverTrainingRecord>(entity =>
+        {
+            entity.ToTable("DriverTrainingRecords");
+            entity.HasKey(e => e.TrainingRecordId);
+            entity.Property(e => e.RequirementCode).IsRequired().HasMaxLength(80);
+            entity.Property(e => e.RequirementName).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.CertificateOrReference).HasMaxLength(100);
+            entity.Property(e => e.ProviderOrInstructor).HasMaxLength(100);
+            entity.Property(e => e.Notes).HasMaxLength(1000);
+            entity.HasIndex(e => e.DriverId).HasDatabaseName("IX_DriverTrainingRecords_Driver");
+            entity.HasIndex(e => new { e.DriverId, e.RequirementCode })
+                .IsUnique()
+                .HasDatabaseName("IX_DriverTrainingRecords_Driver_Code");
         });
 
         // Configure Route entity with enhanced relationships and indexing

--- a/BusBuddy.Core/Data/BusBuddyDbContext.cs
+++ b/BusBuddy.Core/Data/BusBuddyDbContext.cs
@@ -78,6 +78,7 @@ public class BusBuddyDbContext : DbContext
     public virtual DbSet<SchoolCalendar> SchoolCalendar { get; set; } = null!;
     public virtual DbSet<ActivitySchedule> ActivitySchedule { get; set; } = null!;
     public virtual DbSet<Destination> Destinations { get; set; } = null!;
+    public virtual DbSet<StudentSchoolTransfer> StudentSchoolTransfers { get; set; } = null!;
     public virtual DbSet<RouteAssignment> RouteAssignments { get; set; } = null!;
 
     public virtual DbSet<AIInsight> AIInsights { get; set; } = null!;
@@ -605,10 +606,14 @@ public class BusBuddyDbContext : DbContext
             entity.Property(e => e.EmergencyPhone).HasMaxLength(20);
             entity.Property(e => e.School).HasMaxLength(100);
             entity.Property(e => e.ParentGuardian).HasMaxLength(100);
+            entity.Property(e => e.ParentEmail).HasMaxLength(100);
+            entity.Property(e => e.CellPhone).HasMaxLength(20);
+            entity.Property(e => e.EmergencyContactName).HasMaxLength(100);
             entity.Property(e => e.HomeAddress).HasMaxLength(200);
             entity.Property(e => e.City).HasMaxLength(50);
             entity.Property(e => e.State).HasMaxLength(2);
             entity.Property(e => e.Zip).HasMaxLength(10);
+            entity.Property(e => e.HasMedicalNeeds).HasDefaultValue(false);
 
             // Audit fields
             entity.Property(e => e.CreatedBy).HasMaxLength(100);
@@ -620,6 +625,54 @@ public class BusBuddyDbContext : DbContext
             entity.HasIndex(e => e.Grade).HasDatabaseName("IX_Students_Grade");
             entity.HasIndex(e => e.School).HasDatabaseName("IX_Students_School");
             entity.HasIndex(e => e.Active).HasDatabaseName("IX_Students_Active");
+
+            entity.HasOne(e => e.Destination)
+                .WithMany()
+                .HasForeignKey(e => e.DestinationId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<Destination>(entity =>
+        {
+            entity.ToTable("Destinations");
+            entity.HasKey(e => e.DestinationId);
+            entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.Address).IsRequired().HasMaxLength(300);
+            entity.Property(e => e.City).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.State).IsRequired().HasMaxLength(2);
+            entity.Property(e => e.ZipCode).IsRequired().HasMaxLength(10);
+            entity.Property(e => e.DestinationType).IsRequired().HasMaxLength(50);
+            entity.Property(e => e.DistrictName).HasMaxLength(150);
+            entity.Property(e => e.GradeMin).HasMaxLength(20);
+            entity.Property(e => e.GradeMax).HasMaxLength(20);
+            entity.Property(e => e.AdminContactName).HasMaxLength(100);
+            entity.Property(e => e.AdminPhone).HasMaxLength(20);
+            entity.Property(e => e.AdminEmail).HasMaxLength(100);
+            entity.HasIndex(e => e.DestinationType).HasDatabaseName("IX_Destinations_Type");
+            entity.HasIndex(e => e.IsActive).HasDatabaseName("IX_Destinations_Active");
+        });
+
+        modelBuilder.Entity<StudentSchoolTransfer>(entity =>
+        {
+            entity.ToTable("StudentSchoolTransfers");
+            entity.HasKey(e => e.TransferId);
+            entity.Property(e => e.PickupAddress).HasMaxLength(300);
+            entity.Property(e => e.DropoffAddress).HasMaxLength(300);
+            entity.Property(e => e.Notes).HasMaxLength(1000);
+            entity.HasOne(e => e.Student)
+                .WithMany()
+                .HasForeignKey(e => e.StudentId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.FromDestination)
+                .WithMany()
+                .HasForeignKey(e => e.FromDestinationId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(e => e.ToDestination)
+                .WithMany()
+                .HasForeignKey(e => e.ToDestinationId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasIndex(e => e.StudentId).HasDatabaseName("IX_StudentSchoolTransfers_Student");
+            entity.HasIndex(e => e.IsActive).HasDatabaseName("IX_StudentSchoolTransfers_Active");
         });
 
         // Configure Family entity for JSON import
@@ -666,7 +719,8 @@ public class BusBuddyDbContext : DbContext
         modelBuilder.Entity<Guardian>(entity =>
         {
             entity.ToTable("Guardians");
-            entity.HasKey(e => e.Id);
+            entity.HasKey(e => e.GuardianId);
+            entity.Ignore(e => e.Id);
             entity.Property(e => e.FirstName).IsRequired().HasMaxLength(50);
             entity.Property(e => e.LastName).IsRequired().HasMaxLength(50);
             entity.Property(e => e.Address).IsRequired().HasMaxLength(200);

--- a/BusBuddy.Core/Data/Repositories/StudentRepository.cs
+++ b/BusBuddy.Core/Data/Repositories/StudentRepository.cs
@@ -477,7 +477,7 @@ public class StudentRepository : Repository<Student>, IStudentRepository
     public async Task<IEnumerable<Student>> GetStudentsByParentEmailAsync(string email)
     {
         return await Context.Students
-            .Where(s => s.ParentGuardian != null && s.ParentGuardian.Contains(email))
+            .Where(s => s.ParentEmail != null && s.ParentEmail.Contains(email))
             .ToListAsync();
     }
 

--- a/BusBuddy.Core/Data/UnitOfWork/UnitOfWork.cs
+++ b/BusBuddy.Core/Data/UnitOfWork/UnitOfWork.cs
@@ -524,9 +524,9 @@ public class StudentRepository : Repository<Student>, IStudentRepository
     public async Task<Dictionary<string, int>> GetStudentCountByTransportationTypeAsync() => await Task.FromResult(new Dictionary<string, int>());
     // TODO: Age property not available on Student model - return all students for now
     public async Task<IEnumerable<Student>> GetStudentsByAgeRangeAsync(int minAge, int maxAge) => await GetAllAsync();
-    public async Task<IEnumerable<Student>> GetStudentsByParentEmailAsync(string email) => await FindAsync(s => s.ParentGuardian != null && s.ParentGuardian.Contains(email));
-    public async Task<IEnumerable<Student>> GetStudentsByParentPhoneAsync(string phone) => await FindAsync(s => s.HomePhone == phone || s.EmergencyPhone == phone || s.AlternativePhone == phone);
-    public async Task<IEnumerable<Student>> GetStudentsWithIncompleteContactInfoAsync() => await FindAsync(s => string.IsNullOrEmpty(s.ParentGuardian) || string.IsNullOrEmpty(s.HomePhone));
+    public async Task<IEnumerable<Student>> GetStudentsByParentEmailAsync(string email) => await FindAsync(s => s.ParentEmail != null && s.ParentEmail.Contains(email));
+    public async Task<IEnumerable<Student>> GetStudentsByParentPhoneAsync(string phone) => await FindAsync(s => s.HomePhone == phone || s.CellPhone == phone || s.EmergencyPhone == phone || s.AlternativePhone == phone);
+    public async Task<IEnumerable<Student>> GetStudentsWithIncompleteContactInfoAsync() => await FindAsync(s => string.IsNullOrEmpty(s.ParentGuardian) || (string.IsNullOrEmpty(s.HomePhone) && string.IsNullOrEmpty(s.CellPhone)));
     public async Task<IEnumerable<Student>> GetStudentsBySchoolAsync(string schoolName) => await FindAsync(s => s.School == schoolName);
     public async Task<IEnumerable<Student>> GetStudentsWithActivityPermissionsAsync() => await FindAsync(s => s.PhotoPermission || s.FieldTripPermission);
     public async Task<IEnumerable<Student>> GetStudentsWithoutActivityPermissionsAsync() => await FindAsync(s => !s.PhotoPermission && !s.FieldTripPermission);

--- a/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
@@ -111,6 +111,8 @@ namespace BusBuddy.Core.Extensions
             services.AddSingleton<PdfReportService>();
             services.AddScoped<IOperationalReportService, OperationalReportService>();
             services.AddScoped<IStudentService, StudentService>();
+            services.AddScoped<IDestinationService, DestinationService>();
+            services.AddScoped<IStudentSchoolTransferService, StudentSchoolTransferService>();
             services.AddScoped<IFuelService, FuelService>();
             services.AddScoped<IMaintenanceService, MaintenanceService>();
             services.AddScoped<IScheduleService, ScheduleService>();

--- a/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
@@ -113,6 +113,7 @@ namespace BusBuddy.Core.Extensions
             services.AddScoped<IStudentService, StudentService>();
             services.AddScoped<IDestinationService, DestinationService>();
             services.AddScoped<IStudentSchoolTransferService, StudentSchoolTransferService>();
+            services.AddScoped<IDriverTrainingService, DriverTrainingService>();
             services.AddScoped<IFuelService, FuelService>();
             services.AddScoped<IMaintenanceService, MaintenanceService>();
             services.AddScoped<IScheduleService, ScheduleService>();

--- a/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
@@ -113,6 +113,7 @@ namespace BusBuddy.Core.Extensions
             services.AddScoped<IStudentService, StudentService>();
             services.AddScoped<IDestinationService, DestinationService>();
             services.AddScoped<IStudentSchoolTransferService, StudentSchoolTransferService>();
+            services.AddScoped<IRouteWaypointRebuildService, RouteWaypointRebuildService>();
             services.AddScoped<IDriverTrainingService, DriverTrainingService>();
             services.AddScoped<IFuelService, FuelService>();
             services.AddScoped<IMaintenanceService, MaintenanceService>();

--- a/BusBuddy.Core/Migrations/20260817140000_StudentContactFieldsAlignment.cs
+++ b/BusBuddy.Core/Migrations/20260817140000_StudentContactFieldsAlignment.cs
@@ -1,0 +1,191 @@
+using BusBuddy.Core.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BusBuddy.Core.Migrations;
+
+/// <summary>
+/// Student contact fields (parent email/cell, emergency name) + school Destination params +
+/// inter-district StudentSchoolTransfers + seed Wiley campus.
+/// </summary>
+[DbContext(typeof(BusBuddyDbContext))]
+[Migration("20260817140000_StudentContactFieldsAlignment")]
+public partial class StudentContactFieldsAlignment : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "ParentEmail",
+            table: "Students",
+            maxLength: 100,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "CellPhone",
+            table: "Students",
+            maxLength: 20,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "EmergencyContactName",
+            table: "Students",
+            maxLength: 100,
+            nullable: true);
+
+        migrationBuilder.AddColumn<bool>(
+            name: "HasMedicalNeeds",
+            table: "Students",
+            nullable: false,
+            defaultValue: false);
+
+        migrationBuilder.AddColumn<int>(
+            name: "DestinationId",
+            table: "Students",
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "AdminContactName",
+            table: "Destinations",
+            maxLength: 100,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "AdminPhone",
+            table: "Destinations",
+            maxLength: 20,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "AdminEmail",
+            table: "Destinations",
+            maxLength: 100,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "DistrictName",
+            table: "Destinations",
+            maxLength: 150,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "GradeMin",
+            table: "Destinations",
+            maxLength: 20,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "GradeMax",
+            table: "Destinations",
+            maxLength: 20,
+            nullable: true);
+
+        migrationBuilder.AddColumn<int>(
+            name: "AgeMinYears",
+            table: "Destinations",
+            nullable: true);
+
+        migrationBuilder.AddColumn<int>(
+            name: "AgeMaxYears",
+            table: "Destinations",
+            nullable: true);
+
+        migrationBuilder.CreateTable(
+            name: "StudentSchoolTransfers",
+            columns: table => new
+            {
+                TransferId = table.Column<int>(nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1")
+                    .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                StudentId = table.Column<int>(nullable: false),
+                FromDestinationId = table.Column<int>(nullable: false),
+                ToDestinationId = table.Column<int>(nullable: false),
+                PickupTime = table.Column<TimeSpan>(nullable: true),
+                DropoffTime = table.Column<TimeSpan>(nullable: true),
+                PickupAddress = table.Column<string>(maxLength: 300, nullable: true),
+                DropoffAddress = table.Column<string>(maxLength: 300, nullable: true),
+                PickupLatitude = table.Column<decimal>(type: "decimal(10,8)", nullable: true),
+                PickupLongitude = table.Column<decimal>(type: "decimal(11,8)", nullable: true),
+                DropoffLatitude = table.Column<decimal>(type: "decimal(10,8)", nullable: true),
+                DropoffLongitude = table.Column<decimal>(type: "decimal(11,8)", nullable: true),
+                EffectiveDate = table.Column<DateTime>(nullable: true),
+                EndDate = table.Column<DateTime>(nullable: true),
+                IsActive = table.Column<bool>(nullable: false, defaultValue: true),
+                Notes = table.Column<string>(maxLength: 1000, nullable: true),
+                CreatedDate = table.Column<DateTime>(nullable: false),
+                CreatedBy = table.Column<string>(maxLength: 100, nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_StudentSchoolTransfers", x => x.TransferId);
+                table.ForeignKey(
+                    name: "FK_StudentSchoolTransfers_Students_StudentId",
+                    column: x => x.StudentId,
+                    principalTable: "Students",
+                    principalColumn: "StudentId",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_StudentSchoolTransfers_Destinations_FromDestinationId",
+                    column: x => x.FromDestinationId,
+                    principalTable: "Destinations",
+                    principalColumn: "DestinationId",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_StudentSchoolTransfers_Destinations_ToDestinationId",
+                    column: x => x.ToDestinationId,
+                    principalTable: "Destinations",
+                    principalColumn: "DestinationId",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Students_DestinationId",
+            table: "Students",
+            column: "DestinationId");
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_Students_Destinations_DestinationId",
+            table: "Students",
+            column: "DestinationId",
+            principalTable: "Destinations",
+            principalColumn: "DestinationId",
+            onDelete: ReferentialAction.SetNull);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_StudentSchoolTransfers_Student",
+            table: "StudentSchoolTransfers",
+            column: "StudentId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_StudentSchoolTransfers_Active",
+            table: "StudentSchoolTransfers",
+            column: "IsActive");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_Students_Destinations_DestinationId",
+            table: "Students");
+
+        migrationBuilder.DropTable(name: "StudentSchoolTransfers");
+
+        migrationBuilder.DropIndex(name: "IX_Students_DestinationId", table: "Students");
+
+        migrationBuilder.DropColumn(name: "ParentEmail", table: "Students");
+        migrationBuilder.DropColumn(name: "CellPhone", table: "Students");
+        migrationBuilder.DropColumn(name: "EmergencyContactName", table: "Students");
+        migrationBuilder.DropColumn(name: "HasMedicalNeeds", table: "Students");
+        migrationBuilder.DropColumn(name: "DestinationId", table: "Students");
+
+        migrationBuilder.DropColumn(name: "AdminContactName", table: "Destinations");
+        migrationBuilder.DropColumn(name: "AdminPhone", table: "Destinations");
+        migrationBuilder.DropColumn(name: "AdminEmail", table: "Destinations");
+        migrationBuilder.DropColumn(name: "DistrictName", table: "Destinations");
+        migrationBuilder.DropColumn(name: "GradeMin", table: "Destinations");
+        migrationBuilder.DropColumn(name: "GradeMax", table: "Destinations");
+        migrationBuilder.DropColumn(name: "AgeMinYears", table: "Destinations");
+        migrationBuilder.DropColumn(name: "AgeMaxYears", table: "Destinations");
+    }
+}

--- a/BusBuddy.Core/Migrations/20260817150000_DriverTrainingSubmodule.cs
+++ b/BusBuddy.Core/Migrations/20260817150000_DriverTrainingSubmodule.cs
@@ -1,0 +1,107 @@
+using BusBuddy.Core.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BusBuddy.Core.Migrations;
+
+/// <summary>
+/// Driver employment fields + DriverTrainingRecords sub-module for Colorado CDE 2024-25 license/training matrix.
+/// </summary>
+[DbContext(typeof(BusBuddyDbContext))]
+[Migration("20260817150000_DriverTrainingSubmodule")]
+public partial class DriverTrainingSubmodule : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "EmployingDistrict",
+            table: "Drivers",
+            maxLength: 150,
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "EmploymentEndDate",
+            table: "Drivers",
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "DutyCategory",
+            table: "Drivers",
+            maxLength: 20,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "VehicleCategory",
+            table: "Drivers",
+            maxLength: 60,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "CdlRestrictions",
+            table: "Drivers",
+            maxLength: 50,
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "MedicalFormType",
+            table: "Drivers",
+            maxLength: 40,
+            nullable: true);
+
+        migrationBuilder.CreateTable(
+            name: "DriverTrainingRecords",
+            columns: table => new
+            {
+                TrainingRecordId = table.Column<int>(nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1")
+                    .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                DriverId = table.Column<int>(nullable: false),
+                RequirementCode = table.Column<string>(maxLength: 80, nullable: false),
+                RequirementName = table.Column<string>(maxLength: 200, nullable: false),
+                CompletedDate = table.Column<DateTime>(nullable: true),
+                ExpiryDate = table.Column<DateTime>(nullable: true),
+                IsRequired = table.Column<bool>(nullable: false, defaultValue: true),
+                IsApplicable = table.Column<bool>(nullable: false, defaultValue: true),
+                CertificateOrReference = table.Column<string>(maxLength: 100, nullable: true),
+                ProviderOrInstructor = table.Column<string>(maxLength: 100, nullable: true),
+                Notes = table.Column<string>(maxLength: 1000, nullable: true),
+                CreatedDate = table.Column<DateTime>(nullable: false),
+                CreatedBy = table.Column<string>(maxLength: 100, nullable: true),
+                UpdatedDate = table.Column<DateTime>(nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_DriverTrainingRecords", x => x.TrainingRecordId);
+                table.ForeignKey(
+                    name: "FK_DriverTrainingRecords_Drivers_DriverId",
+                    column: x => x.DriverId,
+                    principalTable: "Drivers",
+                    principalColumn: "DriverID",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_DriverTrainingRecords_Driver",
+            table: "DriverTrainingRecords",
+            column: "DriverId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_DriverTrainingRecords_Driver_Code",
+            table: "DriverTrainingRecords",
+            columns: new[] { "DriverId", "RequirementCode" },
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "DriverTrainingRecords");
+        migrationBuilder.DropColumn(name: "EmployingDistrict", table: "Drivers");
+        migrationBuilder.DropColumn(name: "EmploymentEndDate", table: "Drivers");
+        migrationBuilder.DropColumn(name: "DutyCategory", table: "Drivers");
+        migrationBuilder.DropColumn(name: "VehicleCategory", table: "Drivers");
+        migrationBuilder.DropColumn(name: "CdlRestrictions", table: "Drivers");
+        migrationBuilder.DropColumn(name: "MedicalFormType", table: "Drivers");
+    }
+}

--- a/BusBuddy.Core/Migrations/BusBuddyDbContextModelSnapshot.cs
+++ b/BusBuddy.Core/Migrations/BusBuddyDbContextModelSnapshot.cs
@@ -1744,6 +1744,10 @@ namespace BusBuddy.Core.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
 
+                    b.Property<string>("CellPhone")
+                        .HasMaxLength(20)
+                        .HasColumnType("nvarchar(20)");
+
                     b.Property<string>("City")
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
@@ -1772,6 +1776,10 @@ namespace BusBuddy.Core.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 
+                    b.Property<string>("EmergencyContactName")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
                     b.Property<string>("EmergencyPhone")
                         .HasMaxLength(20)
                         .HasColumnType("nvarchar(20)");
@@ -1792,6 +1800,11 @@ namespace BusBuddy.Core.Migrations
                     b.Property<string>("Grade")
                         .HasMaxLength(20)
                         .HasColumnType("nvarchar(20)");
+
+                    b.Property<bool>("HasMedicalNeeds")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bit")
+                        .HasDefaultValue(false);
 
                     b.Property<string>("HomeAddress")
                         .HasMaxLength(200)
@@ -1818,6 +1831,10 @@ namespace BusBuddy.Core.Migrations
                     b.Property<string>("PMRoute")
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
+
+                    b.Property<string>("ParentEmail")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("ParentGuardian")
                         .HasMaxLength(100)

--- a/BusBuddy.Core/Models/CdeDriverTrainingCodes.cs
+++ b/BusBuddy.Core/Models/CdeDriverTrainingCodes.cs
@@ -1,0 +1,73 @@
+namespace BusBuddy.Core.Models;
+
+/// <summary>
+/// Colorado CDE School Finance &amp; Operations — 2024-25 License/Training Matrix requirement codes.
+/// Source: https://resources.finalsite.net/images/v1764086158/cdestatecous/mpcomjjt3zryb1vussig/2024-25-License-Training-Matrix.pdf
+/// </summary>
+public static class CdeDriverTrainingCodes
+{
+    public const string BackgroundCheck = "BACKGROUND_CHECK";
+    public const string MvrAnnual = "MVR_ANNUAL";
+    public const string PreEmploymentDrugAlcohol = "PRE_EMPLOY_DA";
+    public const string FmcsaClearinghouse = "FMCSA_CLEARINGHOUSE";
+    public const string SubstanceAbuseTraining = "DA_SUBSTANCE_ABUSE_TRAINING";
+    public const string FmcsaRandomDa = "FMCSA_RANDOM_DA";
+    public const string MedicalForm = "MEDICAL_FORM";
+    public const string PerformanceEvalPreTrip = "PERF_EVAL_PRETRIP";
+    public const string SignedJobDescription = "SIGNED_JOB_DESCRIPTION";
+    public const string CdeAnnualWrittenTest = "CDE_ANNUAL_WRITTEN_TEST";
+    public const string CdeGuideCertificate = "CDE_GUIDE_CERTIFICATE";
+    public const string ConfidentialityTraining = "CONFIDENTIALITY_TRAINING";
+    public const string MountainAdverseWeather = "MOUNTAIN_ADVERSE_WEATHER";
+    public const string MandatoryReporting = "MANDATORY_REPORTING";
+    public const string FirstAidCpr = "FIRST_AID_CPR";
+    public const string AnnualSixHourInService = "ANNUAL_SIX_HOUR_INSERVICE";
+    public const string EldtPreservice = "ELDT_PRESERVICE";
+    public const string CsrsTraining = "CSRS_TRAINING";
+    public const string WheelchairSecurement = "WHEELCHAIR_SECUREMENT";
+    public const string SpecialNeedsTraining = "SPECIAL_NEEDS_1CCR_301-26";
+
+    public static IReadOnlyList<(string Code, string DisplayName, int? DefaultValidityMonths, bool OftenApplicable)> Catalog { get; } =
+    [
+        (BackgroundCheck, "Required Background Check", 24, true),
+        (MvrAnnual, "MVR Pre-Employment and Annually", 12, true),
+        (PreEmploymentDrugAlcohol, "Pre-Employment D & A Testing", null, true),
+        (FmcsaClearinghouse, "FMCSA D & A Clearinghouse", null, true),
+        (SubstanceAbuseTraining, "D & A Substance Abuse Training", null, true),
+        (FmcsaRandomDa, "FMCSA D & A Random Testing", 12, true),
+        (MedicalForm, "Required Medical Form (USDOT Physical / STU-17)", 24, true),
+        (PerformanceEvalPreTrip, "Performance Evaluation & Pre-Trip", 12, true),
+        (SignedJobDescription, "Signed Job Description", null, true),
+        (CdeAnnualWrittenTest, "CDE Annual Written Test", 12, true),
+        (CdeGuideCertificate, "CDE Guide Certificate of Receipt", 12, true),
+        (ConfidentialityTraining, "Confidentiality Training", null, true),
+        (MountainAdverseWeather, "Mountain & Adverse Weather Training", null, true),
+        (MandatoryReporting, "Mandatory Reporting Training", null, true),
+        (FirstAidCpr, "First Aid / CPR / Universal Precautions", 24, true),
+        (AnnualSixHourInService, "Annual Six Hour In-Service", 12, true),
+        (EldtPreservice, "ELDT Pre-service (Syllabus / BTW / Theory)", null, true),
+        (CsrsTraining, "Proper Use and Maintenance of CSRS", null, false),
+        (WheelchairSecurement, "Proper Wheelchair Securement Training", null, false),
+        (SpecialNeedsTraining, "Special Needs Training (1 CCR 301-26, 5.6)", null, false)
+    ];
+}
+
+/// <summary>Route vs activity duty used with the CDE license/training matrix.</summary>
+public static class DriverDutyCategories
+{
+    public const string Route = "Route";
+    public const string Activity = "Activity";
+}
+
+/// <summary>Vehicle capacity / GVWR bucket aligned to CDE matrix columns.</summary>
+public static class DriverVehicleCategories
+{
+    public const string Route16PlusGvwrOver26001 = "Route_16+_GVWR_GT_26001";
+    public const string Route16PlusGvwrUnder26001 = "Route_16+_GVWR_LT_26001";
+    public const string RouteTypeA15OrLess = "Route_TypeA_15_or_less";
+    public const string ActivityMf16PlusGvwrOver26001 = "Activity_MF_16+_GVWR_GT_26001";
+    public const string ActivityMf16PlusGvwrUnder26001 = "Activity_MF_16+_GVWR_LT_26001";
+    public const string ActivityTypeA15OrLess = "Activity_TypeA_MF_15_or_less";
+    public const string ActivityUnder12 = "Activity_LT_12_passengers";
+    public const string ActivityMotorcoach = "Activity_Motorcoach_16+_GVWR_GT_26001";
+}

--- a/BusBuddy.Core/Models/Destination.cs
+++ b/BusBuddy.Core/Models/Destination.cs
@@ -66,18 +66,49 @@ namespace BusBuddy.Core.Models
         public string? ContactPhone { get; set; }
 
         /// <summary>
-        /// Contact email address
+        /// Contact email address (administrative for schools)
         /// </summary>
         [StringLength(100)]
         [EmailAddress]
         public string? ContactEmail { get; set; }
 
         /// <summary>
+        /// Secondary administrative contact (e.g. transportation liaison)
+        /// </summary>
+        [StringLength(100)]
+        public string? AdminContactName { get; set; }
+
+        [StringLength(20)]
+        public string? AdminPhone { get; set; }
+
+        [StringLength(100)]
+        [EmailAddress]
+        public string? AdminEmail { get; set; }
+
+        /// <summary>District or LEA name (supports inter-district transfers).</summary>
+        [StringLength(150)]
+        public string? DistrictName { get; set; }
+
+        /// <summary>Lowest served grade label (e.g. Pre-K, K, 1).</summary>
+        [StringLength(20)]
+        public string? GradeMin { get; set; }
+
+        /// <summary>Highest served grade label (e.g. 5, 8, 12).</summary>
+        [StringLength(20)]
+        public string? GradeMax { get; set; }
+
+        /// <summary>Approximate minimum age served (years), optional.</summary>
+        public int? AgeMinYears { get; set; }
+
+        /// <summary>Approximate maximum age served (years), optional.</summary>
+        public int? AgeMaxYears { get; set; }
+
+        /// <summary>
         /// Type of destination for categorization
         /// </summary>
         [Required]
         [StringLength(50)]
-        public string DestinationType { get; set; } = "Field Trip";
+        public string DestinationType { get; set; } = DestinationTypes.FieldTrip;
 
         /// <summary>
         /// Maximum number of students the venue can accommodate
@@ -163,6 +194,7 @@ namespace BusBuddy.Core.Models
     /// </summary>
     public static class DestinationTypes
     {
+        public const string School = "School";
         public const string FieldTrip = "Field Trip";
         public const string SportsEvent = "Sports Event";
         public const string AcademicCompetition = "Academic Competition";
@@ -176,9 +208,12 @@ namespace BusBuddy.Core.Models
         public const string Other = "Other";
 
         public static readonly string[] AllTypes = {
-            FieldTrip, SportsEvent, AcademicCompetition, CommunityService,
+            School, FieldTrip, SportsEvent, AcademicCompetition, CommunityService,
             BandCompetition, DramaPerformance, CareerFair, CulturalExchange,
             VolunteerWork, GraduationCeremony, Other
         };
+
+        public static bool IsSchool(string? type) =>
+            string.Equals(type, School, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/BusBuddy.Core/Models/Driver.cs
+++ b/BusBuddy.Core/Models/Driver.cs
@@ -272,6 +272,34 @@ public class Driver : INotifyPropertyChanged
     [Display(Name = "Hire Date")]
     public DateTime? HireDate { get; set; }
 
+    /// <summary>School / LEA employer name (district-specific employment).</summary>
+    [StringLength(150)]
+    [Display(Name = "Employing School / District")]
+    public string? EmployingDistrict { get; set; }
+
+    [Display(Name = "Employment End Date")]
+    public DateTime? EmploymentEndDate { get; set; }
+
+    /// <summary><see cref="DriverDutyCategories"/> — Route or Activity.</summary>
+    [StringLength(20)]
+    [Display(Name = "Duty Category")]
+    public string? DutyCategory { get; set; }
+
+    /// <summary><see cref="DriverVehicleCategories"/> — CDE matrix vehicle column.</summary>
+    [StringLength(60)]
+    [Display(Name = "Vehicle Category")]
+    public string? VehicleCategory { get; set; }
+
+    /// <summary>CDL restriction codes (e.g. M air-brake restriction from CDE matrix).</summary>
+    [StringLength(50)]
+    [Display(Name = "CDL Restrictions")]
+    public string? CdlRestrictions { get; set; }
+
+    /// <summary>USDOT Physical or STU-17 per CDE matrix medical form row.</summary>
+    [StringLength(40)]
+    [Display(Name = "Medical Form Type")]
+    public string? MedicalFormType { get; set; }
+
     [Display(Name = "Created Date")]
     public DateTime CreatedDate { get; set; } // Remove dynamic default, handle in application logic
 
@@ -443,6 +471,7 @@ public class Driver : INotifyPropertyChanged
     public string? Phone => DriverPhone;
 
     // Navigation properties
+    public virtual ICollection<DriverTrainingRecord> TrainingRecords { get; set; } = new List<DriverTrainingRecord>();
     public virtual ICollection<Route> AMRoutes { get; set; } = new List<Route>();
     public virtual ICollection<Route> PMRoutes { get; set; } = new List<Route>();
     public virtual ICollection<Schedule> Schedules { get; set; } = new List<Schedule>();

--- a/BusBuddy.Core/Models/DriverTrainingRecord.cs
+++ b/BusBuddy.Core/Models/DriverTrainingRecord.cs
@@ -1,0 +1,73 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BusBuddy.Core.Models;
+
+/// <summary>
+/// Per-driver training / compliance record (sub-module of Drivers).
+/// Tracks Colorado CDE matrix items (background, CDL medical, annual tests, ELDT, etc.).
+/// </summary>
+[Table("DriverTrainingRecords")]
+public class DriverTrainingRecord
+{
+    [Key]
+    public int TrainingRecordId { get; set; }
+
+    public int DriverId { get; set; }
+
+    [ForeignKey(nameof(DriverId))]
+    public Driver? Driver { get; set; }
+
+    /// <summary>Code from <see cref="CdeDriverTrainingCodes"/>.</summary>
+    [Required]
+    [StringLength(80)]
+    public string RequirementCode { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(200)]
+    public string RequirementName { get; set; } = string.Empty;
+
+    public DateTime? CompletedDate { get; set; }
+
+    public DateTime? ExpiryDate { get; set; }
+
+    public bool IsRequired { get; set; } = true;
+
+    public bool IsApplicable { get; set; } = true;
+
+    [StringLength(100)]
+    public string? CertificateOrReference { get; set; }
+
+    [StringLength(100)]
+    public string? ProviderOrInstructor { get; set; }
+
+    [StringLength(1000)]
+    public string? Notes { get; set; }
+
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+
+    [StringLength(100)]
+    public string? CreatedBy { get; set; }
+
+    public DateTime? UpdatedDate { get; set; }
+
+    [NotMapped]
+    public bool IsComplete => CompletedDate.HasValue;
+
+    [NotMapped]
+    public bool IsExpired => ExpiryDate.HasValue && ExpiryDate.Value.Date < DateTime.Today;
+
+    [NotMapped]
+    public bool IsExpiringSoon =>
+        ExpiryDate.HasValue &&
+        !IsExpired &&
+        ExpiryDate.Value.Date <= DateTime.Today.AddDays(30);
+
+    [NotMapped]
+    public string StatusLabel =>
+        !IsApplicable ? "N/A" :
+        !IsComplete ? "Missing" :
+        IsExpired ? "Expired" :
+        IsExpiringSoon ? "Expiring Soon" :
+        "Current";
+}

--- a/BusBuddy.Core/Models/Student.cs
+++ b/BusBuddy.Core/Models/Student.cs
@@ -29,6 +29,12 @@ public class Student : INotifyPropertyChanged
   // Optional for MVP: family association can be added later during edit
   public int? FamilyId { get; set; }
   public Family? Family { get; set; }
+
+  /// <summary>Assigned campus from Destinations (DestinationType = School).</summary>
+  public int? DestinationId { get; set; }
+
+  [ForeignKey(nameof(DestinationId))]
+  public Destination? Destination { get; set; }
   [StringLength(20, ErrorMessage = "Student number cannot exceed 20 characters")]
   [Display(Name = "Student Number")]
   public string? StudentNumber { get; set; }
@@ -72,13 +78,40 @@ public class Student : INotifyPropertyChanged
   [Display(Name = "Home Phone")]
   public string? HomePhone { get; set; }
 
+  [StringLength(20, ErrorMessage = "Cell phone cannot exceed 20 characters")]
+  [Phone]
+  [Display(Name = "Parent/Guardian Cell")]
+  public string? CellPhone { get; set; }
+
   [StringLength(100, ErrorMessage = "Parent/Guardian name cannot exceed 100 characters")]
   [Display(Name = "Parent/Guardian")]
   public string? ParentGuardian { get; set; }
 
+  [StringLength(100, ErrorMessage = "Parent email cannot exceed 100 characters")]
+  [EmailAddress]
+  [Display(Name = "Parent/Guardian Email")]
+  public string? ParentEmail { get; set; }
+
+  /// <summary>
+  /// Emergency contact person (often different from primary parent/guardian).
+  /// Kept separate from <see cref="ParentGuardian"/> per school emergency-card practice.
+  /// </summary>
+  [StringLength(100, ErrorMessage = "Emergency contact name cannot exceed 100 characters")]
+  [Display(Name = "Emergency Contact Name")]
+  public string? EmergencyContactName { get; set; }
+
   [StringLength(20, ErrorMessage = "Emergency phone cannot exceed 20 characters")]
-  [Display(Name = "Emergency Phone")]
+  [Display(Name = "Emergency Contact Phone")]
   public string? EmergencyPhone { get; set; }
+
+  /// <summary>Form alias for emergency phone (same column as <see cref="EmergencyPhone"/>).</summary>
+  [NotMapped]
+  [Display(Name = "Emergency Contact Phone")]
+  public string? EmergencyContactPhone
+  {
+    get => EmergencyPhone;
+    set => EmergencyPhone = value;
+  }
 
   [StringLength(100, ErrorMessage = "School name cannot exceed 100 characters")]
   [Display(Name = "School")]
@@ -97,6 +130,10 @@ public class Student : INotifyPropertyChanged
   public string? PMRoute { get; set; }
 
   public bool Active { get; set; } = true;
+
+  /// <summary>True when bus staff should review medical / allergy / medication fields.</summary>
+  [Display(Name = "Has Medical Needs")]
+  public bool HasMedicalNeeds { get; set; }
 
   public string SpecialNeeds { get; set; } = string.Empty;
 
@@ -140,6 +177,15 @@ public class Student : INotifyPropertyChanged
   [Display(Name = "Transportation Notes")]
   public string? TransportationNotes { get; set; }
 
+  /// <summary>UI alias used by StudentForm (maps to <see cref="TransportationNotes"/>).</summary>
+  [NotMapped]
+  [Display(Name = "Special Instructions")]
+  public string? SpecialInstructions
+  {
+    get => TransportationNotes;
+    set => TransportationNotes = value;
+  }
+
   [StringLength(100, ErrorMessage = "Alternative contact cannot exceed 100 characters")]
   [Display(Name = "Alternative Contact")]
   public string? AlternativeContact { get; set; }
@@ -170,6 +216,29 @@ public class Student : INotifyPropertyChanged
 
   [NotMapped]
   public string FullAddress => string.Join(", ", new[] { HomeAddress, City, State, Zip }.Where(s => !string.IsNullOrWhiteSpace(s))!);
+
+  /// <summary>Derived age for seating / car-seat rules — do not store separately (use <see cref="DateOfBirth"/>).</summary>
+  [NotMapped]
+  [Display(Name = "Age")]
+  public int? AgeYears
+  {
+    get
+    {
+      if (!DateOfBirth.HasValue)
+      {
+        return null;
+      }
+
+      var today = DateTime.Today;
+      var age = today.Year - DateOfBirth.Value.Year;
+      if (DateOfBirth.Value.Date > today.AddYears(-age))
+      {
+        age--;
+      }
+
+      return age < 0 ? null : age;
+    }
+  }
 
   // INotifyPropertyChanged implementation for Syncfusion data binding
   public event PropertyChangedEventHandler? PropertyChanged;

--- a/BusBuddy.Core/Models/StudentSchoolTransfer.cs
+++ b/BusBuddy.Core/Models/StudentSchoolTransfer.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BusBuddy.Core.Models;
+
+/// <summary>
+/// Inter-district (or school-to-school) transfer: timed pickup/dropoff between two school destinations.
+/// Used to plan home→school routes when a student attends a school other than their neighborhood campus.
+/// </summary>
+[Table("StudentSchoolTransfers")]
+public class StudentSchoolTransfer
+{
+    [Key]
+    public int TransferId { get; set; }
+
+    public int StudentId { get; set; }
+
+    [ForeignKey(nameof(StudentId))]
+    public Student? Student { get; set; }
+
+    /// <summary>Sending / morning-origin school (often neighborhood school or home district).</summary>
+    public int FromDestinationId { get; set; }
+
+    [ForeignKey(nameof(FromDestinationId))]
+    public Destination? FromDestination { get; set; }
+
+    /// <summary>Receiving school the student attends.</summary>
+    public int ToDestinationId { get; set; }
+
+    [ForeignKey(nameof(ToDestinationId))]
+    public Destination? ToDestination { get; set; }
+
+    /// <summary>Scheduled pickup time (local).</summary>
+    public TimeSpan? PickupTime { get; set; }
+
+    /// <summary>Scheduled dropoff time (local).</summary>
+    public TimeSpan? DropoffTime { get; set; }
+
+    [StringLength(300)]
+    public string? PickupAddress { get; set; }
+
+    [StringLength(300)]
+    public string? DropoffAddress { get; set; }
+
+    [Column(TypeName = "decimal(10,8)")]
+    public decimal? PickupLatitude { get; set; }
+
+    [Column(TypeName = "decimal(11,8)")]
+    public decimal? PickupLongitude { get; set; }
+
+    [Column(TypeName = "decimal(10,8)")]
+    public decimal? DropoffLatitude { get; set; }
+
+    [Column(TypeName = "decimal(11,8)")]
+    public decimal? DropoffLongitude { get; set; }
+
+    public DateTime? EffectiveDate { get; set; }
+
+    public DateTime? EndDate { get; set; }
+
+    public bool IsActive { get; set; } = true;
+
+    [StringLength(1000)]
+    public string? Notes { get; set; }
+
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+
+    [StringLength(100)]
+    public string? CreatedBy { get; set; }
+}

--- a/BusBuddy.Core/Services/DestinationService.cs
+++ b/BusBuddy.Core/Services/DestinationService.cs
@@ -1,0 +1,89 @@
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Mapping;
+using BusBuddy.Core.Models;
+using BusBuddy.Core.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace BusBuddy.Core.Services;
+
+public sealed class DestinationService : IDestinationService
+{
+    private static readonly ILogger Logger = Log.ForContext<DestinationService>();
+    private readonly IBusBuddyDbContextFactory _contextFactory;
+
+    public DestinationService(IBusBuddyDbContextFactory contextFactory)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+    }
+
+    public async Task EnsureDefaultSchoolsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var exists = await context.Destinations.AnyAsync(
+            d => d.DestinationType == DestinationTypes.School &&
+                 d.Name == WileyMapDefaults.SchoolLabel &&
+                 !d.IsDeleted,
+            cancellationToken).ConfigureAwait(false);
+
+        if (exists)
+        {
+            return;
+        }
+
+        context.Destinations.Add(new Destination
+        {
+            Name = WileyMapDefaults.SchoolLabel,
+            Address = "510 Ward St",
+            City = "Wiley",
+            State = "CO",
+            ZipCode = "81092",
+            DestinationType = DestinationTypes.School,
+            IsActive = true,
+            Latitude = (decimal)WileyMapDefaults.SchoolLatitude,
+            Longitude = (decimal)WileyMapDefaults.SchoolLongitude,
+            DistrictName = "Wiley RE-13JT",
+            GradeMin = "Pre-K",
+            GradeMax = "12",
+            AgeMinYears = 4,
+            AgeMaxYears = 18,
+            ContactName = "Main Office",
+            CreatedDate = DateTime.UtcNow,
+            UpdatedDate = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        Logger.Information("Seeded default school destination {Name}", WileyMapDefaults.SchoolLabel);
+    }
+
+    public async Task<IReadOnlyList<Destination>> GetActiveSchoolsAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureDefaultSchoolsAsync(cancellationToken).ConfigureAwait(false);
+        return await GetActiveDestinationsAsync(DestinationTypes.School, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<Destination>> GetActiveDestinationsAsync(
+        string? destinationType = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var query = context.Destinations.AsNoTracking()
+            .Where(d => d.IsActive && !d.IsDeleted);
+
+        if (!string.IsNullOrWhiteSpace(destinationType))
+        {
+            query = query.Where(d => d.DestinationType == destinationType);
+        }
+
+        var list = await query.OrderBy(d => d.Name).ToListAsync(cancellationToken).ConfigureAwait(false);
+        Logger.Debug("Loaded {Count} destinations Type={Type}", list.Count, destinationType ?? "*");
+        return list;
+    }
+
+    public async Task<Destination?> GetByIdAsync(int destinationId, CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        return await context.Destinations.AsNoTracking()
+            .FirstOrDefaultAsync(d => d.DestinationId == destinationId && !d.IsDeleted, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/BusBuddy.Core/Services/DriverTrainingService.cs
+++ b/BusBuddy.Core/Services/DriverTrainingService.cs
@@ -1,0 +1,176 @@
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace BusBuddy.Core.Services;
+
+/// <summary>Driver training / CDE compliance sub-module.</summary>
+public sealed class DriverTrainingService : IDriverTrainingService
+{
+    private static readonly ILogger Logger = Log.ForContext<DriverTrainingService>();
+    private readonly IBusBuddyDbContextFactory _contextFactory;
+
+    public DriverTrainingService(IBusBuddyDbContextFactory contextFactory)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+    }
+
+    public async Task<IReadOnlyList<DriverTrainingRecord>> GetRecordsForDriverAsync(
+        int driverId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        return await context.DriverTrainingRecords.AsNoTracking()
+            .Where(r => r.DriverId == driverId)
+            .OrderBy(r => r.RequirementName)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<DriverTrainingRecord>> EnsureMatrixChecklistAsync(
+        int driverId,
+        bool includeOptionalApplicable = false,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var driver = await context.Drivers.FirstOrDefaultAsync(d => d.DriverId == driverId, cancellationToken)
+            .ConfigureAwait(false);
+        if (driver is null)
+        {
+            throw new ArgumentException($"Driver {driverId} not found", nameof(driverId));
+        }
+
+        var existing = await context.DriverTrainingRecords
+            .Where(r => r.DriverId == driverId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var byCode = existing.ToDictionary(r => r.RequirementCode, StringComparer.OrdinalIgnoreCase);
+
+        var added = 0;
+        foreach (var (code, name, validityMonths, oftenApplicable) in CdeDriverTrainingCodes.Catalog)
+        {
+            if (!oftenApplicable && !includeOptionalApplicable)
+            {
+                continue;
+            }
+
+            if (byCode.ContainsKey(code))
+            {
+                continue;
+            }
+
+            context.DriverTrainingRecords.Add(new DriverTrainingRecord
+            {
+                DriverId = driverId,
+                RequirementCode = code,
+                RequirementName = name,
+                IsRequired = oftenApplicable,
+                IsApplicable = oftenApplicable || includeOptionalApplicable,
+                CreatedDate = DateTime.UtcNow
+            });
+            added++;
+        }
+
+        if (added > 0)
+        {
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            Logger.Information("Seeded {Count} CDE training checklist rows for DriverId={DriverId}", added, driverId);
+        }
+
+        return await GetRecordsForDriverAsync(driverId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<DriverTrainingRecord> UpsertCompletionAsync(
+        int driverId,
+        string requirementCode,
+        DateTime completedDate,
+        DateTime? expiryDate = null,
+        string? certificateOrReference = null,
+        string? notes = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(requirementCode))
+        {
+            throw new ArgumentException("Requirement code is required", nameof(requirementCode));
+        }
+
+        await using var context = _contextFactory.CreateDbContext();
+        var catalogItem = CdeDriverTrainingCodes.Catalog
+            .FirstOrDefault(c => string.Equals(c.Code, requirementCode, StringComparison.OrdinalIgnoreCase));
+        var hasCatalog = !string.IsNullOrEmpty(catalogItem.Code);
+
+        var record = await context.DriverTrainingRecords
+            .FirstOrDefaultAsync(
+                r => r.DriverId == driverId && r.RequirementCode == requirementCode,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (record is null)
+        {
+            record = new DriverTrainingRecord
+            {
+                DriverId = driverId,
+                RequirementCode = requirementCode,
+                RequirementName = hasCatalog ? catalogItem.DisplayName : requirementCode,
+                IsRequired = hasCatalog && catalogItem.OftenApplicable,
+                IsApplicable = true,
+                CreatedDate = DateTime.UtcNow
+            };
+            context.DriverTrainingRecords.Add(record);
+        }
+
+        record.CompletedDate = completedDate.Date;
+        record.ExpiryDate = expiryDate?.Date
+            ?? (hasCatalog && catalogItem.DefaultValidityMonths is int months
+                ? completedDate.Date.AddMonths(months)
+                : null);
+        record.CertificateOrReference = certificateOrReference;
+        if (!string.IsNullOrWhiteSpace(notes))
+        {
+            record.Notes = notes;
+        }
+
+        record.UpdatedDate = DateTime.UtcNow;
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        await RefreshTrainingCompleteFlagAsync(driverId, cancellationToken).ConfigureAwait(false);
+        Logger.Information(
+            "Training upserted DriverId={DriverId} Code={Code} Completed={Completed} Expiry={Expiry}",
+            driverId, requirementCode, record.CompletedDate, record.ExpiryDate);
+
+        return record;
+    }
+
+    public async Task<bool> RefreshTrainingCompleteFlagAsync(
+        int driverId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var driver = await context.Drivers.FirstOrDefaultAsync(d => d.DriverId == driverId, cancellationToken)
+            .ConfigureAwait(false);
+        if (driver is null)
+        {
+            return false;
+        }
+
+        var required = await context.DriverTrainingRecords
+            .Where(r => r.DriverId == driverId && r.IsRequired && r.IsApplicable)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var complete = required.Count > 0 &&
+                       required.All(r => r.CompletedDate.HasValue &&
+                                         (!r.ExpiryDate.HasValue || r.ExpiryDate.Value.Date >= DateTime.Today));
+
+        if (driver.TrainingComplete != complete)
+        {
+            driver.TrainingComplete = complete;
+            driver.UpdatedDate = DateTime.UtcNow;
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            Logger.Information("DriverId={DriverId} TrainingComplete={Complete}", driverId, complete);
+        }
+
+        return complete;
+    }
+}

--- a/BusBuddy.Core/Services/DriverTrainingService.cs
+++ b/BusBuddy.Core/Services/DriverTrainingService.cs
@@ -33,15 +33,16 @@ public sealed class DriverTrainingService : IDriverTrainingService
         bool includeOptionalApplicable = false,
         CancellationToken cancellationToken = default)
     {
-        await using var context = _contextFactory.CreateDbContext();
-        var driver = await context.Drivers.FirstOrDefaultAsync(d => d.DriverId == driverId, cancellationToken)
+        await using var context = _contextFactory.CreateWriteDbContext();
+        var driver = await context.Drivers.AsTracking()
+            .FirstOrDefaultAsync(d => d.DriverId == driverId, cancellationToken)
             .ConfigureAwait(false);
         if (driver is null)
         {
             throw new ArgumentException($"Driver {driverId} not found", nameof(driverId));
         }
 
-        var existing = await context.DriverTrainingRecords
+        var existing = await context.DriverTrainingRecords.AsTracking()
             .Where(r => r.DriverId == driverId)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -95,12 +96,13 @@ public sealed class DriverTrainingService : IDriverTrainingService
             throw new ArgumentException("Requirement code is required", nameof(requirementCode));
         }
 
-        await using var context = _contextFactory.CreateDbContext();
+        // Write path must track: BusBuddyDbContext defaults to NoTracking.
+        await using var context = _contextFactory.CreateWriteDbContext();
         var catalogItem = CdeDriverTrainingCodes.Catalog
             .FirstOrDefault(c => string.Equals(c.Code, requirementCode, StringComparison.OrdinalIgnoreCase));
         var hasCatalog = !string.IsNullOrEmpty(catalogItem.Code);
 
-        var record = await context.DriverTrainingRecords
+        var record = await context.DriverTrainingRecords.AsTracking()
             .FirstOrDefaultAsync(
                 r => r.DriverId == driverId && r.RequirementCode == requirementCode,
                 cancellationToken)
@@ -146,8 +148,9 @@ public sealed class DriverTrainingService : IDriverTrainingService
         int driverId,
         CancellationToken cancellationToken = default)
     {
-        await using var context = _contextFactory.CreateDbContext();
-        var driver = await context.Drivers.FirstOrDefaultAsync(d => d.DriverId == driverId, cancellationToken)
+        await using var context = _contextFactory.CreateWriteDbContext();
+        var driver = await context.Drivers.AsTracking()
+            .FirstOrDefaultAsync(d => d.DriverId == driverId, cancellationToken)
             .ConfigureAwait(false);
         if (driver is null)
         {

--- a/BusBuddy.Core/Services/IDriverTrainingService.cs
+++ b/BusBuddy.Core/Services/IDriverTrainingService.cs
@@ -1,0 +1,27 @@
+using BusBuddy.Core.Models;
+
+namespace BusBuddy.Core.Services;
+
+public interface IDriverTrainingService
+{
+    Task<IReadOnlyList<DriverTrainingRecord>> GetRecordsForDriverAsync(
+        int driverId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Ensure CDE matrix checklist rows exist for the driver (idempotent by RequirementCode).</summary>
+    Task<IReadOnlyList<DriverTrainingRecord>> EnsureMatrixChecklistAsync(
+        int driverId,
+        bool includeOptionalApplicable = false,
+        CancellationToken cancellationToken = default);
+
+    Task<DriverTrainingRecord> UpsertCompletionAsync(
+        int driverId,
+        string requirementCode,
+        DateTime completedDate,
+        DateTime? expiryDate = null,
+        string? certificateOrReference = null,
+        string? notes = null,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> RefreshTrainingCompleteFlagAsync(int driverId, CancellationToken cancellationToken = default);
+}

--- a/BusBuddy.Core/Services/Interfaces/IDestinationService.cs
+++ b/BusBuddy.Core/Services/Interfaces/IDestinationService.cs
@@ -1,0 +1,17 @@
+using BusBuddy.Core.Models;
+
+namespace BusBuddy.Core.Services.Interfaces;
+
+/// <summary>School / destination catalog for intake dropdowns and map markers.</summary>
+public interface IDestinationService
+{
+    Task EnsureDefaultSchoolsAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Destination>> GetActiveSchoolsAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Destination>> GetActiveDestinationsAsync(
+        string? destinationType = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Destination?> GetByIdAsync(int destinationId, CancellationToken cancellationToken = default);
+}

--- a/BusBuddy.Core/Services/RouteService.cs
+++ b/BusBuddy.Core/Services/RouteService.cs
@@ -23,6 +23,7 @@ namespace BusBuddy.Core.Services
     {
         private static readonly ILogger Logger = Log.ForContext<RouteService>();
         private readonly IBusBuddyDbContextFactory _contextFactory;
+        private readonly IRouteWaypointRebuildService? _waypointRebuild;
 
         // Minimal op timing helper (basic only; can expand later)
         private static (Guid OpId, Stopwatch Sw) StartOp(string name, object? routeId = null)
@@ -47,8 +48,16 @@ namespace BusBuddy.Core.Services
         }
 
         public RouteService(IBusBuddyDbContextFactory contextFactory)
+            : this(contextFactory, null)
+        {
+        }
+
+        public RouteService(
+            IBusBuddyDbContextFactory contextFactory,
+            IRouteWaypointRebuildService? waypointRebuild)
         {
             _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+            _waypointRebuild = waypointRebuild;
         }
 
         // Context helpers: only dispose when using the concrete runtime factory
@@ -819,6 +828,19 @@ namespace BusBuddy.Core.Services
                     context.Entry(student).State = EntityState.Modified;
                     await context.SaveChangesAsync();
                     Logger.Information("Assigned student {StudentId} to route {RouteName} ({Slot})", studentId, route.RouteName, timeSlot);
+
+                    if (_waypointRebuild is not null)
+                    {
+                        try
+                        {
+                            await _waypointRebuild.RebuildAndPersistAsync(routeId);
+                        }
+                        catch (Exception wpEx)
+                        {
+                            Logger.Warning(wpEx, "Waypoint rebuild after assign failed RouteId={RouteId}", routeId);
+                        }
+                    }
+
                     return Result.SuccessResult(true);
                 }
                 finally

--- a/BusBuddy.Core/Services/RouteWaypointRebuildService.cs
+++ b/BusBuddy.Core/Services/RouteWaypointRebuildService.cs
@@ -1,0 +1,187 @@
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Mapping;
+using BusBuddy.Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace BusBuddy.Core.Services;
+
+/// <summary>
+/// Builds Route.WaypointsJson from assigned students' homes, school destinations,
+/// and active school-to-school transfer pickup/dropoff pairs (home→school path).
+/// </summary>
+public interface IRouteWaypointRebuildService
+{
+    Task<string?> RebuildAndPersistAsync(int routeId, CancellationToken cancellationToken = default);
+
+    Task RebuildForStudentRoutesAsync(int studentId, CancellationToken cancellationToken = default);
+}
+
+public sealed class RouteWaypointRebuildService : IRouteWaypointRebuildService
+{
+    private static readonly ILogger Logger = Log.ForContext<RouteWaypointRebuildService>();
+    private readonly IBusBuddyDbContextFactory _contextFactory;
+
+    public RouteWaypointRebuildService(IBusBuddyDbContextFactory contextFactory)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+    }
+
+    public async Task RebuildForStudentRoutesAsync(int studentId, CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var student = await context.Students.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.StudentId == studentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (student is null)
+        {
+            return;
+        }
+
+        var routeNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(student.AMRoute))
+        {
+            routeNames.Add(student.AMRoute!);
+        }
+
+        if (!string.IsNullOrWhiteSpace(student.PMRoute))
+        {
+            routeNames.Add(student.PMRoute!);
+        }
+
+        if (routeNames.Count == 0)
+        {
+            return;
+        }
+
+        var routeIds = await context.Routes.AsNoTracking()
+            .Where(r => routeNames.Contains(r.RouteName))
+            .Select(r => r.RouteId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var routeId in routeIds)
+        {
+            await RebuildAndPersistAsync(routeId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<string?> RebuildAndPersistAsync(int routeId, CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateWriteDbContext();
+        var route = await context.Routes.FirstOrDefaultAsync(r => r.RouteId == routeId, cancellationToken)
+            .ConfigureAwait(false);
+        if (route is null || string.IsNullOrWhiteSpace(route.RouteName))
+        {
+            return null;
+        }
+
+        var students = await context.Students.AsNoTracking()
+            .Where(s => s.Active &&
+                        (s.AMRoute == route.RouteName || s.PMRoute == route.RouteName))
+            .OrderBy(s => s.StudentName)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var studentIds = students.Select(s => s.StudentId).ToList();
+        var transfers = studentIds.Count == 0
+            ? new List<StudentSchoolTransfer>()
+            : await context.StudentSchoolTransfers.AsNoTracking()
+                .Include(t => t.FromDestination)
+                .Include(t => t.ToDestination)
+                .Where(t => t.IsActive && studentIds.Contains(t.StudentId))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        var transfersByStudent = transfers
+            .GroupBy(t => t.StudentId)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(t => t.EffectiveDate).First());
+
+        var points = new List<(double Lat, double Lon)>();
+        foreach (var student in students)
+        {
+            TryAdd(points, student.Latitude, student.Longitude);
+
+            if (!transfersByStudent.TryGetValue(student.StudentId, out var transfer))
+            {
+                continue;
+            }
+
+            // Transfer stop pair: requested pickup → dropoff (coords or school destination GPS)
+            var pickupLat = transfer.PickupLatitude ?? transfer.FromDestination?.Latitude;
+            var pickupLon = transfer.PickupLongitude ?? transfer.FromDestination?.Longitude;
+            var dropLat = transfer.DropoffLatitude ?? transfer.ToDestination?.Latitude;
+            var dropLon = transfer.DropoffLongitude ?? transfer.ToDestination?.Longitude;
+            TryAdd(points, pickupLat, pickupLon);
+            TryAdd(points, dropLat, dropLon);
+        }
+
+        // Terminal school for home→school path
+        Destination? school = null;
+        if (!string.IsNullOrWhiteSpace(route.School))
+        {
+            school = await context.Destinations.AsNoTracking()
+                .FirstOrDefaultAsync(
+                    d => d.IsActive && !d.IsDeleted && d.Name == route.School,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (school is null)
+        {
+            var destinationIds = students
+                .Where(s => s.DestinationId.HasValue)
+                .Select(s => s.DestinationId!.Value)
+                .Distinct()
+                .ToList();
+            if (destinationIds.Count == 1)
+            {
+                school = await context.Destinations.AsNoTracking()
+                    .FirstOrDefaultAsync(d => d.DestinationId == destinationIds[0], cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        TryAdd(points, school?.Latitude, school?.Longitude);
+
+        if (points.Count < 2)
+        {
+            Logger.Information(
+                "Waypoint rebuild skipped RouteId={RouteId} — need ≥2 points (have {Count})",
+                routeId,
+                points.Count);
+            return route.WaypointsJson;
+        }
+
+        var json = RouteWaypointSerializer.FromPairs(points);
+        route.WaypointsJson = json;
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        Logger.Information(
+            "Rebuilt WaypointsJson RouteId={RouteId} Points={Count} Students={Students} Transfers={Transfers}",
+            routeId,
+            points.Count,
+            students.Count,
+            transfersByStudent.Count);
+        return json;
+    }
+
+    private static void TryAdd(List<(double Lat, double Lon)> points, decimal? lat, decimal? lon)
+    {
+        if (!lat.HasValue || !lon.HasValue)
+        {
+            return;
+        }
+
+        var next = ((double)lat.Value, (double)lon.Value);
+        if (points.Count > 0)
+        {
+            var last = points[^1];
+            if (Math.Abs(last.Lat - next.Item1) < 1e-7 && Math.Abs(last.Lon - next.Item2) < 1e-7)
+            {
+                return;
+            }
+        }
+
+        points.Add(next);
+    }
+}

--- a/BusBuddy.Core/Services/StudentSchoolTransferService.cs
+++ b/BusBuddy.Core/Services/StudentSchoolTransferService.cs
@@ -1,0 +1,95 @@
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace BusBuddy.Core.Services;
+
+/// <summary>
+/// Creates/lists school-to-school (inter-district) transfer assignments with timed pickup/dropoff.
+/// Route planning can later use these as waypoints between FromDestination and ToDestination.
+/// </summary>
+public interface IStudentSchoolTransferService
+{
+    Task<StudentSchoolTransfer> AssignTransferAsync(StudentSchoolTransfer transfer, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<StudentSchoolTransfer>> GetActiveTransfersForStudentAsync(
+        int studentId,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class StudentSchoolTransferService : IStudentSchoolTransferService
+{
+    private static readonly ILogger Logger = Log.ForContext<StudentSchoolTransferService>();
+    private readonly IBusBuddyDbContextFactory _contextFactory;
+
+    public StudentSchoolTransferService(IBusBuddyDbContextFactory contextFactory)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+    }
+
+    public async Task<StudentSchoolTransfer> AssignTransferAsync(
+        StudentSchoolTransfer transfer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(transfer);
+        if (transfer.StudentId <= 0)
+        {
+            throw new ArgumentException("StudentId is required", nameof(transfer));
+        }
+
+        if (transfer.FromDestinationId <= 0 || transfer.ToDestinationId <= 0)
+        {
+            throw new ArgumentException("From and To school destinations are required", nameof(transfer));
+        }
+
+        if (transfer.FromDestinationId == transfer.ToDestinationId)
+        {
+            throw new ArgumentException("From and To schools must differ for a transfer", nameof(transfer));
+        }
+
+        await using var context = _contextFactory.CreateDbContext();
+        transfer.CreatedDate = DateTime.UtcNow;
+        transfer.IsActive = true;
+        context.StudentSchoolTransfers.Add(transfer);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Keep attending campus aligned with receiving school when DestinationId is set.
+        var student = await context.Students.FirstOrDefaultAsync(s => s.StudentId == transfer.StudentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (student is not null)
+        {
+            var toSchool = await context.Destinations.FirstOrDefaultAsync(
+                d => d.DestinationId == transfer.ToDestinationId, cancellationToken).ConfigureAwait(false);
+            if (toSchool is not null)
+            {
+                student.DestinationId = toSchool.DestinationId;
+                student.School = toSchool.Name;
+                student.UpdatedDate = DateTime.UtcNow;
+                await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        Logger.Information(
+            "School transfer assigned StudentId={StudentId} From={From} To={To} Pickup={Pickup} Dropoff={Dropoff}",
+            transfer.StudentId,
+            transfer.FromDestinationId,
+            transfer.ToDestinationId,
+            transfer.PickupTime,
+            transfer.DropoffTime);
+
+        return transfer;
+    }
+
+    public async Task<IReadOnlyList<StudentSchoolTransfer>> GetActiveTransfersForStudentAsync(
+        int studentId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        return await context.StudentSchoolTransfers.AsNoTracking()
+            .Where(t => t.StudentId == studentId && t.IsActive)
+            .OrderByDescending(t => t.EffectiveDate)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/BusBuddy.Core/Services/StudentSchoolTransferService.cs
+++ b/BusBuddy.Core/Services/StudentSchoolTransferService.cs
@@ -7,7 +7,7 @@ namespace BusBuddy.Core.Services;
 
 /// <summary>
 /// Creates/lists school-to-school (inter-district) transfer assignments with timed pickup/dropoff.
-/// Route planning can later use these as waypoints between FromDestination and ToDestination.
+/// Required: from/to schools, pickup address, dropoff address, pickup time, dropoff time.
 /// </summary>
 public interface IStudentSchoolTransferService
 {
@@ -22,10 +22,14 @@ public sealed class StudentSchoolTransferService : IStudentSchoolTransferService
 {
     private static readonly ILogger Logger = Log.ForContext<StudentSchoolTransferService>();
     private readonly IBusBuddyDbContextFactory _contextFactory;
+    private readonly IRouteWaypointRebuildService? _waypointRebuild;
 
-    public StudentSchoolTransferService(IBusBuddyDbContextFactory contextFactory)
+    public StudentSchoolTransferService(
+        IBusBuddyDbContextFactory contextFactory,
+        IRouteWaypointRebuildService? waypointRebuild = null)
     {
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        _waypointRebuild = waypointRebuild;
     }
 
     public async Task<StudentSchoolTransfer> AssignTransferAsync(
@@ -48,35 +52,105 @@ public sealed class StudentSchoolTransferService : IStudentSchoolTransferService
             throw new ArgumentException("From and To schools must differ for a transfer", nameof(transfer));
         }
 
+        if (string.IsNullOrWhiteSpace(transfer.PickupAddress))
+        {
+            throw new ArgumentException("Pickup location is required", nameof(transfer));
+        }
+
+        if (string.IsNullOrWhiteSpace(transfer.DropoffAddress))
+        {
+            throw new ArgumentException("Dropoff location is required", nameof(transfer));
+        }
+
+        if (!transfer.PickupTime.HasValue)
+        {
+            throw new ArgumentException("Requested transfer pickup time is required", nameof(transfer));
+        }
+
+        if (!transfer.DropoffTime.HasValue)
+        {
+            throw new ArgumentException("Requested transfer dropoff time is required", nameof(transfer));
+        }
+
+        if (transfer.DropoffTime <= transfer.PickupTime)
+        {
+            throw new ArgumentException("Dropoff time must be after pickup time", nameof(transfer));
+        }
+
         await using var context = _contextFactory.CreateDbContext();
+
+        var fromSchool = await context.Destinations.AsNoTracking()
+            .FirstOrDefaultAsync(d => d.DestinationId == transfer.FromDestinationId, cancellationToken)
+            .ConfigureAwait(false);
+        var toSchool = await context.Destinations.AsNoTracking()
+            .FirstOrDefaultAsync(d => d.DestinationId == transfer.ToDestinationId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (fromSchool is null || toSchool is null)
+        {
+            throw new ArgumentException("From or To school destination was not found", nameof(transfer));
+        }
+
+        if (!transfer.PickupLatitude.HasValue || !transfer.PickupLongitude.HasValue)
+        {
+            transfer.PickupLatitude = fromSchool.Latitude;
+            transfer.PickupLongitude = fromSchool.Longitude;
+        }
+
+        if (!transfer.DropoffLatitude.HasValue || !transfer.DropoffLongitude.HasValue)
+        {
+            transfer.DropoffLatitude = toSchool.Latitude;
+            transfer.DropoffLongitude = toSchool.Longitude;
+        }
+
         transfer.CreatedDate = DateTime.UtcNow;
         transfer.IsActive = true;
+
+        var prior = await context.StudentSchoolTransfers
+            .Where(t => t.StudentId == transfer.StudentId && t.IsActive)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        foreach (var old in prior)
+        {
+            old.IsActive = false;
+            old.EndDate ??= DateTime.Today;
+        }
+
         context.StudentSchoolTransfers.Add(transfer);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        // Keep attending campus aligned with receiving school when DestinationId is set.
         var student = await context.Students.FirstOrDefaultAsync(s => s.StudentId == transfer.StudentId, cancellationToken)
             .ConfigureAwait(false);
         if (student is not null)
         {
-            var toSchool = await context.Destinations.FirstOrDefaultAsync(
-                d => d.DestinationId == transfer.ToDestinationId, cancellationToken).ConfigureAwait(false);
-            if (toSchool is not null)
-            {
-                student.DestinationId = toSchool.DestinationId;
-                student.School = toSchool.Name;
-                student.UpdatedDate = DateTime.UtcNow;
-                await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            }
+            student.DestinationId = toSchool.DestinationId;
+            student.School = toSchool.Name;
+            student.UpdatedDate = DateTime.UtcNow;
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 
         Logger.Information(
-            "School transfer assigned StudentId={StudentId} From={From} To={To} Pickup={Pickup} Dropoff={Dropoff}",
+            "School transfer assigned StudentId={StudentId} From={From} To={To} Pickup={Pickup}@{PickupTime} Dropoff={Dropoff}@{DropoffTime}",
             transfer.StudentId,
             transfer.FromDestinationId,
             transfer.ToDestinationId,
+            transfer.PickupAddress,
             transfer.PickupTime,
+            transfer.DropoffAddress,
             transfer.DropoffTime);
+
+        if (_waypointRebuild is not null)
+        {
+            try
+            {
+                await _waypointRebuild.RebuildForStudentRoutesAsync(transfer.StudentId, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Waypoint rebuild after transfer failed StudentId={StudentId}", transfer.StudentId);
+            }
+        }
 
         return transfer;
     }
@@ -87,6 +161,8 @@ public sealed class StudentSchoolTransferService : IStudentSchoolTransferService
     {
         await using var context = _contextFactory.CreateDbContext();
         return await context.StudentSchoolTransfers.AsNoTracking()
+            .Include(t => t.FromDestination)
+            .Include(t => t.ToDestination)
             .Where(t => t.StudentId == studentId && t.IsActive)
             .OrderByDescending(t => t.EffectiveDate)
             .ToListAsync(cancellationToken)

--- a/BusBuddy.Tests/Core/DriverTrainingServiceTests.cs
+++ b/BusBuddy.Tests/Core/DriverTrainingServiceTests.cs
@@ -1,0 +1,108 @@
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Models;
+using BusBuddy.Core.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core;
+
+[TestFixture]
+[Category("Unit")]
+public class DriverTrainingServiceTests
+{
+    private sealed class TestDbContextFactory : IBusBuddyDbContextFactory
+    {
+        private readonly DbContextOptions<BusBuddyDbContext> _options;
+
+        public TestDbContextFactory(DbContextOptions<BusBuddyDbContext> options) => _options = options;
+
+        public BusBuddyDbContext CreateDbContext() => new(_options);
+
+        public BusBuddyDbContext CreateWriteDbContext() => new(_options);
+    }
+
+    private static DbContextOptions<BusBuddyDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<BusBuddyDbContext>()
+            .UseInMemoryDatabase($"DriverTraining_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+    [Test]
+    public async Task EnsureMatrixChecklist_SeedsStandardCdeRows()
+    {
+        var options = CreateOptions();
+        var factory = new TestDbContextFactory(options);
+        await using (var seed = factory.CreateDbContext())
+        {
+            seed.Drivers.Add(new Driver
+            {
+                DriverName = "Test Driver",
+                DriversLicenceType = "CDL",
+                Status = "Active",
+                CreatedDate = DateTime.UtcNow
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var service = new DriverTrainingService(factory);
+        int driverId;
+        await using (var ctx = factory.CreateDbContext())
+        {
+            driverId = ctx.Drivers.Single().DriverId;
+        }
+
+        var records = await service.EnsureMatrixChecklistAsync(driverId);
+        var expectedRequired = CdeDriverTrainingCodes.Catalog.Count(c => c.OftenApplicable);
+
+        Assert.That(records.Count, Is.EqualTo(expectedRequired));
+        Assert.That(records.Any(r => r.RequirementCode == CdeDriverTrainingCodes.FirstAidCpr), Is.True);
+        Assert.That(records.Any(r => r.RequirementCode == CdeDriverTrainingCodes.EldtPreservice), Is.True);
+        Assert.That(records.Any(r => r.RequirementCode == CdeDriverTrainingCodes.CsrsTraining), Is.False);
+
+        var again = await service.EnsureMatrixChecklistAsync(driverId);
+        Assert.That(again.Count, Is.EqualTo(expectedRequired), "second ensure should be idempotent");
+    }
+
+    [Test]
+    public async Task UpsertCompletion_SetsExpiryAndRefreshesTrainingComplete()
+    {
+        var options = CreateOptions();
+        var factory = new TestDbContextFactory(options);
+        await using (var seed = factory.CreateDbContext())
+        {
+            seed.Drivers.Add(new Driver
+            {
+                DriverName = "Trainee",
+                DriversLicenceType = "CDL",
+                Status = "Active",
+                TrainingComplete = false,
+                CreatedDate = DateTime.UtcNow
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var service = new DriverTrainingService(factory);
+        int driverId;
+        await using (var ctx = factory.CreateDbContext())
+        {
+            driverId = ctx.Drivers.Single().DriverId;
+        }
+
+        await service.EnsureMatrixChecklistAsync(driverId);
+        var completed = DateTime.Today;
+        await service.UpsertCompletionAsync(
+            driverId,
+            CdeDriverTrainingCodes.FirstAidCpr,
+            completed);
+
+        var records = await service.GetRecordsForDriverAsync(driverId);
+        var firstAid = records.Single(r => r.RequirementCode == CdeDriverTrainingCodes.FirstAidCpr);
+        Assert.That(firstAid.CompletedDate?.Date, Is.EqualTo(completed));
+        Assert.That(firstAid.ExpiryDate?.Date, Is.EqualTo(completed.AddMonths(24)));
+
+        // Incomplete until all required rows completed
+        var flag = await service.RefreshTrainingCompleteFlagAsync(driverId);
+        Assert.That(flag, Is.False);
+    }
+}

--- a/BusBuddy.Tests/Core/DriverTrainingServiceTests.cs
+++ b/BusBuddy.Tests/Core/DriverTrainingServiceTests.cs
@@ -19,7 +19,12 @@ public class DriverTrainingServiceTests
 
         public BusBuddyDbContext CreateDbContext() => new(_options);
 
-        public BusBuddyDbContext CreateWriteDbContext() => new(_options);
+        public BusBuddyDbContext CreateWriteDbContext()
+        {
+            var ctx = new BusBuddyDbContext(_options);
+            ctx.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+            return ctx;
+        }
     }
 
     private static DbContextOptions<BusBuddyDbContext> CreateOptions() =>

--- a/BusBuddy.Tests/Core/StudentSchoolTransferAndWaypointTests.cs
+++ b/BusBuddy.Tests/Core/StudentSchoolTransferAndWaypointTests.cs
@@ -1,0 +1,135 @@
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Mapping;
+using BusBuddy.Core.Models;
+using BusBuddy.Core.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core;
+
+[TestFixture]
+[Category("Unit")]
+public class StudentSchoolTransferAndWaypointTests
+{
+    private sealed class TestDbContextFactory : IBusBuddyDbContextFactory
+    {
+        private readonly DbContextOptions<BusBuddyDbContext> _options;
+        public TestDbContextFactory(DbContextOptions<BusBuddyDbContext> options) => _options = options;
+        public BusBuddyDbContext CreateDbContext() => new(_options);
+        public BusBuddyDbContext CreateWriteDbContext() => new(_options);
+    }
+
+    private static DbContextOptions<BusBuddyDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<BusBuddyDbContext>()
+            .UseInMemoryDatabase($"TransferWp_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+    [Test]
+    public async Task AssignTransfer_RequiresPickupDropoffAndTimes()
+    {
+        var factory = new TestDbContextFactory(CreateOptions());
+        var service = new StudentSchoolTransferService(factory);
+        var transfer = new StudentSchoolTransfer
+        {
+            StudentId = 1,
+            FromDestinationId = 1,
+            ToDestinationId = 2
+        };
+
+        try
+        {
+            await service.AssignTransferAsync(transfer);
+            Assert.Fail("Expected ArgumentException");
+        }
+        catch (ArgumentException)
+        {
+            Assert.Pass();
+        }
+    }
+
+    [Test]
+    public async Task AssignTransfer_AndRebuild_IncludesTransferStopPairs()
+    {
+        var options = CreateOptions();
+        var factory = new TestDbContextFactory(options);
+        await using (var seed = factory.CreateDbContext())
+        {
+            seed.Destinations.AddRange(
+                new Destination
+                {
+                    DestinationId = 1,
+                    Name = "Neighborhood School",
+                    Address = "100 Main",
+                    City = "Wiley",
+                    State = "CO",
+                    ZipCode = "81092",
+                    DestinationType = DestinationTypes.School,
+                    Latitude = 38.15m,
+                    Longitude = -102.72m,
+                    IsActive = true
+                },
+                new Destination
+                {
+                    DestinationId = 2,
+                    Name = "Receiving School",
+                    Address = "200 Oak",
+                    City = "Lamar",
+                    State = "CO",
+                    ZipCode = "81052",
+                    DestinationType = DestinationTypes.School,
+                    Latitude = 38.09m,
+                    Longitude = -102.62m,
+                    IsActive = true
+                });
+            seed.Students.Add(new Student
+            {
+                StudentName = "Transfer Kid",
+                Active = true,
+                Latitude = 38.16m,
+                Longitude = -102.71m,
+                AMRoute = "Route A",
+                CreatedDate = DateTime.UtcNow
+            });
+            seed.Routes.Add(new Route
+            {
+                RouteName = "Route A",
+                Date = DateTime.Today,
+                IsActive = true,
+                School = "Receiving School"
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        int studentId;
+        int routeId;
+        await using (var ctx = factory.CreateDbContext())
+        {
+            studentId = ctx.Students.Single().StudentId;
+            routeId = ctx.Routes.Single().RouteId;
+        }
+
+        var rebuild = new RouteWaypointRebuildService(factory);
+        var transferService = new StudentSchoolTransferService(factory, rebuild);
+
+        await transferService.AssignTransferAsync(new StudentSchoolTransfer
+        {
+            StudentId = studentId,
+            FromDestinationId = 1,
+            ToDestinationId = 2,
+            PickupAddress = "100 Main, Wiley, CO 81092",
+            DropoffAddress = "200 Oak, Lamar, CO 81052",
+            PickupTime = TimeSpan.FromHours(7).Add(TimeSpan.FromMinutes(15)),
+            DropoffTime = TimeSpan.FromHours(7).Add(TimeSpan.FromMinutes(45)),
+            EffectiveDate = DateTime.Today
+        });
+
+        var json = await rebuild.RebuildAndPersistAsync(routeId);
+        Assert.That(json, Is.Not.Null.And.Not.Empty);
+        var points = RouteWaypointSerializer.Parse(json);
+        Assert.That(points.Count, Is.GreaterThanOrEqualTo(3), "home + pickup + dropoff (+ school)");
+        Assert.That(points.Any(p => Math.Abs(p.Latitude - 38.15) < 0.001), Is.True);
+        Assert.That(points.Any(p => Math.Abs(p.Latitude - 38.09) < 0.001), Is.True);
+    }
+}

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -429,6 +429,8 @@ namespace BusBuddy.WPF
 
                 // Register core business services for Students, Routes, Buses, Drivers
                 services.AddScoped<IStudentService, StudentService>();
+                services.AddScoped<BusBuddy.Core.Services.Interfaces.IDestinationService, BusBuddy.Core.Services.DestinationService>();
+                services.AddScoped<BusBuddy.Core.Services.IStudentSchoolTransferService, BusBuddy.Core.Services.StudentSchoolTransferService>();
                 services.AddScoped<IDriverService, DriverService>();
                 services.AddScoped<IRouteService, RouteService>();
                 services.AddScoped<BusBuddy.Core.Services.Interfaces.IBusService, BusService>();

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -431,6 +431,7 @@ namespace BusBuddy.WPF
                 services.AddScoped<IStudentService, StudentService>();
                 services.AddScoped<BusBuddy.Core.Services.Interfaces.IDestinationService, BusBuddy.Core.Services.DestinationService>();
                 services.AddScoped<BusBuddy.Core.Services.IStudentSchoolTransferService, BusBuddy.Core.Services.StudentSchoolTransferService>();
+                services.AddScoped<BusBuddy.Core.Services.IRouteWaypointRebuildService, BusBuddy.Core.Services.RouteWaypointRebuildService>();
                 services.AddScoped<BusBuddy.Core.Services.IDriverTrainingService, BusBuddy.Core.Services.DriverTrainingService>();
                 services.AddScoped<IDriverService, DriverService>();
                 services.AddScoped<IRouteService, RouteService>();

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -431,6 +431,7 @@ namespace BusBuddy.WPF
                 services.AddScoped<IStudentService, StudentService>();
                 services.AddScoped<BusBuddy.Core.Services.Interfaces.IDestinationService, BusBuddy.Core.Services.DestinationService>();
                 services.AddScoped<BusBuddy.Core.Services.IStudentSchoolTransferService, BusBuddy.Core.Services.StudentSchoolTransferService>();
+                services.AddScoped<BusBuddy.Core.Services.IDriverTrainingService, BusBuddy.Core.Services.DriverTrainingService>();
                 services.AddScoped<IDriverService, DriverService>();
                 services.AddScoped<IRouteService, RouteService>();
                 services.AddScoped<BusBuddy.Core.Services.Interfaces.IBusService, BusService>();

--- a/BusBuddy.WPF/ViewModels/Driver/DriverTrainingChecklistViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Driver/DriverTrainingChecklistViewModel.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using BusBuddy.Core.Models;
+using BusBuddy.Core.Services;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+
+namespace BusBuddy.WPF.ViewModels.Driver;
+
+/// <summary>Editable CDE training checklist grid for one driver.</summary>
+public sealed class DriverTrainingChecklistViewModel : BaseViewModel
+{
+    private static readonly new ILogger Logger = Log.ForContext<DriverTrainingChecklistViewModel>();
+    private readonly IDriverTrainingService _trainingService;
+    private readonly int _driverId;
+    private readonly string _driverName;
+    private DriverTrainingRecord? _selectedRecord;
+
+    public event EventHandler? Closed;
+
+    public DriverTrainingChecklistViewModel(int driverId, string driverName, IDriverTrainingService trainingService)
+    {
+        _driverId = driverId;
+        _driverName = driverName;
+        _trainingService = trainingService ?? throw new ArgumentNullException(nameof(trainingService));
+        Records = new ObservableCollection<DriverTrainingRecord>();
+        RefreshCommand = new AsyncRelayCommand(LoadAsync);
+        MarkCompleteCommand = new AsyncRelayCommand(MarkCompleteAsync, () => SelectedRecord is not null);
+        SaveRowCommand = new AsyncRelayCommand(SaveSelectedAsync, () => SelectedRecord is not null);
+        IncludeOptionalCommand = new AsyncRelayCommand(() => LoadAsync(includeOptional: true));
+        CloseCommand = new RelayCommand(() => Closed?.Invoke(this, EventArgs.Empty));
+        _ = LoadAsync();
+    }
+
+    public string Title => $"CDE Training — {_driverName}";
+
+    public ObservableCollection<DriverTrainingRecord> Records { get; }
+
+    public DriverTrainingRecord? SelectedRecord
+    {
+        get => _selectedRecord;
+        set
+        {
+            if (SetProperty(ref _selectedRecord, value))
+            {
+                (MarkCompleteCommand as IRelayCommand)?.NotifyCanExecuteChanged();
+                (SaveRowCommand as IRelayCommand)?.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    public ICommand RefreshCommand { get; }
+    public ICommand MarkCompleteCommand { get; }
+    public ICommand SaveRowCommand { get; }
+    public ICommand IncludeOptionalCommand { get; }
+    public ICommand CloseCommand { get; }
+
+    private async Task LoadAsync() => await LoadAsync(includeOptional: false);
+
+    private async Task LoadAsync(bool includeOptional)
+    {
+        try
+        {
+            IsLoading = true;
+            var list = await _trainingService.EnsureMatrixChecklistAsync(_driverId, includeOptional);
+            await _trainingService.RefreshTrainingCompleteFlagAsync(_driverId);
+            Records.Clear();
+            foreach (var row in list)
+            {
+                Records.Add(row);
+            }
+
+            var required = list.Count(r => r.IsRequired && r.IsApplicable);
+            var complete = list.Count(r => r.IsRequired && r.IsApplicable && r.IsComplete && !r.IsExpired);
+            StatusMessage = $"{complete}/{required} required current";
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed loading training checklist DriverId={DriverId}", _driverId);
+            StatusMessage = ex.Message;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private async Task MarkCompleteAsync()
+    {
+        if (SelectedRecord is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _trainingService.UpsertCompletionAsync(
+                _driverId,
+                SelectedRecord.RequirementCode,
+                DateTime.Today,
+                SelectedRecord.ExpiryDate,
+                SelectedRecord.CertificateOrReference,
+                SelectedRecord.Notes);
+            await LoadAsync();
+            StatusMessage = $"Marked {SelectedRecord.RequirementName} complete";
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Mark complete failed");
+            StatusMessage = ex.Message;
+        }
+    }
+
+    private async Task SaveSelectedAsync()
+    {
+        if (SelectedRecord is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var completed = SelectedRecord.CompletedDate ?? DateTime.Today;
+            await _trainingService.UpsertCompletionAsync(
+                _driverId,
+                SelectedRecord.RequirementCode,
+                completed,
+                SelectedRecord.ExpiryDate,
+                SelectedRecord.CertificateOrReference,
+                SelectedRecord.Notes);
+            await LoadAsync();
+            StatusMessage = "Row saved";
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Save training row failed");
+            StatusMessage = ex.Message;
+        }
+    }
+}

--- a/BusBuddy.WPF/ViewModels/Driver/DriversViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Driver/DriversViewModel.cs
@@ -28,6 +28,7 @@ namespace BusBuddy.WPF.ViewModels.Driver
         private readonly IBusBuddyDbContextFactory _contextFactory;
         private readonly IDriverService? _driverService;
         private readonly IOperationalReportService? _reportService;
+        private readonly IDriverTrainingService? _trainingService;
 
     private Core.Models.Driver? _selectedDriver;
         private string _searchText = string.Empty;
@@ -187,7 +188,8 @@ namespace BusBuddy.WPF.ViewModels.Driver
             : this(
                 App.ServiceProvider?.GetService<IBusBuddyDbContextFactory>() ?? new BusBuddyDbContextFactory(),
                 App.ServiceProvider?.GetService<IDriverService>(),
-                App.ServiceProvider?.GetService<IOperationalReportService>())
+                App.ServiceProvider?.GetService<IOperationalReportService>(),
+                App.ServiceProvider?.GetService<IDriverTrainingService>())
         {
         }
 
@@ -197,11 +199,13 @@ namespace BusBuddy.WPF.ViewModels.Driver
         public DriversViewModel(
             IBusBuddyDbContextFactory contextFactory,
             IDriverService? driverService = null,
-            IOperationalReportService? reportService = null)
+            IOperationalReportService? reportService = null,
+            IDriverTrainingService? trainingService = null)
         {
             _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
             _driverService = driverService;
             _reportService = reportService;
+            _trainingService = trainingService;
 
             LoadDriversCommand = new AsyncRelayCommand(LoadDriversAsync);
             AddDriverCommand = new RelayCommand(ExecuteAddDriver);
@@ -215,7 +219,7 @@ namespace BusBuddy.WPF.ViewModels.Driver
             AssignRouteCommand = new AsyncRelayCommand(ExecuteAssignRouteAsync, () => HasSelectedDriver);
             EditDetailsCommand = new RelayCommand(ExecuteEditDetails, () => HasSelectedDriver);
             ViewLicenseCommand = new RelayCommand(ExecuteViewLicense, () => HasSelectedDriver);
-            TrainingHistoryCommand = new RelayCommand(ExecuteTrainingHistory, () => HasSelectedDriver);
+            TrainingHistoryCommand = new AsyncRelayCommand(ExecuteTrainingHistoryAsync, () => HasSelectedDriver);
 
             _ = LoadDriversAsync();
         }
@@ -472,7 +476,7 @@ namespace BusBuddy.WPF.ViewModels.Driver
                 $"status {d.LicenseStatus ?? "?"} expires {expiry} ({days} days)";
         }
 
-        private void ExecuteTrainingHistory()
+        private async Task ExecuteTrainingHistoryAsync()
         {
             if (SelectedDriver is null)
             {
@@ -480,17 +484,48 @@ namespace BusBuddy.WPF.ViewModels.Driver
             }
 
             var d = SelectedDriver;
-            var training = d.TrainingComplete ? "complete" : "incomplete";
-            var bg = d.BackgroundCheckDate?.ToString("yyyy-MM-dd") ?? "not set";
-            var hire = d.HireDate?.ToString("yyyy-MM-dd") ?? "not set";
+            try
+            {
+                if (_trainingService is null)
+                {
+                    var training = d.TrainingComplete ? "complete" : "incomplete";
+                    var hire = d.HireDate?.ToString("yyyy-MM-dd") ?? "not set";
+                    base.StatusMessage =
+                        $"{d.DriverName}: training {training}; hire {hire} (training service unavailable)";
+                    return;
+                }
 
-            Logger.Information(
-                "Training history DriverId={DriverId} TrainingComplete={TrainingComplete}",
-                d.DriverId,
-                d.TrainingComplete);
+                var records = await _trainingService.EnsureMatrixChecklistAsync(d.DriverId);
+                await _trainingService.RefreshTrainingCompleteFlagAsync(d.DriverId);
 
-            base.StatusMessage =
-                $"{d.DriverName}: training {training}; hire {hire}; background check {bg}";
+                var required = records.Where(r => r.IsRequired && r.IsApplicable).ToList();
+                var complete = required.Count(r => r.IsComplete && !r.IsExpired);
+                var missing = required.Count - complete;
+                var expiring = records.Count(r => r.IsExpiringSoon);
+
+                Logger.Information(
+                    "CDE training checklist DriverId={DriverId} Required={Required} Complete={Complete} Missing={Missing}",
+                    d.DriverId,
+                    required.Count,
+                    complete,
+                    missing);
+
+                base.StatusMessage =
+                    $"{d.DriverName}: CDE checklist {complete}/{required.Count} current" +
+                    (missing > 0 ? $", {missing} missing/expired" : string.Empty) +
+                    (expiring > 0 ? $", {expiring} expiring ≤30d" : string.Empty) +
+                    $"; hire {d.HireDate?.ToString("yyyy-MM-dd") ?? "not set"}" +
+                    (string.IsNullOrWhiteSpace(d.EmployingDistrict) ? string.Empty : $"; {d.EmployingDistrict}");
+
+                // Refresh list so TrainingComplete flag shows updates
+                await LoadDriversAsync();
+                SelectedDriver = Drivers.FirstOrDefault(x => x.DriverId == d.DriverId);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed loading CDE training for driver {DriverId}", d.DriverId);
+                base.StatusMessage = $"Training checklist error: {ex.Message}";
+            }
         }
 
         private async Task GenerateDriverReportAsync(OperationalReportKind kind, string label)

--- a/BusBuddy.WPF/ViewModels/Driver/DriversViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Driver/DriversViewModel.cs
@@ -392,6 +392,12 @@ namespace BusBuddy.WPF.ViewModels.Driver
 
         private async Task ExecuteTrainingRecordsAsync()
         {
+            if (SelectedDriver is not null)
+            {
+                OpenTrainingChecklist(SelectedDriver);
+                return;
+            }
+
             SelectedStatusFilter = "Training";
             var incomplete = Drivers.Count(d => !d.TrainingComplete);
             Logger.Information("Training records: {Incomplete} incomplete of {Total}", incomplete, Drivers.Count);
@@ -483,47 +489,46 @@ namespace BusBuddy.WPF.ViewModels.Driver
                 return;
             }
 
-            var d = SelectedDriver;
+            OpenTrainingChecklist(SelectedDriver);
+            await Task.CompletedTask;
+        }
+
+        private void OpenTrainingChecklist(Core.Models.Driver driver)
+        {
             try
             {
-                if (_trainingService is null)
+                var training = _trainingService
+                    ?? App.ServiceProvider?.GetService<IDriverTrainingService>();
+                if (training is null)
                 {
-                    var training = d.TrainingComplete ? "complete" : "incomplete";
-                    var hire = d.HireDate?.ToString("yyyy-MM-dd") ?? "not set";
-                    base.StatusMessage =
-                        $"{d.DriverName}: training {training}; hire {hire} (training service unavailable)";
+                    base.StatusMessage = "Training service unavailable";
                     return;
                 }
 
-                var records = await _trainingService.EnsureMatrixChecklistAsync(d.DriverId);
-                await _trainingService.RefreshTrainingCompleteFlagAsync(d.DriverId);
+                var vm = new DriverTrainingChecklistViewModel(
+                    driver.DriverId,
+                    driver.DriverName ?? $"Driver {driver.DriverId}",
+                    training);
+                var dialog = new BusBuddy.WPF.Views.Driver.DriverTrainingChecklistView(vm);
+                try
+                {
+                    var owner = System.Windows.Application.Current?.Windows
+                        .OfType<System.Windows.Window>()
+                        .FirstOrDefault(w => w.IsActive)
+                        ?? System.Windows.Application.Current?.MainWindow;
+                    if (owner != null)
+                    {
+                        dialog.Owner = owner;
+                    }
+                }
+                catch { /* owner optional */ }
 
-                var required = records.Where(r => r.IsRequired && r.IsApplicable).ToList();
-                var complete = required.Count(r => r.IsComplete && !r.IsExpired);
-                var missing = required.Count - complete;
-                var expiring = records.Count(r => r.IsExpiringSoon);
-
-                Logger.Information(
-                    "CDE training checklist DriverId={DriverId} Required={Required} Complete={Complete} Missing={Missing}",
-                    d.DriverId,
-                    required.Count,
-                    complete,
-                    missing);
-
-                base.StatusMessage =
-                    $"{d.DriverName}: CDE checklist {complete}/{required.Count} current" +
-                    (missing > 0 ? $", {missing} missing/expired" : string.Empty) +
-                    (expiring > 0 ? $", {expiring} expiring ≤30d" : string.Empty) +
-                    $"; hire {d.HireDate?.ToString("yyyy-MM-dd") ?? "not set"}" +
-                    (string.IsNullOrWhiteSpace(d.EmployingDistrict) ? string.Empty : $"; {d.EmployingDistrict}");
-
-                // Refresh list so TrainingComplete flag shows updates
-                await LoadDriversAsync();
-                SelectedDriver = Drivers.FirstOrDefault(x => x.DriverId == d.DriverId);
+                dialog.ShowDialog();
+                _ = LoadDriversAsync();
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, "Failed loading CDE training for driver {DriverId}", d.DriverId);
+                Logger.Error(ex, "Failed opening training checklist DriverId={DriverId}", driver.DriverId);
                 base.StatusMessage = $"Training checklist error: {ex.Message}";
             }
         }

--- a/BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs
@@ -18,6 +18,7 @@ using System.Linq; // For LINQ operations
 using System.Windows.Media; // For VisualTreeHelper during snapshot
 using System.Windows.Media.Imaging; // For RenderTargetBitmap / PngBitmapEncoder (Microsoft WPF docs: Imaging)
 using System.IO; // For saving generated eligibility PDF to disk
+using BusBuddy.WPF;
 
 namespace BusBuddy.WPF.ViewModels.GoogleEarth
 {
@@ -745,17 +746,34 @@ namespace BusBuddy.WPF.ViewModels.GoogleEarth
             }
         }
 
-        private void ShowSchools()
+        private async void ShowSchools()
         {
             StatusMessage = "Showing schools on map...";
             Logger.Information("Show schools requested");
             try
             {
-                if (!MapMarkers.Any(m => m.Label != null && m.Label.Contains("School", StringComparison.OrdinalIgnoreCase)))
+                using var scope = _scopeFactory?.CreateScope();
+                var destService = scope?.ServiceProvider.GetService<IDestinationService>()
+                    ?? App.ServiceProvider?.GetService<IDestinationService>();
+
+                var schools = destService is not null
+                    ? await destService.GetActiveSchoolsAsync()
+                    : Array.Empty<Destination>();
+
+                var plotted = 0;
+                foreach (var school in schools.Where(s => s.HasGpsCoordinates))
                 {
-                    PlotStop(WileyMapDefaults.SchoolLatitude, WileyMapDefaults.SchoolLongitude, null, WileyMapDefaults.SchoolLabel);
+                    PlotStop((double)school.Latitude!, (double)school.Longitude!, null, school.Name);
+                    plotted++;
                 }
 
+                if (plotted == 0)
+                {
+                    PlotStop(WileyMapDefaults.SchoolLatitude, WileyMapDefaults.SchoolLongitude, null, WileyMapDefaults.SchoolLabel);
+                    plotted = 1;
+                }
+
+                StatusMessage = $"Showing {plotted} school(s) on map";
                 ViewResetRequested?.Invoke(this, EventArgs.Empty);
             }
             catch (Exception ex)

--- a/BusBuddy.WPF/ViewModels/Student/StudentFormViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Student/StudentFormViewModel.cs
@@ -75,6 +75,7 @@ namespace BusBuddy.WPF.ViewModels.Student
 
             AvailableRoutes = new ObservableCollection<string>();
             AvailableBusStops = new ObservableCollection<string>();
+            AvailableSchools = new ObservableCollection<Destination>();
 
             try { _student.PropertyChanged += OnStudentPropertyChanged; } catch { }
             InitializeCommands();
@@ -106,6 +107,7 @@ namespace BusBuddy.WPF.ViewModels.Student
 
             AvailableRoutes = new ObservableCollection<string>();
             AvailableBusStops = new ObservableCollection<string>();
+            AvailableSchools = new ObservableCollection<Destination>();
 
             try { _student.PropertyChanged += OnStudentPropertyChanged; } catch { }
             InitializeCommands();
@@ -182,6 +184,32 @@ namespace BusBuddy.WPF.ViewModels.Student
         /// Available bus stop names for assignment
         /// </summary>
         public ObservableCollection<string> AvailableBusStops { get; }
+
+        /// <summary>Active school Destinations for intake assignment (home-to-school routing).</summary>
+        public ObservableCollection<Destination> AvailableSchools { get; }
+
+        private Destination? _selectedSchoolDestination;
+
+        /// <summary>Selected campus; syncs <see cref="Student.School"/> and <see cref="Student.DestinationId"/>.</summary>
+        public Destination? SelectedSchoolDestination
+        {
+            get => _selectedSchoolDestination;
+            set
+            {
+                if (!SetProperty(ref _selectedSchoolDestination, value))
+                {
+                    return;
+                }
+
+                if (value is null)
+                {
+                    return;
+                }
+
+                Student.School = value.Name;
+                Student.DestinationId = value.DestinationId;
+            }
+        }
 
         /// <summary>
         /// Whether form is in edit mode (vs add mode)
@@ -1029,12 +1057,54 @@ namespace BusBuddy.WPF.ViewModels.Student
                     AvailableBusStops.Add(stop);
                 }
 
-                Logger.Information("Loaded {RouteCount} routes and {StopCount} bus stops",
-                    AvailableRoutes.Count, AvailableBusStops.Count);
+                await LoadSchoolsAsync();
+
+                Logger.Information("Form data loaded: {RouteCount} routes, {BusStopCount} bus stops, {SchoolCount} schools",
+                    AvailableRoutes.Count, AvailableBusStops.Count, AvailableSchools.Count);
             }
             catch (Exception ex)
             {
                 Logger.Error(ex, "Error loading form data");
+            }
+        }
+
+        private async Task LoadSchoolsAsync()
+        {
+            AvailableSchools.Clear();
+            try
+            {
+                var destService = App.ServiceProvider?.GetService<IDestinationService>();
+                IReadOnlyList<Destination> schools;
+                if (destService is not null)
+                {
+                    schools = await destService.GetActiveSchoolsAsync();
+                }
+                else
+                {
+                    schools = await _context.Destinations
+                        .Where(d => d.IsActive && !d.IsDeleted && d.DestinationType == DestinationTypes.School)
+                        .OrderBy(d => d.Name)
+                        .ToListAsync();
+                }
+
+                foreach (var school in schools)
+                {
+                    AvailableSchools.Add(school);
+                }
+
+                if (Student.DestinationId.HasValue)
+                {
+                    SelectedSchoolDestination = AvailableSchools.FirstOrDefault(s => s.DestinationId == Student.DestinationId.Value);
+                }
+                else if (!string.IsNullOrWhiteSpace(Student.School))
+                {
+                    SelectedSchoolDestination = AvailableSchools.FirstOrDefault(s =>
+                        string.Equals(s.Name, Student.School, StringComparison.OrdinalIgnoreCase));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Failed to load school destinations — intake school dropdown may be empty");
             }
         }
 

--- a/BusBuddy.WPF/ViewModels/Student/StudentFormViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Student/StudentFormViewModel.cs
@@ -190,7 +190,7 @@ namespace BusBuddy.WPF.ViewModels.Student
 
         private Destination? _selectedSchoolDestination;
 
-        /// <summary>Selected campus; syncs <see cref="Student.School"/> and <see cref="Student.DestinationId"/>.</summary>
+        /// <summary>Selected campus; syncs Student.School and Student.DestinationId.</summary>
         public Destination? SelectedSchoolDestination
         {
             get => _selectedSchoolDestination;

--- a/BusBuddy.WPF/ViewModels/Student/StudentSchoolTransferViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Student/StudentSchoolTransferViewModel.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using BusBuddy.Core.Models;
+using BusBuddy.Core.Services;
+using BusBuddy.Core.Services.Interfaces;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+
+namespace BusBuddy.WPF.ViewModels.Student;
+
+/// <summary>School-to-school transfer dialog — pickup/dropoff locations and times required.</summary>
+public sealed class StudentSchoolTransferViewModel : BaseViewModel
+{
+    private static readonly new ILogger Logger = Log.ForContext<StudentSchoolTransferViewModel>();
+
+    private readonly IStudentSchoolTransferService _transferService;
+    private readonly IDestinationService _destinationService;
+    private readonly int _studentId;
+    private readonly string _studentName;
+
+    private Destination? _fromSchool;
+    private Destination? _toSchool;
+    private string _pickupAddress = string.Empty;
+    private string _dropoffAddress = string.Empty;
+    private string _pickupTimeText = "07:15";
+    private string _dropoffTimeText = "07:45";
+    private string _notes = string.Empty;
+    private string _validationMessage = string.Empty;
+
+    public event EventHandler<bool?>? RequestClose;
+
+    public StudentSchoolTransferViewModel(
+        int studentId,
+        string studentName,
+        IStudentSchoolTransferService transferService,
+        IDestinationService destinationService)
+    {
+        _studentId = studentId;
+        _studentName = studentName;
+        _transferService = transferService ?? throw new ArgumentNullException(nameof(transferService));
+        _destinationService = destinationService ?? throw new ArgumentNullException(nameof(destinationService));
+
+        Schools = new ObservableCollection<Destination>();
+        SaveCommand = new AsyncRelayCommand(SaveAsync, () => CanSave);
+        CancelCommand = new RelayCommand(() => RequestClose?.Invoke(this, false));
+        _ = LoadSchoolsAsync();
+    }
+
+    public string Title => $"School Transfer — {_studentName}";
+
+    public ObservableCollection<Destination> Schools { get; }
+
+    public Destination? FromSchool
+    {
+        get => _fromSchool;
+        set
+        {
+            if (SetProperty(ref _fromSchool, value))
+            {
+                if (value is not null && string.IsNullOrWhiteSpace(PickupAddress))
+                {
+                    PickupAddress = value.FullAddress;
+                }
+
+                NotifySave();
+            }
+        }
+    }
+
+    public Destination? ToSchool
+    {
+        get => _toSchool;
+        set
+        {
+            if (SetProperty(ref _toSchool, value))
+            {
+                if (value is not null && string.IsNullOrWhiteSpace(DropoffAddress))
+                {
+                    DropoffAddress = value.FullAddress;
+                }
+
+                NotifySave();
+            }
+        }
+    }
+
+    public string PickupAddress
+    {
+        get => _pickupAddress;
+        set
+        {
+            if (SetProperty(ref _pickupAddress, value))
+            {
+                NotifySave();
+            }
+        }
+    }
+
+    public string DropoffAddress
+    {
+        get => _dropoffAddress;
+        set
+        {
+            if (SetProperty(ref _dropoffAddress, value))
+            {
+                NotifySave();
+            }
+        }
+    }
+
+    public string PickupTimeText
+    {
+        get => _pickupTimeText;
+        set
+        {
+            if (SetProperty(ref _pickupTimeText, value))
+            {
+                NotifySave();
+            }
+        }
+    }
+
+    public string DropoffTimeText
+    {
+        get => _dropoffTimeText;
+        set
+        {
+            if (SetProperty(ref _dropoffTimeText, value))
+            {
+                NotifySave();
+            }
+        }
+    }
+
+    public string Notes
+    {
+        get => _notes;
+        set => SetProperty(ref _notes, value);
+    }
+
+    public string ValidationMessage
+    {
+        get => _validationMessage;
+        set => SetProperty(ref _validationMessage, value);
+    }
+
+    public bool CanSave =>
+        FromSchool is not null &&
+        ToSchool is not null &&
+        FromSchool.DestinationId != ToSchool.DestinationId &&
+        !string.IsNullOrWhiteSpace(PickupAddress) &&
+        !string.IsNullOrWhiteSpace(DropoffAddress) &&
+        TryParseTime(PickupTimeText, out _) &&
+        TryParseTime(DropoffTimeText, out var drop) &&
+        TryParseTime(PickupTimeText, out var pick) &&
+        drop > pick;
+
+    public ICommand SaveCommand { get; }
+    public ICommand CancelCommand { get; }
+
+    private async Task LoadSchoolsAsync()
+    {
+        try
+        {
+            IsLoading = true;
+            var schools = await _destinationService.GetActiveSchoolsAsync();
+            Schools.Clear();
+            foreach (var s in schools)
+            {
+                Schools.Add(s);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed loading schools for transfer");
+            ValidationMessage = ex.Message;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        ValidationMessage = string.Empty;
+        if (!CanSave || FromSchool is null || ToSchool is null)
+        {
+            ValidationMessage = "From/To schools, pickup & dropoff locations, and times (dropoff after pickup) are required.";
+            return;
+        }
+
+        if (!TryParseTime(PickupTimeText, out var pickup) || !TryParseTime(DropoffTimeText, out var dropoff))
+        {
+            ValidationMessage = "Use time format HH:mm (e.g. 07:15).";
+            return;
+        }
+
+        try
+        {
+            IsLoading = true;
+            await _transferService.AssignTransferAsync(new StudentSchoolTransfer
+            {
+                StudentId = _studentId,
+                FromDestinationId = FromSchool.DestinationId,
+                ToDestinationId = ToSchool.DestinationId,
+                PickupAddress = PickupAddress.Trim(),
+                DropoffAddress = DropoffAddress.Trim(),
+                PickupTime = pickup,
+                DropoffTime = dropoff,
+                EffectiveDate = DateTime.Today,
+                Notes = string.IsNullOrWhiteSpace(Notes) ? null : Notes.Trim(),
+                CreatedBy = Environment.UserName
+            });
+            StatusMessage = "Transfer saved";
+            RequestClose?.Invoke(this, true);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed assigning school transfer");
+            ValidationMessage = ex.Message;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private void NotifySave()
+    {
+        OnPropertyChanged(nameof(CanSave));
+        if (SaveCommand is IRelayCommand relay)
+        {
+            relay.NotifyCanExecuteChanged();
+        }
+    }
+
+    private static bool TryParseTime(string? text, out TimeSpan time)
+    {
+        time = default;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        return TimeSpan.TryParseExact(
+                   text.Trim(),
+                   new[] { @"h\:mm", @"hh\:mm", @"h\:mm\:ss", @"hh\:mm\:ss" },
+                   CultureInfo.InvariantCulture,
+                   out time)
+               || TimeSpan.TryParse(text.Trim(), CultureInfo.InvariantCulture, out time);
+    }
+}

--- a/BusBuddy.WPF/ViewModels/Student/StudentsViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Student/StudentsViewModel.cs
@@ -1232,12 +1232,36 @@ namespace BusBuddy.WPF.ViewModels.Student
 
                 using var context = _contextFactory.CreateDbContext();
                 AvailableSchools.Clear();
-                var schools = await context.Students
+                var schoolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                try
+                {
+                    var destService = App.ServiceProvider?.GetService<IDestinationService>();
+                    var destinations = destService is not null
+                        ? await destService.GetActiveSchoolsAsync()
+                        : await context.Destinations
+                            .Where(d => d.IsActive && !d.IsDeleted && d.DestinationType == DestinationTypes.School)
+                            .ToListAsync();
+                    foreach (var d in destinations)
+                    {
+                        schoolNames.Add(d.Name);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(ex, "Destination school catalog unavailable — falling back to student.School values");
+                }
+
+                var fromStudents = await context.Students
                     .Where(s => !string.IsNullOrEmpty(s.School))
                     .Select(s => s.School!)
                     .Distinct()
                     .ToListAsync();
-                foreach (var school in schools)
+                foreach (var school in fromStudents)
+                {
+                    schoolNames.Add(school);
+                }
+
+                foreach (var school in schoolNames.OrderBy(s => s))
                 {
                     AvailableSchools.Add(school);
                 }

--- a/BusBuddy.WPF/ViewModels/Student/StudentsViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Student/StudentsViewModel.cs
@@ -180,6 +180,7 @@ namespace BusBuddy.WPF.ViewModels.Student
                     _deleteStudentRelay?.NotifyCanExecuteChanged();
                     _validateAddressRelay?.NotifyCanExecuteChanged();
                     _bulkAssignRouteRelay?.NotifyCanExecuteChanged();
+                    _schoolTransferRelay?.NotifyCanExecuteChanged();
             Logger.Debug("Selection-dependent commands invalidated (CanExecute re-evaluated)");
                 }
             }
@@ -281,6 +282,7 @@ namespace BusBuddy.WPF.ViewModels.Student
                     _deleteStudentRelay?.NotifyCanExecuteChanged();
                     _validateAddressRelay?.NotifyCanExecuteChanged();
                     _bulkAssignRouteRelay?.NotifyCanExecuteChanged();
+                    _schoolTransferRelay?.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -320,8 +322,10 @@ namespace BusBuddy.WPF.ViewModels.Student
         public ICommand SuggestRouteCommand { get; private set; } = null!;
         public ICommand ShowSummaryCommand { get; private set; } = null!;
         public ICommand ShowQuickActionsCommand { get; private set; } = null!;
-    public ICommand PlotStudentsCommand { get; private set; } = null!;
+        public ICommand PlotStudentsCommand { get; private set; } = null!;
     public ICommand SaveGridEditsCommand { get; private set; } = null!; // Inline save for grid edits
+        public ICommand SchoolTransferCommand { get; private set; } = null!;
+        private RelayCommand? _schoolTransferRelay;
 
         #endregion
 
@@ -355,8 +359,10 @@ namespace BusBuddy.WPF.ViewModels.Student
             ShowQuickActionsCommand = new RelayCommand(ExecuteShowQuickActions);
             PlotStudentsCommand = new RelayCommand(ExecutePlotStudents);
             SaveGridEditsCommand = new AsyncRelayCommand(SaveInlineGridEditsAsync);
+            _schoolTransferRelay = new RelayCommand(ExecuteSchoolTransfer, () => HasSelectedStudent);
+            SchoolTransferCommand = _schoolTransferRelay;
 
-            Logger.Debug("Commands initialized: Add/Edit/Delete/Import/BulkAssign/Optimize/ViewMap/ViewOnMap/Suggest/Validate/Refresh/Export/ShowSummary/ShowQuickActions/Plot");
+            Logger.Debug("Commands initialized: Add/Edit/Delete/Import/BulkAssign/Optimize/ViewMap/ViewOnMap/Suggest/Validate/Refresh/Export/ShowSummary/ShowQuickActions/Plot/SchoolTransfer");
         }
 
         #endregion
@@ -441,6 +447,60 @@ namespace BusBuddy.WPF.ViewModels.Student
                 StatusMessage = $"Error editing student: {ex.Message}";
             }
         }
+
+    /// <summary>
+    /// Opens school-to-school transfer dialog (pickup/dropoff locations + times required).
+    /// </summary>
+    private void ExecuteSchoolTransfer()
+    {
+        try
+        {
+            if (SelectedStudent is null)
+            {
+                return;
+            }
+
+            var sp = App.ServiceProvider;
+            var transferService = sp?.GetService<IStudentSchoolTransferService>();
+            var destinationService = sp?.GetService<IDestinationService>();
+            if (transferService is null || destinationService is null)
+            {
+                StatusMessage = "Transfer services unavailable";
+                Logger.Warning("School transfer skipped — services not registered");
+                return;
+            }
+
+            var vm = new StudentSchoolTransferViewModel(
+                SelectedStudent.StudentId,
+                SelectedStudent.StudentName ?? $"Student {SelectedStudent.StudentId}",
+                transferService,
+                destinationService);
+            var dialog = new BusBuddy.WPF.Views.Student.StudentSchoolTransferForm(vm);
+            try
+            {
+                var owner = System.Windows.Application.Current?.Windows
+                    .OfType<System.Windows.Window>()
+                    .FirstOrDefault(w => w.IsActive)
+                    ?? System.Windows.Application.Current?.MainWindow;
+                if (owner != null)
+                {
+                    dialog.Owner = owner;
+                }
+            }
+            catch { /* owner optional */ }
+
+            if (dialog.ShowDialog() == true)
+            {
+                _ = LoadStudentsAsync();
+                StatusMessage = $"School transfer saved for {SelectedStudent.StudentName}";
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Error opening school transfer");
+            StatusMessage = $"Transfer error: {ex.Message}";
+        }
+    }
 
     /// <summary>
     /// Only enabled when a student is selected.

--- a/BusBuddy.WPF/Views/Driver/DriverForm.xaml
+++ b/BusBuddy.WPF/Views/Driver/DriverForm.xaml
@@ -99,6 +99,8 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <StackPanel Grid.Row="0"
                                 Grid.Column="0">
@@ -147,6 +149,47 @@
                     <StackPanel Grid.Row="2"
                                 Grid.Column="0"
                                 Grid.ColumnSpan="3">
+                        <TextBlock Text="Address:"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:SfMaskedEdit Text="{Binding Driver.Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 Style="{StaticResource FieldInputStyle}"
+                                                 AutomationProperties.Name="Driver Address"
+                                                 AutomationProperties.HelpText="Enter street address" />
+                    </StackPanel>
+                    <StackPanel Grid.Row="3"
+                                Grid.Column="0">
+                        <TextBlock Text="City:"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:SfMaskedEdit Text="{Binding Driver.City, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 Style="{StaticResource FieldInputStyle}"
+                                                 AutomationProperties.Name="City"
+                                                 AutomationProperties.HelpText="Enter city" />
+                    </StackPanel>
+                    <StackPanel Grid.Row="3"
+                                Grid.Column="2">
+                        <TextBlock Text="State / ZIP:"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="80" />
+                                <ColumnDefinition Width="10" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <syncfusion:SfMaskedEdit Grid.Column="0"
+                                                     Text="{Binding Driver.State, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     Style="{StaticResource FieldInputStyle}"
+                                                     AutomationProperties.Name="State"
+                                                     AutomationProperties.HelpText="State abbreviation" />
+                            <syncfusion:SfMaskedEdit Grid.Column="2"
+                                                     Text="{Binding Driver.Zip, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     Style="{StaticResource FieldInputStyle}"
+                                                     AutomationProperties.Name="ZIP"
+                                                     AutomationProperties.HelpText="ZIP code" />
+                        </Grid>
+                    </StackPanel>
+                    <StackPanel Grid.Row="4"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="3">
                         <TextBlock Text="Status:"
                                    Style="{StaticResource FieldLabelStyle}" />
                         <syncfusion:ComboBoxAdv Height="32"
@@ -163,8 +206,111 @@
                     </StackPanel>
                 </Grid>
             </GroupBox>
-            <!-- License Information Section -->
+            <!-- School employment / CDE matrix category -->
             <GroupBox Grid.Row="2"
+                      Header="School Employment"
+                      Margin="0,0,0,15"
+                      Padding="15">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="10" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <StackPanel Grid.Row="0"
+                                Grid.Column="0">
+                        <TextBlock Text="Employing School / District:"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:SfMaskedEdit Text="{Binding Driver.EmployingDistrict, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 Style="{StaticResource FieldInputStyle}"
+                                                 AutomationProperties.Name="Employing District"
+                                                 AutomationProperties.HelpText="School or district employer" />
+                    </StackPanel>
+                    <StackPanel Grid.Row="0"
+                                Grid.Column="2">
+                        <TextBlock Text="Hire Date:"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:SfDatePicker Value="{Binding Driver.HireDate, Mode=TwoWay}"
+                                                 Height="32"
+                                                 Margin="0,0,0,10"
+                                                 AutomationProperties.Name="Hire Date"
+                                                 AutomationProperties.HelpText="Employment start date" />
+                    </StackPanel>
+                    <StackPanel Grid.Row="1"
+                                Grid.Column="0">
+                        <TextBlock Text="Employment End Date:"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:SfDatePicker Value="{Binding Driver.EmploymentEndDate, Mode=TwoWay}"
+                                                 Height="32"
+                                                 Margin="0,0,0,10"
+                                                 AutomationProperties.Name="Employment End Date"
+                                                 AutomationProperties.HelpText="Leave blank if currently employed" />
+                    </StackPanel>
+                    <StackPanel Grid.Row="1"
+                                Grid.Column="2">
+                        <TextBlock Text="Duty Category:"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:ComboBoxAdv Height="32"
+                                                SelectedItem="{Binding Driver.DutyCategory, Mode=TwoWay}"
+                                                Margin="0,0,0,10"
+                                                AutomationProperties.Name="Duty Category"
+                                                AutomationProperties.HelpText="Route or Activity per CDE matrix">
+                            <ComboBoxItem Content="Route" />
+                            <ComboBoxItem Content="Activity" />
+                        </syncfusion:ComboBoxAdv>
+                    </StackPanel>
+                    <StackPanel Grid.Row="2"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="3">
+                        <TextBlock Text="Vehicle Category (CDE matrix):"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:ComboBoxAdv Height="32"
+                                                SelectedItem="{Binding Driver.VehicleCategory, Mode=TwoWay}"
+                                                Margin="0,0,0,10"
+                                                AutomationProperties.Name="Vehicle Category"
+                                                AutomationProperties.HelpText="CDE 2024-25 license/training matrix column">
+                            <ComboBoxItem Content="Route_16+_GVWR_GT_26001" />
+                            <ComboBoxItem Content="Route_16+_GVWR_LT_26001" />
+                            <ComboBoxItem Content="Route_TypeA_15_or_less" />
+                            <ComboBoxItem Content="Activity_MF_16+_GVWR_GT_26001" />
+                            <ComboBoxItem Content="Activity_MF_16+_GVWR_LT_26001" />
+                            <ComboBoxItem Content="Activity_TypeA_MF_15_or_less" />
+                            <ComboBoxItem Content="Activity_LT_12_passengers" />
+                            <ComboBoxItem Content="Activity_Motorcoach_16+_GVWR_GT_26001" />
+                        </syncfusion:ComboBoxAdv>
+                    </StackPanel>
+                    <StackPanel Grid.Row="3"
+                                Grid.Column="0">
+                        <TextBlock Text="CDL Restrictions (e.g. M):"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:SfMaskedEdit Text="{Binding Driver.CdlRestrictions, Mode=TwoWay}"
+                                                 Style="{StaticResource FieldInputStyle}"
+                                                 AutomationProperties.Name="CDL Restrictions"
+                                                 AutomationProperties.HelpText="CDL restriction codes from CDE matrix" />
+                    </StackPanel>
+                    <StackPanel Grid.Row="3"
+                                Grid.Column="2">
+                        <TextBlock Text="Medical Form Type:"
+                                   Style="{StaticResource FieldLabelStyle}" />
+                        <syncfusion:ComboBoxAdv Height="32"
+                                                SelectedItem="{Binding Driver.MedicalFormType, Mode=TwoWay}"
+                                                Margin="0,0,0,10"
+                                                AutomationProperties.Name="Medical Form Type"
+                                                AutomationProperties.HelpText="USDOT Physical or STU-17">
+                            <ComboBoxItem Content="USDOT Physical" />
+                            <ComboBoxItem Content="STU-17" />
+                        </syncfusion:ComboBoxAdv>
+                    </StackPanel>
+                </Grid>
+            </GroupBox>
+            <!-- License Information Section -->
+            <GroupBox Grid.Row="3"
                       Header="License Information"
                       Margin="0,0,0,15"
                       Padding="15">
@@ -225,7 +371,7 @@
                 </Grid>
             </GroupBox>
             <!-- Training and Compliance Section -->
-            <GroupBox Grid.Row="3"
+            <GroupBox Grid.Row="4"
                       Header="Training and Compliance"
                       Margin="0,0,0,15"
                       Padding="15">
@@ -271,7 +417,7 @@
                 </Grid>
             </GroupBox>
             <!-- Emergency Contact Section -->
-            <GroupBox Grid.Row="4"
+            <GroupBox Grid.Row="5"
                       Header="Emergency Contact"
                       Margin="0,0,0,15"
                       Padding="15">
@@ -301,7 +447,7 @@
                 </Grid>
             </GroupBox>
             <!-- Error/Status Display -->
-            <Border Grid.Row="11"
+            <Border Grid.Row="6"
                     Background="{StaticResource BusBuddy.Warning.Background}"
                     BorderBrush="{StaticResource BusBuddy.Warning.Border}"
                     BorderThickness="1"
@@ -314,7 +460,7 @@
                            TextWrapping="Wrap" />
             </Border>
             <!-- Action Buttons -->
-            <StackPanel Grid.Row="12"
+            <StackPanel Grid.Row="7"
                         Orientation="Horizontal"
                         HorizontalAlignment="Right"
                         Margin="0,20,0,0">

--- a/BusBuddy.WPF/Views/Driver/DriverTrainingChecklistView.xaml
+++ b/BusBuddy.WPF/Views/Driver/DriverTrainingChecklistView.xaml
@@ -1,0 +1,106 @@
+<syncfusion:ChromelessWindow x:Class="BusBuddy.WPF.Views.Driver.DriverTrainingChecklistView"
+                             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                             xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+                             Title="{Binding Title}"
+                             Height="640"
+                             Width="960"
+                             WindowStartupLocation="CenterOwner"
+                             ResizeMode="CanResize">
+    <syncfusion:ChromelessWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/BusBuddy.WPF;component/Resources/SyncfusionV30_Validated_ResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </syncfusion:ChromelessWindow.Resources>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0"
+                Background="{DynamicResource BusBuddy.Brush.Primary}"
+                CornerRadius="5"
+                Padding="12"
+                Margin="0,0,0,10">
+            <TextBlock Text="{Binding Title}"
+                       FontSize="16"
+                       FontWeight="Bold"
+                       Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" />
+        </Border>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
+            <syncfusion:ButtonAdv Label="Refresh"
+                                  Command="{Binding RefreshCommand}"
+                                  Margin="0,0,8,0"
+                                  AutomationProperties.Name="Refresh training checklist" />
+            <syncfusion:ButtonAdv Label="Include optional (CSRS / wheelchair / special needs)"
+                                  Command="{Binding IncludeOptionalCommand}"
+                                  Margin="0,0,8,0"
+                                  AutomationProperties.Name="Include optional training" />
+            <syncfusion:ButtonAdv Label="Mark selected complete"
+                                  Command="{Binding MarkCompleteCommand}"
+                                  Margin="0,0,8,0"
+                                  Background="{DynamicResource BusBuddy.Brush.FleetGreen}"
+                                  Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
+                                  AutomationProperties.Name="Mark training complete" />
+            <syncfusion:ButtonAdv Label="Save selected row"
+                                  Command="{Binding SaveRowCommand}"
+                                  AutomationProperties.Name="Save training row" />
+        </StackPanel>
+
+        <syncfusion:SfDataGrid Grid.Row="2"
+                               ItemsSource="{Binding Records}"
+                               SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                               AutoGenerateColumns="False"
+                               AllowEditing="True"
+                               AllowSorting="True"
+                               AllowFiltering="True"
+                               NavigationMode="Row"
+                               AutomationProperties.Name="Driver training checklist">
+            <syncfusion:SfDataGrid.Columns>
+                <syncfusion:GridTextColumn HeaderText="Requirement"
+                                           MappingName="RequirementName"
+                                           Width="260"
+                                           AllowEditing="False" />
+                <syncfusion:GridTextColumn HeaderText="Status"
+                                           MappingName="StatusLabel"
+                                           Width="110"
+                                           AllowEditing="False" />
+                <syncfusion:GridDateTimeColumn HeaderText="Completed"
+                                              MappingName="CompletedDate"
+                                              Width="120"
+                                              Pattern="ShortDate" />
+                <syncfusion:GridDateTimeColumn HeaderText="Expires"
+                                              MappingName="ExpiryDate"
+                                              Width="120"
+                                              Pattern="ShortDate" />
+                <syncfusion:GridTextColumn HeaderText="Certificate / Ref"
+                                           MappingName="CertificateOrReference"
+                                           Width="160" />
+                <syncfusion:GridTextColumn HeaderText="Notes"
+                                           MappingName="Notes"
+                                           Width="200" />
+                <syncfusion:GridCheckBoxColumn HeaderText="Required"
+                                               MappingName="IsRequired"
+                                               Width="80"
+                                               AllowEditing="False" />
+            </syncfusion:SfDataGrid.Columns>
+        </syncfusion:SfDataGrid>
+
+        <DockPanel Grid.Row="3" Margin="0,10,0,0" LastChildFill="True">
+            <syncfusion:ButtonAdv DockPanel.Dock="Right"
+                                  Label="Close"
+                                  Command="{Binding CloseCommand}"
+                                  AutomationProperties.Name="Close training checklist" />
+            <TextBlock Text="{Binding StatusMessage}"
+                       VerticalAlignment="Center"
+                       TextWrapping="Wrap" />
+        </DockPanel>
+    </Grid>
+</syncfusion:ChromelessWindow>

--- a/BusBuddy.WPF/Views/Driver/DriverTrainingChecklistView.xaml.cs
+++ b/BusBuddy.WPF/Views/Driver/DriverTrainingChecklistView.xaml.cs
@@ -1,0 +1,23 @@
+using BusBuddy.WPF.Utilities;
+using BusBuddy.WPF.ViewModels.Driver;
+using Syncfusion.SfSkinManager;
+using Syncfusion.Windows.Shared;
+
+namespace BusBuddy.WPF.Views.Driver;
+
+public partial class DriverTrainingChecklistView : ChromelessWindow
+{
+    public DriverTrainingChecklistView(DriverTrainingChecklistViewModel viewModel)
+    {
+        InitializeComponent();
+        SyncfusionThemeManager.ApplyTheme(this);
+        DataContext = viewModel;
+        viewModel.Closed += (_, _) => Close();
+    }
+
+    protected override void OnClosed(System.EventArgs e)
+    {
+        SfSkinManager.Dispose(this);
+        base.OnClosed(e);
+    }
+}

--- a/BusBuddy.WPF/Views/Student/StudentForm.xaml
+++ b/BusBuddy.WPF/Views/Student/StudentForm.xaml
@@ -274,10 +274,16 @@
 
                         <StackPanel Grid.Row="1" Grid.Column="1" Margin="10,0,0,0">
                             <Label Content="School"/>
-                            <syncfusion:SfTextBoxExt Name="SchoolTextBox"
-                                     Text="{Binding Student.School, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                     Watermark="Optional"
-                                     AutomationProperties.Name="School"/>
+                            <syncfusion:ComboBoxAdv Name="SchoolComboBox"
+                                          ItemsSource="{Binding AvailableSchools}"
+                                          DisplayMemberPath="Name"
+                                          SelectedItem="{Binding SelectedSchoolDestination, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                          IsEditable="True"
+                                          AutomationProperties.Name="School">
+                                <syncfusion:ComboBoxAdv.ToolTip>
+                                    <ToolTip Content="Campus from Destinations (School). Assigns DestinationId for home-to-school routing."/>
+                                </syncfusion:ComboBoxAdv.ToolTip>
+                            </syncfusion:ComboBoxAdv>
                         </StackPanel>
 
                         <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,10,0">
@@ -411,8 +417,8 @@
                     </Grid>
                 </GroupBox>
 
-                <!-- Contact Information -->
-                <GroupBox Header="Contact Information" Margin="0,0,0,15" Padding="15">
+                <!-- Contact Information: primary parent/guardian (distinct from emergency contact) -->
+                <GroupBox Header="Parent / Guardian Contact" Margin="0,0,0,15" Padding="15">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -421,11 +427,19 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <StackPanel Grid.Row="0" Grid.Column="0" Margin="0,0,10,0">
+                        <StackPanel Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,8">
+                            <Label Content="Parent/Guardian Name"/>
+                            <syncfusion:SfTextBoxExt Name="ParentGuardianTextBox"
+                                     Text="{Binding Student.ParentGuardian, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     Watermark="Primary parent or legal guardian"
+                                     AutomationProperties.Name="Parent or Guardian"/>
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,10,0">
                             <Label Content="Home Phone"/>
-                            <!-- Use SfMaskedEdit for US phone number pattern -->
                             <syncfusion:SfMaskedEdit Name="HomePhoneMaskedEdit"
                                        Value="{Binding Student.HomePhone, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                        Mask="(###) ###-####"
@@ -434,22 +448,22 @@
                                        AutomationProperties.Name="Home Phone"/>
                         </StackPanel>
 
-                        <StackPanel Grid.Row="0" Grid.Column="1" Margin="10,0,0,0">
-                            <Label Content="Emergency Phone"/>
-                            <syncfusion:SfMaskedEdit Name="EmergencyPhoneMaskedEdit"
-                                       Value="{Binding Student.EmergencyPhone, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        <StackPanel Grid.Row="1" Grid.Column="1" Margin="10,0,0,0">
+                            <Label Content="Cell Phone"/>
+                            <syncfusion:SfMaskedEdit Name="CellPhoneMaskedEdit"
+                                       Value="{Binding Student.CellPhone, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                        Mask="(###) ###-####"
                                        PromptChar="_"
                                        Watermark="(555) 123-4567 — Optional"
-                                       AutomationProperties.Name="Emergency Phone"/>
+                                       AutomationProperties.Name="Parent Cell Phone"/>
                         </StackPanel>
 
-                        <StackPanel Grid.Row="1" Grid.ColumnSpan="2">
-                            <Label Content="Parent/Guardian"/>
-                            <syncfusion:SfTextBoxExt Name="ParentGuardianTextBox"
-                                     Text="{Binding Student.ParentGuardian, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                     Watermark="Optional"
-                                     AutomationProperties.Name="Parent or Guardian"/>
+                        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Margin="0,8,0,0">
+                            <Label Content="Parent/Guardian Email"/>
+                            <syncfusion:SfTextBoxExt Name="ParentEmailTextBox"
+                                     Text="{Binding Student.ParentEmail, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     Watermark="optional@example.com"
+                                     AutomationProperties.Name="Parent or Guardian Email"/>
                         </StackPanel>
                     </Grid>
                 </GroupBox>
@@ -566,17 +580,18 @@
 
                         <!-- Special Instructions -->
                         <StackPanel Grid.Row="1" Margin="0,10,0,0">
-                            <Label Content="Special Instructions"/>
+                            <Label Content="Special Transportation Instructions"/>
                             <syncfusion:SfTextBoxExt Name="SpecialInstructionsTextBox"
                                        Text="{Binding Student.SpecialInstructions, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                        AcceptsReturn="True"
                                        TextWrapping="Wrap"
                                        Height="60"
                                        VerticalScrollBarVisibility="Auto"
-                                       Watermark="Enter any special transportation instructions... — Optional"/>
+                                       Watermark="Bus-relevant notes only (pickup, equipment, seating). Avoid unrelated medical detail here."
+                                       AutomationProperties.Name="Special Transportation Instructions"/>
                         </StackPanel>
 
-                        <!-- Emergency Contact -->
+                        <!-- Emergency Contact (separate person from primary parent/guardian) -->
                         <Grid Grid.Row="2" Margin="0,10,0,0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
@@ -587,7 +602,8 @@
                                 <Label Content="Emergency Contact Name"/>
                                 <syncfusion:SfTextBoxExt Name="EmergencyContactNameTextBox"
                                            Text="{Binding Student.EmergencyContactName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                           Watermark="Emergency contact full name — Optional"/>
+                                           Watermark="If different from parent/guardian — Recommended"
+                                           AutomationProperties.Name="Emergency Contact Name"/>
                             </StackPanel>
 
                             <StackPanel Grid.Column="1" Margin="10,0,0,0">
@@ -596,7 +612,8 @@
                                            Value="{Binding Student.EmergencyContactPhone, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                            Mask="(###) ###-####"
                                            PromptChar="_"
-                                           Watermark="(555) 123-4567 — Optional"/>
+                                           Watermark="(555) 123-4567 — Recommended"
+                                           AutomationProperties.Name="Emergency Contact Phone"/>
                             </StackPanel>
                         </Grid>
                     </Grid>

--- a/BusBuddy.WPF/Views/Student/StudentSchoolTransferForm.xaml
+++ b/BusBuddy.WPF/Views/Student/StudentSchoolTransferForm.xaml
@@ -1,0 +1,119 @@
+<syncfusion:ChromelessWindow x:Class="BusBuddy.WPF.Views.Student.StudentSchoolTransferForm"
+                             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                             xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+                             Title="{Binding Title}"
+                             Height="560"
+                             Width="640"
+                             WindowStartupLocation="CenterOwner"
+                             ResizeMode="CanResize">
+    <syncfusion:ChromelessWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/BusBuddy.WPF;component/Resources/SyncfusionV30_Validated_ResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </syncfusion:ChromelessWindow.Resources>
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0"
+                Background="{DynamicResource BusBuddy.Brush.Primary}"
+                CornerRadius="5"
+                Padding="15"
+                Margin="0,0,0,15">
+            <TextBlock Text="{Binding Title}"
+                       FontSize="16"
+                       FontWeight="Bold"
+                       Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
+                       TextWrapping="Wrap" />
+        </Border>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <TextBlock Text="From school *" Margin="0,0,0,4" />
+                <syncfusion:ComboBoxAdv ItemsSource="{Binding Schools}"
+                                        SelectedItem="{Binding FromSchool, Mode=TwoWay}"
+                                        DisplayMemberPath="Name"
+                                        Height="32"
+                                        Margin="0,0,0,12"
+                                        AutomationProperties.Name="From school" />
+
+                <TextBlock Text="To school *" Margin="0,0,0,4" />
+                <syncfusion:ComboBoxAdv ItemsSource="{Binding Schools}"
+                                        SelectedItem="{Binding ToSchool, Mode=TwoWay}"
+                                        DisplayMemberPath="Name"
+                                        Height="32"
+                                        Margin="0,0,0,12"
+                                        AutomationProperties.Name="To school" />
+
+                <TextBlock Text="Pickup location *" Margin="0,0,0,4" />
+                <syncfusion:SfMaskedEdit Text="{Binding PickupAddress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Height="32"
+                                         Margin="0,0,0,12"
+                                         AutomationProperties.Name="Pickup location"
+                                         AutomationProperties.HelpText="Required pickup address for the transfer" />
+
+                <TextBlock Text="Dropoff location *" Margin="0,0,0,4" />
+                <syncfusion:SfMaskedEdit Text="{Binding DropoffAddress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Height="32"
+                                         Margin="0,0,0,12"
+                                         AutomationProperties.Name="Dropoff location"
+                                         AutomationProperties.HelpText="Required dropoff address for the transfer" />
+
+                <Grid Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="12" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0">
+                        <TextBlock Text="Requested pickup time (HH:mm) *" Margin="0,0,0,4" />
+                        <syncfusion:SfMaskedEdit Text="{Binding PickupTimeText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 Height="32"
+                                                 Mask="99:99"
+                                                 AutomationProperties.Name="Pickup time" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="2">
+                        <TextBlock Text="Requested dropoff time (HH:mm) *" Margin="0,0,0,4" />
+                        <syncfusion:SfMaskedEdit Text="{Binding DropoffTimeText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 Height="32"
+                                                 Mask="99:99"
+                                                 AutomationProperties.Name="Dropoff time" />
+                    </StackPanel>
+                </Grid>
+
+                <TextBlock Text="Notes" Margin="0,0,0,4" />
+                <TextBox Text="{Binding Notes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         Height="72"
+                         TextWrapping="Wrap"
+                         AcceptsReturn="True"
+                         AutomationProperties.Name="Transfer notes" />
+            </StackPanel>
+        </ScrollViewer>
+
+        <TextBlock Grid.Row="2"
+                   Text="{Binding ValidationMessage}"
+                   Foreground="{DynamicResource BusBuddy.Brush.Semantic.Danger}"
+                   TextWrapping="Wrap"
+                   Margin="0,10,0,10" />
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
+            <syncfusion:ButtonAdv Label="Cancel"
+                                  Command="{Binding CancelCommand}"
+                                  Margin="0,0,10,0"
+                                  AutomationProperties.Name="Cancel transfer" />
+            <syncfusion:ButtonAdv Label="Save Transfer"
+                                  Command="{Binding SaveCommand}"
+                                  Background="{DynamicResource BusBuddy.Brush.Primary}"
+                                  Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
+                                  AutomationProperties.Name="Save transfer" />
+        </StackPanel>
+    </Grid>
+</syncfusion:ChromelessWindow>

--- a/BusBuddy.WPF/Views/Student/StudentSchoolTransferForm.xaml.cs
+++ b/BusBuddy.WPF/Views/Student/StudentSchoolTransferForm.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+using BusBuddy.WPF.Utilities;
+using BusBuddy.WPF.ViewModels.Student;
+using Syncfusion.SfSkinManager;
+using Syncfusion.Windows.Shared;
+
+namespace BusBuddy.WPF.Views.Student;
+
+public partial class StudentSchoolTransferForm : ChromelessWindow
+{
+    public StudentSchoolTransferForm(StudentSchoolTransferViewModel viewModel)
+    {
+        InitializeComponent();
+        SyncfusionThemeManager.ApplyTheme(this);
+        DataContext = viewModel;
+        viewModel.RequestClose += (_, result) =>
+        {
+            DialogResult = result;
+            Close();
+        };
+    }
+
+    protected override void OnClosed(System.EventArgs e)
+    {
+        SfSkinManager.Dispose(this);
+        base.OnClosed(e);
+    }
+}

--- a/BusBuddy.WPF/Views/Student/StudentsView.xaml
+++ b/BusBuddy.WPF/Views/Student/StudentsView.xaml
@@ -73,6 +73,13 @@
                             IsEnabled="{Binding HasSelectedStudent}"
                             AutomationProperties.Name="Delete Student"
                             AutomationProperties.HelpText="Removes the currently selected student from the system"/>
+            <syncfusion:ButtonAdv Name="SchoolTransferButton" Label="🔁 School Transfer"
+                            Command="{Binding SchoolTransferCommand}"
+                            IsEnabled="{Binding HasSelectedStudent}"
+                            Background="{DynamicResource BusBuddy.Brush.Semantic.Info}"
+                            Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
+                            AutomationProperties.Name="School Transfer"
+                            AutomationProperties.HelpText="Assign school-to-school transfer with required pickup/dropoff locations and times"/>
                     <Separator Margin="10,0"/>
 
                     <!-- Bulk Operations -->

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -58,7 +58,7 @@
 
 ### P2 — Hygiene / quality
 
-- [x] Bootstrap function-inventory generated scan — `.function-inventory.json` (16 surfaces) → [function-inventory.generated.md](./function-inventory.generated.md) (2026-08-16: 11/16 with proof)
+- [x] Bootstrap function-inventory generated scan — `.function-inventory.json` (26 surfaces) → [function-inventory.generated.md](./function-inventory.generated.md) (2026-08-17: 16/26 with proof; added Destination/Transfer/Training)
 - [x] Resolve LFS/chroma noise — stop tracking `rag/chroma_db/` (~54MB sqlite blobs that triggered GH001); drop `*.pdf`/`*.sqlite` LFS attrs (PDF stays git binary). History purge of old blobs still needs force-push approval.
 - [x] AutoMapper 12.x advisory — upgraded to 15.1.1
 - [x] Restore [Documentation/GCP-GEE-SECRETS-AND-AUTH.md](../Documentation/GCP-GEE-SECRETS-AND-AUTH.md) (was missing; AGENTS link)
@@ -106,7 +106,9 @@ python3 ~/.cursor/skills/function-inventory/scripts/update-function-inventory.py
 | Surface                                                  | Tier | Proof / next check                                                                                                                                                                                                         |
 | -------------------------------------------------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Student / Seed / Route / Optimizer / Reports services    | P1   | Unit tests present (`StudentServiceTests`, `SeedDataServiceTests`, `RouteServiceTests`, `StudentRouteOptimizerTests`, `OperationalReportServiceTests`, `PdfReportServiceTests`)                                            |
-| `StudentsView` / `ReportsView`                           | P1   | No WPF testhost on Mac. Proof is VM smoke (`./run-wpf.sh`) + the Core tests above. Do not treat as a missing feature.                                                                                                      |
+| `DestinationService` / `StudentSchoolTransferService`    | P1   | Transfer + waypoints: `StudentSchoolTransferAndWaypointTests`. Destination unit tests still open. VM migrate + intake school assign still due (P0).                                                                        |
+| `DriverTrainingService`                                  | P1   | `DriverTrainingServiceTests` present. VM Training grid smoke still due (P0).                                                                                                                                               |
+| `StudentsView` / `ReportsView` / transfer & training UI  | P1   | No WPF testhost on Mac. Proof is VM smoke (`./run-wpf.sh`) + Core tests above. Do not treat as a missing feature.                                                                                                          |
 | `ScheduleService`                                        | P1   | **Runtime proof via Serilog:** `GetSchedulesAsync` logs count + elapsed. SfScheduler UI: `DriverScheduleViewModel` / `DriverAvailabilityService` log appointment and 14-day availability summaries. Unit tests still open. |
 | `DriverService`                                          | P1   | `DriverServiceTests` exist; `DriverScheduleView` + `DriverAvailabilityCalculator` (Schedule + ActivitySchedule). Availability calc logs `Drivers=` / `WithOpenDays=`                                                       |
 | `MaintenanceService` / Dashboard metrics / theme manager | P2   | `MaintenanceService` logs CRUD. Dashboard: `DashboardViewModel` logs refresh/optimize/report. Earth Engine retired (spec 007).                                                                                             |
@@ -122,4 +124,4 @@ python3 ~/.cursor/skills/function-inventory/scripts/update-function-inventory.py
 
 ---
 
-*Updated 2026-08-17: P1 stubs closed (availability, maintenance UI, activity persist/conflicts, map scope/dispose). Close issue #11 after merge.*
+*Updated 2026-08-17: function-inventory re-scan — 26 surfaces (added Destination/Transfer/Training); 16 with scanner proof.*

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -31,6 +31,10 @@
   - [ ] Apply migration `20260817150000_DriverTrainingSubmodule` — same Windows/SQL Server path as above
   - [ ] VM: edit driver employment fields; open Training grid; mark complete + certificate
   - [x] Dedicated training grid UI (Drivers → Training) — mark complete / certificate per row
+- [ ] **008 Route determination / fleet sizing** (Spec-Kit next) — minimize buses with geographic + time comfort; AM/PM mirror with AM-only / PM-only / both; recalc on assign; year-start auto-assign + map override; toast when assign breaks arrival/capacity; home→school and transfer planners separate; target >100 riders / medium–large city, still usable for small districts
+  - Design locked 2026-08-17 (user answers): soft capacity = assigned bus `SeatingCapacity` (hard); school map **start times** → work backward for pickups; simple **quadrants** + rural/outlier rules (large pickup gaps → other route); minimize buses without sacrificing ride time/mileage/comfort; keep occasional-rider stops on mirrored routes; suggest new route past thresholds
+  - [ ] `/speckit-specify` → plan/tasks under `specs/008-route-determination/`
+  - [ ] Depends on #36 merge + school start-time on Destination + VM migrate
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit
   - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -23,12 +23,13 @@
   - [x] US4: Places type-ahead — skipped (MVP cut)
   - [x] Docs for US2; Maps clients wired
 - [ ] **Student contact + school destinations** — parent/emergency fields, Destination School catalog, intake school dropdown, map schools, inter-district `StudentSchoolTransfer` (timed pickup/dropoff)
-  - [ ] Apply migration `20260817140000_StudentContactFieldsAlignment`
+  - [ ] Apply migration `20260817140000_StudentContactFieldsAlignment` — **Mac Postgres `dotnet ef database update` blocked** (InitialCreate seed uses SQL Server `bit` / unspecified timestamps). Apply on **Windows VM SQL Server**, or use EnsureCreated for local Postgres smoke only.
   - [ ] VM: assign school on intake; Show Schools on map; create transfer home→campus
   - [x] Transfer UI (Students → School Transfer) — pickup/dropoff location + times required; waypoints rebuild on assign/transfer
+  - [x] Mac smoke 2026-08-17: InMemory services OK (schools, training 17 rows, transfer validation, waypoints). Postgres Migrate blocked as above.
 - [ ] **Driver employment + CDE training sub-module** — contact/address/hire; [CDE 2024-25 License/Training Matrix](https://resources.finalsite.net/images/v1764086158/cdestatecous/mpcomjjt3zryb1vussig/2024-25-License-Training-Matrix.pdf) checklist via `DriverTrainingRecord` / `IDriverTrainingService`
-  - [ ] Apply migration `20260817150000_DriverTrainingSubmodule`
-  - [ ] VM: edit driver employment fields; Training History seeds checklist + status bar summary
+  - [ ] Apply migration `20260817150000_DriverTrainingSubmodule` — same Windows/SQL Server path as above
+  - [ ] VM: edit driver employment fields; open Training grid; mark complete + certificate
   - [x] Dedicated training grid UI (Drivers → Training) — mark complete / certificate per row
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -25,6 +25,9 @@
 - [ ] **Student contact + school destinations** — parent/emergency fields, Destination School catalog, intake school dropdown, map schools, inter-district `StudentSchoolTransfer` (timed pickup/dropoff)
   - [ ] Apply migration `20260817140000_StudentContactFieldsAlignment`
   - [ ] VM: assign school on intake; Show Schools on map; create transfer home→campus
+- [ ] **Driver employment + CDE training sub-module** — contact/address/hire; [CDE 2024-25 License/Training Matrix](https://resources.finalsite.net/images/v1764086158/cdestatecous/mpcomjjt3zryb1vussig/2024-25-License-Training-Matrix.pdf) checklist via `DriverTrainingRecord` / `IDriverTrainingService`
+  - [ ] Apply migration `20260817150000_DriverTrainingSubmodule`
+  - [ ] VM: edit driver employment fields; Training History seeds checklist + status bar summary
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit
   - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -33,7 +33,7 @@
   - [x] Dedicated training grid UI (Drivers → Training) — mark complete / certificate per row
 - [ ] **008 Route determination / fleet sizing** (Spec-Kit next) — minimize buses with geographic + time comfort; AM/PM mirror with AM-only / PM-only / both; recalc on assign; year-start auto-assign + map override; toast when assign breaks arrival/capacity; home→school and transfer planners separate; target >100 riders / medium–large city, still usable for small districts
   - Design locked 2026-08-17 (user answers): soft capacity = assigned bus `SeatingCapacity` (hard); school map **start times** → work backward for pickups; simple **quadrants** + rural/outlier rules (large pickup gaps → other route); minimize buses without sacrificing ride time/mileage/comfort; keep occasional-rider stops on mirrored routes; suggest new route past thresholds
-  - [ ] `/speckit-specify` → plan/tasks under `specs/008-route-determination/`
+  - [ ] `/speckit-specify` → [spec](../specs/008-route-determination/spec.md) (draft; 3 clarifications open) → plan/tasks under `specs/008-route-determination/`
   - [ ] Depends on #36 merge + school start-time on Destination + VM migrate
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -33,8 +33,9 @@
   - [x] Dedicated training grid UI (Drivers → Training) — mark complete / certificate per row
 - [ ] **008 Route determination / fleet sizing** (Spec-Kit next) — minimize buses with geographic + time comfort; AM/PM mirror with AM-only / PM-only / both; recalc on assign; year-start auto-assign + map override; toast when assign breaks arrival/capacity; home→school and transfer planners separate; target >100 riders / medium–large city, still usable for small districts
   - Design locked 2026-08-17 (user answers): soft capacity = assigned bus `SeatingCapacity` (hard); school map **start times** → work backward for pickups; simple **quadrants** + rural/outlier rules (large pickup gaps → other route); minimize buses without sacrificing ride time/mileage/comfort; keep occasional-rider stops on mirrored routes; suggest new route past thresholds
-  - [ ] `/speckit-specify` → [spec](../specs/008-route-determination/spec.md) (draft; 3 clarifications open) → plan/tasks under `specs/008-route-determination/`
-  - [ ] Depends on #36 merge + school start-time on Destination + VM migrate
+  - [x] `/speckit-specify` + `/speckit-plan` — [spec](../specs/008-route-determination/spec.md) · [plan](../specs/008-route-determination/plan.md) (Q1:A / Q2:B / Q3:B locked)
+  - [x] `/speckit-tasks` — [tasks.md](../specs/008-route-determination/tasks.md) (41 tasks; MVP = US1 T001–T020)
+  - [ ] `/speckit-implement` (prefer after #36 merge) + school start/dismissal on Destination + VM migrate
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit
   - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -25,9 +25,11 @@
 - [ ] **Student contact + school destinations** — parent/emergency fields, Destination School catalog, intake school dropdown, map schools, inter-district `StudentSchoolTransfer` (timed pickup/dropoff)
   - [ ] Apply migration `20260817140000_StudentContactFieldsAlignment`
   - [ ] VM: assign school on intake; Show Schools on map; create transfer home→campus
+  - [x] Transfer UI (Students → School Transfer) — pickup/dropoff location + times required; waypoints rebuild on assign/transfer
 - [ ] **Driver employment + CDE training sub-module** — contact/address/hire; [CDE 2024-25 License/Training Matrix](https://resources.finalsite.net/images/v1764086158/cdestatecous/mpcomjjt3zryb1vussig/2024-25-License-Training-Matrix.pdf) checklist via `DriverTrainingRecord` / `IDriverTrainingService`
   - [ ] Apply migration `20260817150000_DriverTrainingSubmodule`
   - [ ] VM: edit driver employment fields; Training History seeds checklist + status bar summary
+  - [x] Dedicated training grid UI (Drivers → Training) — mark complete / certificate per row
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit
   - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -16,12 +16,15 @@
 ### P0 — Platform / tooling
 
 - [x] Spec-Kit brownfield bootstrap (001–005) — merged [PR #20](https://github.com/Bigessfour/BusBuddy-3/pull/20)
-- [x] **007 Maps Platform Geo (retire Earth Engine)** — US2+docs merged [PR #31](https://github.com/Bigessfour/BusBuddy-3/pull/31); US1+US3 on `feature/007-maps-us1-implement` · [spec](../specs/007-maps-platform-geo/spec.md) · [tasks](../specs/007-maps-platform-geo/tasks.md)
+- [x] **007 Maps Platform Geo (retire Earth Engine)** — US2+docs merged [PR #31](https://github.com/Bigessfour/BusBuddy-3/pull/31); US1+US3 [PR #35](https://github.com/Bigessfour/BusBuddy-3/pull/35) · [spec](../specs/007-maps-platform-geo/spec.md) · [tasks](../specs/007-maps-platform-geo/tasks.md)
   - [x] US2: Remove GEE DI, client, probe, unofficial Google tiles
   - [x] US1: Address Validation + geocode onto SfMap (Maps client + DI)
   - [x] US3: Routes API drive polyline (fail-open optimizer)
   - [x] US4: Places type-ahead — skipped (MVP cut)
-  - [x] Docs for US2; Maps clients wired on US1 implement branch
+  - [x] Docs for US2; Maps clients wired
+- [ ] **Student contact + school destinations** — parent/emergency fields, Destination School catalog, intake school dropdown, map schools, inter-district `StudentSchoolTransfer` (timed pickup/dropoff)
+  - [ ] Apply migration `20260817140000_StudentContactFieldsAlignment`
+  - [ ] VM: assign school on intake; Show Schools on map; create transfer home→campus
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit
   - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)

--- a/specs/008-route-determination/checklists/requirements.md
+++ b/specs/008-route-determination/checklists/requirements.md
@@ -13,7 +13,7 @@
 
 ## Requirement Completeness
 
-- [ ] No [NEEDS CLARIFICATION] markers remain — **2 remain (FR-014, FR-016); FR-015 resolved 2026-08-17 (Q2: B)**
+- [x] No [NEEDS CLARIFICATION] markers remain — **resolved 2026-08-17: Q1:A separate transfer fleet; Q2:B block hard seating / warn time-geo; Q3:B density/bbox grid**
 - [x] Requirements are testable and unambiguous (except marked clarifications)
 - [x] Success criteria are measurable
 - [x] Success criteria are technology-agnostic (no implementation details)
@@ -31,4 +31,4 @@
 
 ## Notes
 
-- Resolve FR-014 / FR-016 via user answers (FR-015 = Q2:B block hard seating, warn-and-allow time/geo), then mark this checklist complete before `/speckit-plan`.
+- Clarifications locked: FR-014 = Q1:A; FR-015 = Q2:B; FR-016 = Q3:B. Plan artifacts generated 2026-08-17 (`plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`). Next: `/speckit-tasks`.

--- a/specs/008-route-determination/checklists/requirements.md
+++ b/specs/008-route-determination/checklists/requirements.md
@@ -13,7 +13,7 @@
 
 ## Requirement Completeness
 
-- [ ] No [NEEDS CLARIFICATION] markers remain — **3 remain (FR-014–016); awaiting user choices below**
+- [ ] No [NEEDS CLARIFICATION] markers remain — **2 remain (FR-014, FR-016); FR-015 resolved 2026-08-17 (Q2: B)**
 - [x] Requirements are testable and unambiguous (except marked clarifications)
 - [x] Success criteria are measurable
 - [x] Success criteria are technology-agnostic (no implementation details)
@@ -31,4 +31,4 @@
 
 ## Notes
 
-- Resolve FR-014 / FR-015 / FR-016 via user answers, then mark this checklist complete before `/speckit-plan`.
+- Resolve FR-014 / FR-016 via user answers (FR-015 = Q2:B block hard seating, warn-and-allow time/geo), then mark this checklist complete before `/speckit-plan`.

--- a/specs/008-route-determination/checklists/requirements.md
+++ b/specs/008-route-determination/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Route Determination / Fleet Sizing
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-08-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain — **3 remain (FR-014–016); awaiting user choices below**
+- [x] Requirements are testable and unambiguous (except marked clarifications)
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria (pending FR-014–016 answers)
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Resolve FR-014 / FR-015 / FR-016 via user answers, then mark this checklist complete before `/speckit-plan`.

--- a/specs/008-route-determination/contracts/assign-fitness.md
+++ b/specs/008-route-determination/contracts/assign-fitness.md
@@ -1,0 +1,28 @@
+# Contract: Assign Fitness / Toast
+
+**Consumers**: Students / Route ViewModels (Syncfusion toast or status banner)
+
+## AssignFitnessResult
+
+| Field | Meaning |
+|-------|---------|
+| Allowed | If false, UI must not call assign persist (unless seating override path) |
+| Severity | `None`, `Warn`, `Block` |
+| Reasons | Human-readable strings for toast body |
+| SuggestedRouteIds | Prefer existing routes |
+| SuggestNewRoute | True when past district threshold — toast offers “create route” |
+
+## Policy (locked)
+
+| Condition | Behavior |
+|-----------|----------|
+| Assigned count + 1 &gt; bus `SeatingCapacity` and no override | **Block** + toast |
+| Estimated arrival after school StartTime (or soft MaxRideMinutes) | **Warn** + allow |
+| Student would be geo outlier vs route cell / gap threshold | **Warn** + allow |
+| Explicit seating override recorded | Allow Block seating case; Serilog `Override` |
+
+## UI contract
+
+- Toast/status must show at least one `Reasons` line and, when present, suggested route names.
+- Warn-and-allow: proceed after toast without modal unless clerk cancels.
+- Block: no silent assign; optional Syncfusion dialog for override when `AllowSeatingOverride` is true.

--- a/specs/008-route-determination/contracts/route-determination.md
+++ b/specs/008-route-determination/contracts/route-determination.md
@@ -1,0 +1,42 @@
+# Contract: Route Determination Service
+
+**Interface (Core)**: `IRouteDeterminationService`
+
+## GenerateAndAssignAsync
+
+**Input**:
+- `schoolDestinationId` (int)
+- `slot` — `AM` | `PM` | `Both` (Both ⇒ generate AM then mirror PM)
+- `fleetKind` — `HomeToSchool` | `Transfer`
+- `options` — dry-run (proposals only) vs persist assignments
+
+**Output**:
+- `RouteGenerationResult` — list of proposals, assigned student counts, Serilog-correlated `OperationId`, warnings
+
+**Rules**:
+- HomeToSchool uses student home coordinates + school StartTime/DismissalTime.
+- Transfer uses active `StudentSchoolTransfer` pickup/dropoff pairs only; separate seating pool.
+- Minimize route count subject to seating capacity and gap/time thresholds.
+- Students without coordinates are listed in `UnclusteredStudentIds` (manual).
+
+## RecalculateOnAssignAsync
+
+**Input**: `studentId`, `routeId`, `slot`, `overrideSeating` (bool)
+
+**Output**: `AssignFitnessResult` (see [assign-fitness.md](./assign-fitness.md))
+
+**Side effects** (when Allowed):
+- Persist AM/PM assignment via existing `IRouteService`
+- Trigger waypoint rebuild for affected route(s)
+
+## ApplyClerkOverrideAsync
+
+**Input**: `studentId`, `fromRouteId`, `toRouteId`, `slot`, reason
+
+**Output**: success/failure; keeps occasional-rider stop on mirror when ride mode is one-sided
+
+## Logging (Serilog)
+
+Must emit structured events such as:
+- `Route generation completed School={SchoolId} Fleet={Fleet} Routes={N} Students={S}`
+- `Assign fitness Blocked|Warned Student={Id} Route={Id} Reasons={Reasons}`

--- a/specs/008-route-determination/data-model.md
+++ b/specs/008-route-determination/data-model.md
@@ -1,0 +1,80 @@
+# Data Model: 008 Route Determination
+
+## Destination (School) — extend
+
+| Field | Type | Rules |
+|-------|------|-------|
+| StartTime | TimeSpan? | Required for AM generation for that school |
+| DismissalTime | TimeSpan? | Required for PM mirror schedule |
+| (existing) Latitude/Longitude, Name, DistrictName | | Used as campus anchor |
+
+**Validation**: Year-start generation fails with clear message if StartTime missing for AM (DismissalTime for PM).
+
+## RoutingDistrictSettings (new or appsettings-backed)
+
+| Field | Type | Rules |
+|-------|------|-------|
+| BoundingBox | lat/lon min/max or shapefile extent | District geographic frame |
+| TargetRidersPerCell | int | Density hint for N-cell grid (default ~15–25) |
+| MaxPickupGapMinutes | int | Outlier split threshold |
+| AverageSpeedMph | double | Fallback ETA when Maps unavailable |
+| MaxRideMinutes | int? | Soft comfort cap for warn-and-allow |
+| AllowSeatingOverride | bool | If false, hard block has no UI override |
+
+## Student ride mode
+
+| Mode | Meaning |
+|------|---------|
+| AM | AMRoute set; PMRoute empty — stop kept on PM mirror for occasional riders |
+| PM | PMRoute set; AMRoute empty — stop kept on AM mirror |
+| Both | Both routes set |
+
+Optional later: explicit `RideMode` column; MVP may derive from AM/PM route nullability.
+
+## RouteProposal / draft Route
+
+MVP may create real `Route` rows with a naming convention (`Draft-{School}-{Cell}-{n}`) or a `RouteProposals` table:
+
+| Field | Type | Rules |
+|-------|------|-------|
+| SchoolDestinationId | int | FK |
+| Slot | AM / PM | |
+| FleetKind | HomeToSchool / Transfer | Separate pools (FR-014) |
+| OrderedStudentIds | list | Stop order |
+| SuggestedBusSeatingCapacity | int | From assigned/suggested bus |
+| EstimatedMiles / EstimatedMinutes | double | |
+| CellId | string | Density grid cell id |
+| Status | Draft / Accepted / Rejected | |
+
+Accepted proposals become or update operational `Route` + student AM/PM assignments.
+
+## AssignFitnessResult (transient)
+
+| Field | Type | Rules |
+|-------|------|-------|
+| Allowed | bool | False if seating hard-block without override |
+| Severity | None / Warn / Block | |
+| Reasons | string[] | Overload, arrival risk, geo outlier |
+| SuggestedRouteIds | int[] | Alternates |
+| SuggestNewRoute | bool | Past threshold |
+
+## Transfer fleet
+
+Uses `StudentSchoolTransfer` pickup/dropoff locations + times as stop inputs. `FleetKind=Transfer`. No seat sharing with HomeToSchool (FR-014).
+
+## Relationships
+
+```text
+Destination (School) 1──* Route (HomeToSchool AM/PM)
+Destination (School) 1──* Route (Transfer pool)     # separate
+Student *──0..1 active StudentSchoolTransfer
+Route 1──* ordered stops (students or transfer pairs)
+Assign → AssignFitnessResult (transient)
+```
+
+## State transitions
+
+```text
+YearStart: Idle → Generating → DraftProposals → ClerkOverride → Accepted → Operational
+Assign: CheckFitness → Warn (continue) | Block (stop) | OverrideRecorded → Assigned → WaypointsRefresh
+```

--- a/specs/008-route-determination/plan.md
+++ b/specs/008-route-determination/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Route Determination / Fleet Sizing
+
+**Branch**: `feature/008-route-determination` (spec artifacts; implement after PR #36 merge) | **Date**: 2026-08-17 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/008-route-determination/spec.md`
+
+**Clarifications locked**: Q1:A separate transfer fleet; Q2:B block hard seating / warn-and-allow time-geo; Q3:B density/bbox grid cells
+
+## Summary
+
+Add a Core route-determination service that (1) year-start auto-builds the minimum home→school AM routes (mirrored PM) from school times, student homes, and bus seating, using density-based geographic cells plus outlier splits; (2) recalculates fitness on assign with hard block on seating overload and warn-and-allow toasts for time/geo risk; (3) plans transfer routes in a separate fleet pool with the same rules. WPF surfaces Syncfusion toasts and map override; drive times prefer Maps Routes (007) with average-speed fallback.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 9 (`net9.0-windows` Core/WPF)
+
+**Primary Dependencies**: Existing EF Core, `IRouteService`, `IRoutingService` (007), `IStudentSchoolTransferService`, Syncfusion WPF (toasts / SfMap), Serilog, CommunityToolkit.Mvvm
+
+**Storage**: EF — extend `Destination` with school start/dismissal; optional district routing settings; route proposals may be draft `Route` rows or a `RouteProposal` table (see data-model); student ride mode (AM/PM/both) explicit if not already derivable from AMRoute/PMRoute nullability
+
+**Testing**: NUnit in `BusBuddy.Tests`; InMemory for clustering/capacity/time backward scheduling; no live Maps in CI (`Category!=Integration&Category!=InMemoryFlaky`)
+
+**Target Platform**: Windows WPF (VM); Mac host builds Core/tests with `EnableWindowsTargeting`
+
+**Project Type**: Desktop (Syncfusion WPF) + Core class library
+
+**Performance Goals**: Year-start generation for 100+ riders &lt; ~30s perceived on typical hardware; assign-time fitness check &lt; 1s without live routing (use cached/fallback ETA)
+
+**Constraints**: Syncfusion-only UI; Serilog-only; no cloud hosting; YAGNI — no full commercial VRP solver in MVP (heuristic clustering + greedy fill); constitution Geo = Maps + shapefiles when available
+
+**Scale/Scope**: Small districts through &gt;100 riders / medium–large city; 4 user stories in spec
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status |
+|------|--------|
+| I Spec-driven + RAG | Pass — spec 008; plan/research/data-model/contracts; RAG re-index after merge |
+| II Syncfusion-only UI | Pass — toasts via Syncfusion notifications / existing patterns; SfMap for override |
+| III Serilog-only | Pass — planner logs counts/violations, no secrets |
+| IV Layered architecture | Pass — Core planner services; WPF VM/commands; tests in BusBuddy.Tests |
+| V Hybrid Mac/Windows | Pass — Core algorithms runnable on Mac; UI smoke on VM |
+| VI Solo CI/CD | Pass — feature branch + PR to master |
+| VII YAGNI / no secrets | Pass — heuristic planner; no new paid APIs beyond existing Maps |
+| Geo (v1.1.0) | Pass — optional Routes for ETA; shapefile/bbox for district extent |
+| Hosting | Pass — no AWS/cloud app host |
+
+Post-design re-check: contracts are Core service interfaces + UI event contracts; no new control families. **Pass.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-route-determination/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── route-determination.md
+│   └── assign-fitness.md
+├── checklists/requirements.md
+└── tasks.md                 # /speckit-tasks (not this command)
+```
+
+### Source Code (repository root)
+
+```text
+BusBuddy.Core/
+  Models/                    # Destination times; RoutingDistrictSettings; ride mode helpers
+  Services/
+    RouteDetermination/      # IRouteDeterminationService, clustering, time backward scheduler
+    RouteWaypointRebuildService.cs  # evolve to honor ordered proposals (post-#36)
+  Extensions/ServiceCollectionExtensions.cs
+BusBuddy.WPF/
+  ViewModels/Student|Route|GoogleEarth/  # year-start generate; assign toast; map override
+  App.xaml.cs                            # DI
+BusBuddy.Tests/Core/                     # clustering, capacity block, time schedule, transfer pool
+```
+
+**Structure Decision**: Existing Core + WPF + Tests only. New subfolder `BusBuddy.Core/Services/RouteDetermination/`. No new project.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.
+
+## Implementation approach (high level)
+
+1. Persist school **StartTime** / **DismissalTime** on Destination (School).
+2. Implement density/bbox cell builder + outlier split; greedy pack by seating.
+3. Backward pickup schedule from school start (AM); forward from dismissal (PM mirror).
+4. Year-start `GenerateAndAssignAsync(schoolId)` → draft routes + assignments; map override API.
+5. Wrap `AssignStudentToRouteAsync` with fitness: hard block seating; warn toast time/geo.
+6. Separate `GenerateTransferRoutesAsync` using transfer stop pairs only.
+7. Wire Syncfusion toast/status on Students/Route assign paths; Serilog proof events.

--- a/specs/008-route-determination/quickstart.md
+++ b/specs/008-route-determination/quickstart.md
@@ -1,0 +1,38 @@
+# Quickstart: 008 Route Determination
+
+Validation guide after implementation (not runnable until `/speckit-tasks` + implement).
+
+## Prerequisites
+
+- PR #36 merged (schools, transfers, student geo) and migrations applied on Windows SQL Server or Postgres with fixed seed types
+- At least one School `Destination` with GPS + **StartTime** / **DismissalTime**
+- ≥12 students with home lat/lon assigned to that school; one bus with `SeatingCapacity` ≥ 12
+- Optional: `GOOGLE_MAPS_API_KEY` for tighter ETAs (fail-open without it)
+
+## Core unit checks (Mac OK)
+
+```bash
+dotnet test BusBuddy.Tests/BusBuddy.Tests.csproj -c Release -p:EnableWindowsTargeting=true \
+  --filter "FullyQualifiedName~RouteDetermination&Category!=Integration&Category!=InMemoryFlaky"
+```
+
+Expect: clustering packs nearby 12 into one route; distant gap splits; seating block; time backward schedule monotonic.
+
+## VM UI smoke
+
+1. Set school start/dismissal on map school editor.
+2. Run **Generate routes** (year-start) for that school — expect draft AM + mirrored PM; map shows clusters.
+3. Override one outlier on the map — assignment moves; stop remains on mirror for AM-only student.
+4. Assign a student that exceeds seating — **blocked** toast; assign with time risk only — **warn** and proceeds.
+5. Create two transfers — **Generate transfer routes** produces a separate pool (no seat theft from home routes).
+
+## Serilog proof
+
+Look for:
+
+- `Route generation completed`
+- `Assign fitness Blocked` / `Assign fitness Warned`
+
+## Related
+
+- [spec.md](./spec.md) · [data-model.md](./data-model.md) · [contracts/route-determination.md](./contracts/route-determination.md)

--- a/specs/008-route-determination/research.md
+++ b/specs/008-route-determination/research.md
@@ -1,0 +1,52 @@
+# Research: 008 Route Determination / Fleet Sizing
+
+## Decision: Heuristic clustering + greedy fill (not full VRP solver)
+
+**Rationale**: Spec requires minimize buses with comfort for &gt;100 riders, but constitution YAGNI forbids a heavy commercial OR-Tools/VRP dependency in MVP. Density/bbox cells + outlier gap split + greedy seat packing delivers SC-001/SC-002 and can later plug Maps matrix costs.
+
+**Alternatives considered**:
+- Google OR-Tools VRP — stronger optima; heavier native deps and ops surface; deferred.
+- Single k-means only — weak rural outliers; rejected as sole method.
+- Manual routes only — fails year-start auto-assign requirement.
+
+## Decision: Q1:A — Separate transfer fleet / route pool
+
+**Rationale**: User choice. Transfer demand must not consume home→school seats. Same algorithms, separate inventory and generation entry point.
+
+**Alternatives considered**: Shared buses with time gaps (Q1:B); separate default with share override (Q1:C).
+
+## Decision: Q2:B — Block hard seating; warn-and-allow time/geo
+
+**Rationale**: User choice. Aligns with “soft max with override” only for non-capacity constraints; assigned bus `SeatingCapacity` remains the hard ceiling unless an explicit override is recorded.
+
+**Alternatives considered**: Warn-and-allow everything (A); block both with role override (C).
+
+## Decision: Q3:B — N-cell grid from district bbox + density
+
+**Rationale**: User choice. Fixed 4-from-centroid is too coarse for medium/large cities; density-aware cells better match &gt;100 rider scenarios while remaining simple.
+
+**Alternatives considered**: Fixed 4 (A); 4 + auto-split only (C) — outlier split still used *inside* cells as a secondary rule.
+
+## Decision: School times on Destination; pickups computed, not clerk-entered per stop (MVP)
+
+**Rationale**: Spec US3 — start/dismissal on map school; work backward along ordered stops. Persist computed times on route stops or student schedule fields when those exist; regenerate when start time or order changes.
+
+**Alternatives considered**: Per-student manual pickup windows first — more data entry; deferred.
+
+## Decision: AM/PM mirror with ride mode AM / PM / both
+
+**Rationale**: Spec FR-007. Derive mode from AMRoute/PMRoute presence today; optionally add explicit `RideMode` enum later if ambiguity appears. Occasional-rider stops remain in path order even when mode is one-sided.
+
+## Decision: Drive ETA — Maps Routes when configured, else average-speed Haversine
+
+**Rationale**: Matches 007 fail-open pattern; assign-time checks must not require network. Year-start can optionally refresh with Routes for better schedules.
+
+**Alternatives considered**: Always require Maps — breaks offline/Mac Core tests.
+
+## Decision: Depend on PR #36 entities before implement
+
+**Rationale**: Schools as Destinations, transfers, waypoint rebuild, student geo are prerequisites. Implement 008 on a branch from post-merge master.
+
+## Resolved clarifications
+
+All FR-014 / FR-015 / FR-016 markers resolved (Q1:A, Q2:B, Q3:B). No Technical Context NEEDS CLARIFICATION remaining.

--- a/specs/008-route-determination/spec.md
+++ b/specs/008-route-determination/spec.md
@@ -53,7 +53,7 @@ As a clerk assigning a student to transportation, when the assignment would over
 
 1. **Given** a route at assigned-bus seating capacity, **When** the clerk assigns another student, **Then** a toast explains overload and the system suggests another route or a new route if past threshold.
 2. **Given** a route whose current riders already fill the time budget to school start, **When** assigning a farther student, **Then** a toast warns that optimal arrival goals would be missed and suggests alternatives.
-3. **Given** toast shown, **When** the clerk confirms an allowed override (where policy allows), **Then** assignment proceeds and is logged; when override is not allowed for hard seating, assignment does not proceed.
+3. **Given** toast shown for time/geo risk, **When** the clerk continues, **Then** assignment proceeds (warn-and-allow). **Given** hard seating capacity would be exceeded, **When** the clerk assigns without an explicit override, **Then** assignment does not proceed.
 
 ---
 
@@ -115,7 +115,7 @@ As a director, school-to-school transfer riders are planned with the same capaci
 - **FR-012**: System MUST remain usable for small districts and scale to more than 100 riders in a medium–large city service area.
 - **FR-013**: System MUST log generation and assign decisions with Serilog (counts, route ids, constraint violations—no secrets).
 - **FR-014**: Transfer fleet coupling is [NEEDS CLARIFICATION: separate fleet only vs shared buses with time gaps].
-- **FR-015**: Assign toast policy is [NEEDS CLARIFICATION: warn-and-allow vs block until alternate/override].
+- **FR-015**: On assign, the system MUST **block** when the assignment would exceed the assigned bus seating capacity (hard limit), unless an explicit override is recorded; for arrival-time / geographic fitness risks the system MUST **warn-and-allow** (toast + proceed) so clerks can continue with awareness.
 - **FR-016**: Quadrant construction is [NEEDS CLARIFICATION: fixed 4 from school centroid vs N from district bounding box/density].
 
 ### Key Entities

--- a/specs/008-route-determination/spec.md
+++ b/specs/008-route-determination/spec.md
@@ -1,0 +1,146 @@
+# Feature Specification: Route Determination / Fleet Sizing
+
+**Feature Branch**: `feature/008-route-determination`
+
+**Created**: 2026-08-17
+
+**Status**: Draft
+
+**Input**: From a listing of students (home/pickup location, AM/PM ride mode, school assignment), determine the minimum number of routes and buses needed while respecting seating capacity of the assigned bus, school start/dismissal times (work backward to pickups), geographic clustering (simple quadrants + rural/outlier rules), and student comfort (ride time / mileage / headcount). AM and PM routes mirror each other, but a student may ride AM-only, PM-only, or both; stops remain for occasional riders. Recalculate on student assignment; year-start auto-assign with map override; toast when assign would break arrival goals or overload a bus; suggest additional routes past thresholds. School-to-school transfer routes follow the same logic independently. Must work for small districts and scale to >100 riders across a medium–large city.
+
+## Baseline (as of draft)
+
+| Area | Current | Target |
+| ---- | ------- | ------ |
+| Assign to route | Capacity fill by route name (`AutoAssignStudentsAsync`); no geo/time planner | Suggest/create routes from student geography + school times + bus seats |
+| Capacity | Route/bus capacity checks on assign | Soft guidance; **hard** limit = assigned bus seating capacity |
+| Pickup times | Manual / transfer times only | Derived backward from school start (AM) / dismissal (PM) |
+| Geography | Waypoints rebuild (home → optional transfer stops → school); no clustering | Quadrants + rural outlier split; optimize miles, time, count |
+| Feedback on assign | Fail only when already at capacity / already assigned | Toast: arrival risk, overload, suggest another route; suggest new route past threshold |
+| Transfers | Separate entity + UI; not planned as a fleet | Independent planner with same rules as home→school |
+| Year start | Manual / bulk assign | Auto-assign with map override for outliers |
+
+Constitution: Syncfusion-only UI, Serilog-only logging, hybrid Mac/Windows, no cloud app hosting, no committed secrets. Builds on school Destinations, student geo, Maps drive paths (007), and transfer records (PR #36).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Year-start auto route build for a school (Priority: P1)
+
+As a transportation director, at the start of the year I select a school with start/dismissal times and its assigned riders; the system proposes the minimum set of AM routes (and mirrored PM routes), assigns students into those routes within bus seating limits and geographic clusters, and leaves occasional-rider stops on the path even if some students are AM-only or PM-only.
+
+**Why this priority**: This is the core value for districts with many riders; everything else (toasts, transfers) builds on it.
+
+**Independent Test**: With ≥12 geocoded students at one school and at least one bus seating capacity ≥12 in one geographic cluster, the system proposes one AM route (and mirrored PM) without exceeding seating. With students spread across distant quadrants such that one route would create large pickup gaps, the system proposes more than one route. Clerk can move a student between proposed routes on the map without losing the stop for occasional riders.
+
+**Acceptance Scenarios**:
+
+1. **Given** a school with start time and N students with home coordinates all near one quadrant, **When** year-start generation runs, **Then** the fewest routes that fit bus seating are proposed and students are auto-assigned AM (and mirrored PM where the student rides both or PM).
+2. **Given** students whose homes would create an excessive gap on a single route (rural/outlier rule), **When** generation runs, **Then** outliers are placed on a separate suggested route (or flagged for override).
+3. **Given** a student marked AM-only, **When** mirrored PM routes are built, **Then** the stop remains on the PM route for occasional riders but the student is not required as a daily PM assignment.
+4. **Given** proposed routes on the map, **When** the clerk overrides an outlier assignment, **Then** the change persists and recalculation respects the override until cleared.
+
+---
+
+### User Story 2 - Assign-time toast and route suggestion (Priority: P1)
+
+As a clerk assigning a student to transportation, when the assignment would overload the bus seating capacity or prevent meeting school arrival goals for that route, I see a clear toast and a suggestion to use another route (or create a new one past threshold)—without losing the ability to override when needed.
+
+**Why this priority**: Day-to-day enrollment changes must stay flexible while protecting comfort and capacity.
+
+**Independent Test**: Assigning one more student above hard seating capacity is blocked or requires explicit override after toast. Assigning a student who would break the backward-calculated arrival window shows a toast and suggests an alternate route when one exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a route at assigned-bus seating capacity, **When** the clerk assigns another student, **Then** a toast explains overload and the system suggests another route or a new route if past threshold.
+2. **Given** a route whose current riders already fill the time budget to school start, **When** assigning a farther student, **Then** a toast warns that optimal arrival goals would be missed and suggests alternatives.
+3. **Given** toast shown, **When** the clerk confirms an allowed override (where policy allows), **Then** assignment proceeds and is logged; when override is not allowed for hard seating, assignment does not proceed.
+
+---
+
+### User Story 3 - School times drive pickup schedule (Priority: P2)
+
+As a clerk placing a school on the map, I enter school start (and dismissal) times; assigned students’ pickup times are computed working backward along the route order so the bus arrives by start time.
+
+**Why this priority**: Time windows are the constraint that forces additional routes beyond raw headcount.
+
+**Independent Test**: Changing school start time regenerates pickup times for students on routes serving that school without changing route membership unless a toast/recalc indicates a constraint break.
+
+**Acceptance Scenarios**:
+
+1. **Given** a school with start time and an ordered AM route, **When** times are computed, **Then** each stop has a pickup time such that estimated arrival at school meets start time under the configured average speed / drive-path estimate.
+2. **Given** PM dismissal time, **When** mirrored PM is scheduled, **Then** dropoff/home times work forward from dismissal consistently with AM mirror stops.
+
+---
+
+### User Story 4 - Independent transfer route planning (Priority: P2)
+
+As a director, school-to-school transfer riders are planned with the same capacity, geography, and time logic as home→school, but as a separate set of routes so transfer demand does not silently consume home-route seats.
+
+**Why this priority**: Transfers are uncommon but must not distort primary routing.
+
+**Independent Test**: Generating home→school routes ignores transfer-only legs for seating on those routes; generating transfer routes uses transfer pickup/dropoff locations and times and produces its own minimum route set.
+
+**Acceptance Scenarios**:
+
+1. **Given** active transfer assignments with pickup/dropoff locations and times, **When** transfer planning runs, **Then** a separate route set is suggested under the same minimize-buses / comfort rules.
+2. **Given** home→school generation, **When** it runs, **Then** it does not treat transfer stop pairs as substitutes for home pickups on home routes (home routes still use home coordinates).
+
+---
+
+### Edge Cases
+
+- Student with no coordinates: exclude from auto-geo clustering; flag for manual assign.
+- Student AM-only or PM-only: stop retained on mirror; daily roster reflects ride mode.
+- Multiple schools / campuses: plan per school (or per destination), not one district-wide mega-route.
+- Soft vs hard capacity: soft warnings for “crowding” preferences; hard stop at assigned bus seating capacity unless explicit override policy says otherwise.
+- Recalc on assign: must be incremental enough for >100 riders (not full district rebuild every click if avoidable); full rebuild allowed at year-start.
+- Rural long deadhead: prefer splitting route over forcing one bus across the whole district.
+- Existing manual route names: generation may create drafts; clerk confirms before replacing production assignments.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST treat assigned bus seating capacity as the hard maximum riders on a route slot unless an explicit override is recorded.
+- **FR-002**: System MUST support soft capacity guidance (warnings) below that hard limit when configured.
+- **FR-003**: System MUST store school start time (AM) and dismissal time (PM) on the school destination (or equivalent) when the school is placed/edited on the map.
+- **FR-004**: System MUST compute student pickup times by working backward from school start along the ordered AM route (and forward from dismissal on PM).
+- **FR-005**: System MUST cluster students using a simple quadrant scheme scaled to district geographic size, with rural/outlier rules that split riders when pickup gaps would be unreasonably large.
+- **FR-006**: System MUST minimize the number of buses/routes as the primary objective while respecting ride time, distance, and seating comfort constraints.
+- **FR-007**: System MUST mirror AM and PM route stop structures while allowing per-student ride mode: AM-only, PM-only, or both; occasional-rider stops MUST remain on the mirror.
+- **FR-008**: System MUST recalculate route fitness (capacity/time/geo) when a student is assigned to transportation.
+- **FR-009**: System MUST auto-assign students into proposed routes at year-start generation, with clerk map override for outliers.
+- **FR-010**: System MUST show a toast (or equivalent non-blocking/blocking message per policy) when an assignment would prevent meeting arrival goals or would overload seating, and MUST suggest another route or a new route when past threshold.
+- **FR-011**: System MUST plan school-to-school transfer routes with the same logic independently from home→school routes.
+- **FR-012**: System MUST remain usable for small districts and scale to more than 100 riders in a medium–large city service area.
+- **FR-013**: System MUST log generation and assign decisions with Serilog (counts, route ids, constraint violations—no secrets).
+- **FR-014**: Transfer fleet coupling is [NEEDS CLARIFICATION: separate fleet only vs shared buses with time gaps].
+- **FR-015**: Assign toast policy is [NEEDS CLARIFICATION: warn-and-allow vs block until alternate/override].
+- **FR-016**: Quadrant construction is [NEEDS CLARIFICATION: fixed 4 from school centroid vs N from district bounding box/density].
+
+### Key Entities
+
+- **School destination**: Campus with map location, start time, dismissal time.
+- **Student rider**: Home location, school, ride mode (AM/PM/both), optional transfer.
+- **Route proposal**: Ordered stops, assigned/suggested bus seating, estimated miles/time, AM or PM slot.
+- **Constraint toast**: Human-readable reason (overload, arrival risk) + suggested alternate.
+- **Transfer route set**: Separate proposals using transfer pickup/dropoff pairs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a single-school scenario of 12 nearby students and a bus seating ≥12, year-start generation proposes **1** AM route (and mirrored PM structure) without exceeding seating.
+- **SC-002**: For students split across distant quadrants such that one route would create large pickup gaps, generation proposes **more than one** route rather than a single district-wide path.
+- **SC-003**: A clerk can complete year-start auto-assign for a 100-rider school set and override at least one outlier on the map in one session without re-entering all students.
+- **SC-004**: On assign that exceeds hard seating capacity, the clerk always receives an explicit toast/message before the system either blocks or records an override (per clarified policy).
+- **SC-005**: Changing school start time updates computed pickup times for affected routes without requiring manual re-entry of each stop time.
+- **SC-006**: Transfer planning produces a route count independent of home→school route count for the same student population when transfers exist.
+
+## Assumptions
+
+- Drive-time estimates may use existing Maps routing when configured, or a documented average-speed fallback when not (fail-open like 007).
+- “Quadrant” and “outlier gap” thresholds will be configurable district settings with sensible defaults for Wiley-scale and city-scale.
+- Occasional-rider stops mean the stop stays in the path/order even if the student is not on the daily AM or PM roster for that day.
+- PR #36 school destinations, student geo, and transfer records are available before implementation.
+- Existing `IStudentRouteOptimizer` capacity fill remains a fallback until 008 generation replaces or wraps it.

--- a/specs/008-route-determination/spec.md
+++ b/specs/008-route-determination/spec.md
@@ -10,15 +10,15 @@
 
 ## Baseline (as of draft)
 
-| Area | Current | Target |
-| ---- | ------- | ------ |
-| Assign to route | Capacity fill by route name (`AutoAssignStudentsAsync`); no geo/time planner | Suggest/create routes from student geography + school times + bus seats |
-| Capacity | Route/bus capacity checks on assign | Soft guidance; **hard** limit = assigned bus seating capacity |
-| Pickup times | Manual / transfer times only | Derived backward from school start (AM) / dismissal (PM) |
-| Geography | Waypoints rebuild (home → optional transfer stops → school); no clustering | Quadrants + rural outlier split; optimize miles, time, count |
-| Feedback on assign | Fail only when already at capacity / already assigned | Toast: arrival risk, overload, suggest another route; suggest new route past threshold |
-| Transfers | Separate entity + UI; not planned as a fleet | Independent planner with same rules as home→school |
-| Year start | Manual / bulk assign | Auto-assign with map override for outliers |
+| Area               | Current                                                                      | Target                                                                                 |
+| ------------------ | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Assign to route    | Capacity fill by route name (`AutoAssignStudentsAsync`); no geo/time planner | Suggest/create routes from student geography + school times + bus seats                |
+| Capacity           | Route/bus capacity checks on assign                                          | Soft guidance; **hard** limit = assigned bus seating capacity                          |
+| Pickup times       | Manual / transfer times only                                                 | Derived backward from school start (AM) / dismissal (PM)                               |
+| Geography          | Waypoints rebuild (home → optional transfer stops → school); no clustering   | Quadrants + rural outlier split; optimize miles, time, count                           |
+| Feedback on assign | Fail only when already at capacity / already assigned                        | Toast: arrival risk, overload, suggest another route; suggest new route past threshold |
+| Transfers          | Separate entity + UI; not planned as a fleet                                 | Independent planner with same rules as home→school                                     |
+| Year start         | Manual / bulk assign                                                         | Auto-assign with map override for outliers                                             |
 
 Constitution: Syncfusion-only UI, Serilog-only logging, hybrid Mac/Windows, no cloud app hosting, no committed secrets. Builds on school Destinations, student geo, Maps drive paths (007), and transfer records (PR #36).
 
@@ -114,9 +114,9 @@ As a director, school-to-school transfer riders are planned with the same capaci
 - **FR-011**: System MUST plan school-to-school transfer routes with the same logic independently from home→school routes.
 - **FR-012**: System MUST remain usable for small districts and scale to more than 100 riders in a medium–large city service area.
 - **FR-013**: System MUST log generation and assign decisions with Serilog (counts, route ids, constraint violations—no secrets).
-- **FR-014**: Transfer fleet coupling is [NEEDS CLARIFICATION: separate fleet only vs shared buses with time gaps].
+- **FR-014**: Transfer routes MUST be planned and seated in a **separate fleet / route pool** from home→school routes (same capacity/time/geo rules, independent seat inventory).
 - **FR-015**: On assign, the system MUST **block** when the assignment would exceed the assigned bus seating capacity (hard limit), unless an explicit override is recorded; for arrival-time / geographic fitness risks the system MUST **warn-and-allow** (toast + proceed) so clerks can continue with awareness.
-- **FR-016**: Quadrant construction is [NEEDS CLARIFICATION: fixed 4 from school centroid vs N from district bounding box/density].
+- **FR-016**: System MUST build geographic cells as an **N-cell grid derived from the district bounding box and rider density** (not a fixed 4-from-centroid only), with rural/outlier split when pickup gaps exceed configured thresholds.
 
 ### Key Entities
 
@@ -133,7 +133,7 @@ As a director, school-to-school transfer riders are planned with the same capaci
 - **SC-001**: For a single-school scenario of 12 nearby students and a bus seating ≥12, year-start generation proposes **1** AM route (and mirrored PM structure) without exceeding seating.
 - **SC-002**: For students split across distant quadrants such that one route would create large pickup gaps, generation proposes **more than one** route rather than a single district-wide path.
 - **SC-003**: A clerk can complete year-start auto-assign for a 100-rider school set and override at least one outlier on the map in one session without re-entering all students.
-- **SC-004**: On assign that exceeds hard seating capacity, the clerk always receives an explicit toast/message before the system either blocks or records an override (per clarified policy).
+- **SC-004**: On assign that exceeds hard seating capacity, the clerk always receives an explicit toast/message and the assign is **blocked** unless an explicit override is recorded; time/geo risks warn-and-allow.
 - **SC-005**: Changing school start time updates computed pickup times for affected routes without requiring manual re-entry of each stop time.
 - **SC-006**: Transfer planning produces a route count independent of home→school route count for the same student population when transfers exist.
 

--- a/specs/008-route-determination/tasks.md
+++ b/specs/008-route-determination/tasks.md
@@ -1,0 +1,194 @@
+# Tasks: Route Determination / Fleet Sizing
+
+**Input**: Design documents from `/specs/008-route-determination/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: Included (plan Testing + story Independent Tests). Prefer failing Core unit tests before production services.
+
+**Organization**: Setup → Foundational → US1 (MVP) → US2 → US3 → US4 → Polish.
+
+**Gate**: Prefer branch from `master` after PR #36 merge (schools, transfers, student geo).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete dependencies)
+- **[Story]**: US1–US4 from [spec.md](./spec.md)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Folder + DI registration surface for the planner
+
+- [ ] T001 Create directory `BusBuddy.Core/Services/RouteDetermination/` and add placeholder `README.md` noting contracts in `specs/008-route-determination/contracts/`
+- [ ] T002 [P] Add `RoutingDistrictSettings` options class in `BusBuddy.Core/Configuration/RoutingDistrictSettings.cs` (bbox or extent keys, TargetRidersPerCell, MaxPickupGapMinutes, AverageSpeedMph, MaxRideMinutes, AllowSeatingOverride) per [data-model.md](./data-model.md)
+- [ ] T003 [P] Bind `RoutingDistrictSettings` section in `BusBuddy.WPF/appsettings.json` and `BusBuddy.Core/appsettings.json` with Wiley-scale defaults
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: School times + service contracts + DI — required before any user story
+
+**⚠️ CRITICAL**: No user story work until this phase is complete
+
+- [ ] T004 Add `StartTime` and `DismissalTime` (`TimeSpan?`) to `BusBuddy.Core/Models/Destination.cs` and configure in `BusBuddy.Core/Data/BusBuddyDbContext.cs`
+- [ ] T005 Add EF migration under `BusBuddy.Core/Migrations/` for Destination school times; update snapshot; note Windows SQL Server apply path
+- [ ] T006 [P] Add ride-mode helper in `BusBuddy.Core/Models/StudentRideMode.cs` (AM / PM / Both derived from `AMRoute`/`PMRoute`, with optional future enum)
+- [ ] T007 Create `IRouteDeterminationService` in `BusBuddy.Core/Services/RouteDetermination/IRouteDeterminationService.cs` matching [contracts/route-determination.md](./contracts/route-determination.md) (`GenerateAndAssignAsync`, `RecalculateOnAssignAsync`, `ApplyClerkOverrideAsync`)
+- [ ] T008 [P] Create DTOs `RouteGenerationResult`, `RouteProposalDto`, `AssignFitnessResult` in `BusBuddy.Core/Services/RouteDetermination/RouteDeterminationModels.cs` per [data-model.md](./data-model.md) and [contracts/assign-fitness.md](./contracts/assign-fitness.md)
+- [ ] T009 Register `IRouteDeterminationService` (stub or real) in `BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs` and `BusBuddy.WPF/App.xaml.cs`
+
+**Checkpoint**: Build succeeds; Destination times migrate on SQL Server; DI resolves `IRouteDeterminationService`
+
+---
+
+## Phase 3: User Story 1 - Year-start auto route build (Priority: P1) 🎯 MVP
+
+**Goal**: Minimum HomeToSchool AM routes (+ mirrored PM structure) from school times, homes, seating, density cells + outlier split; auto-assign with map override hook
+
+**Independent Test**: 12 nearby students + bus seats ≥12 → 1 AM proposal; distant gap → >1 route; AM-only student keeps stop on PM mirror; clerk override moves student
+
+### Tests for User Story 1
+
+- [ ] T010 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/DensityCellBuilderTests.cs` — bbox/density yields N cells; empty coords excluded
+- [ ] T011 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/RoutePackingTests.cs` — 12 nearby riders pack into one route under seating; outlier gap forces split (SC-001/SC-002)
+- [ ] T012 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/RideModeMirrorTests.cs` — AM-only retains stop on PM mirror proposal
+
+### Implementation for User Story 1
+
+- [ ] T013 [US1] Implement density/bbox cell builder in `BusBuddy.Core/Services/RouteDetermination/DensityCellBuilder.cs` (Q3:B)
+- [ ] T014 [US1] Implement outlier gap split + greedy seating packer in `BusBuddy.Core/Services/RouteDetermination/RoutePacker.cs` (hard capacity = suggested/assigned bus seating)
+- [ ] T015 [US1] Implement `RouteDeterminationService.GenerateAndAssignAsync` for `FleetKind.HomeToSchool` in `BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs` (create draft routes + AM assignments; mirror PM stop structure)
+- [ ] T016 [US1] Implement `ApplyClerkOverrideAsync` in `RouteDeterminationService.cs` (move student between proposals/routes; Serilog override)
+- [ ] T017 [US1] Persist accepted drafts via `IRouteService` / route create helpers in `RouteDeterminationService.cs` (naming `Draft-{School}-{Cell}-{n}` or accept-into-existing)
+- [ ] T018 [US1] Add year-start **Generate routes** command on `BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs` (or Students) calling `GenerateAndAssignAsync`
+- [ ] T019 [US1] Show draft proposals on map / status in `BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs` (or Route map path) for override selection
+- [ ] T020 [US1] Serilog `Route generation completed School={SchoolId} Fleet={Fleet} Routes={N} Students={S}` in `RouteDeterminationService.cs`
+
+**Checkpoint**: US1 unit tests green; year-start generate produces drafts for one school
+
+---
+
+## Phase 4: User Story 2 - Assign-time toast and route suggestion (Priority: P1)
+
+**Goal**: On assign — **block** hard seating (unless override); **warn-and-allow** time/geo; toast + suggested routes / new route past threshold
+
+**Independent Test**: Overload → Blocked + no persist; time risk → Warned + assign proceeds; suggestions populated when alternate exists
+
+### Tests for User Story 2
+
+- [ ] T021 [P] [US2] Add `BusBuddy.Tests/Core/RouteDetermination/AssignFitnessTests.cs` — seating block without override; seating allow with override; warn on arrival/geo; SuggestNewRoute flag
+
+### Implementation for User Story 2
+
+- [ ] T022 [US2] Implement `RecalculateOnAssignAsync` / fitness evaluator in `BusBuddy.Core/Services/RouteDetermination/AssignFitnessEvaluator.cs` per [contracts/assign-fitness.md](./contracts/assign-fitness.md) (Q2:B)
+- [ ] T023 [US2] Wrap `AssignStudentToRouteAsync` path in `BusBuddy.Core/Services/RouteService.cs` (or caller) to consult fitness before persist; record seating override when requested
+- [ ] T024 [US2] Surface Syncfusion toast/status from `AssignFitnessResult` in `BusBuddy.WPF/ViewModels/Student/StudentsViewModel.cs` (bulk/single assign) and/or Route assign UI
+- [ ] T025 [US2] When `SuggestNewRoute`, offer command to call generation for that school cell in the same ViewModel
+- [ ] T026 [US2] Serilog `Assign fitness Blocked|Warned Student={Id} Route={Id} Reasons={Reasons}` in fitness evaluator
+
+**Checkpoint**: US2 tests green; UI blocks overload and warns on time/geo
+
+---
+
+## Phase 5: User Story 3 - School times drive pickup schedule (Priority: P2)
+
+**Goal**: Start/dismissal on school Destination; backward AM pickups; forward PM from dismissal
+
+**Independent Test**: Changing StartTime regenerates monotonic pickup times; PM mirror consistent with dismissal
+
+### Tests for User Story 3
+
+- [ ] T027 [P] [US3] Add `BusBuddy.Tests/Core/RouteDetermination/PickupScheduleTests.cs` — backward from StartTime; forward from DismissalTime; fail generation when StartTime missing
+
+### Implementation for User Story 3
+
+- [ ] T028 [US3] Implement `PickupScheduleCalculator.cs` in `BusBuddy.Core/Services/RouteDetermination/` (Maps `IRoutingService` ETA when available; else AverageSpeedMph Haversine)
+- [ ] T029 [US3] Integrate schedule calculator into `GenerateAndAssignAsync` and regenerate-on-StartTime-change helper
+- [ ] T030 [US3] Add StartTime/DismissalTime editors on school Destination UI (`BusBuddy.WPF` school/map destination form — extend existing Destination or Student school panel)
+- [ ] T031 [US3] Persist computed stop times onto `RouteStop` ScheduledArrival/Departure (or documented student fields) when writing proposals
+
+**Checkpoint**: US3 tests green; school time fields editable; schedules regenerate
+
+---
+
+## Phase 6: User Story 4 - Independent transfer route planning (Priority: P2)
+
+**Goal**: Separate Transfer fleet pool using transfer pickup/dropoff pairs; same packing rules; no seat theft from HomeToSchool (Q1:A)
+
+**Independent Test**: Transfer generation route count independent of home routes; HomeToSchool generation ignores transfer pairs as home substitutes
+
+### Tests for User Story 4
+
+- [ ] T032 [P] [US4] Add `BusBuddy.Tests/Core/RouteDetermination/TransferFleetTests.cs` — Transfer pool separate; home generation does not seat from transfer demand
+
+### Implementation for User Story 4
+
+- [ ] T033 [US4] Extend `GenerateAndAssignAsync` for `FleetKind.Transfer` using active `StudentSchoolTransfer` stops in `RouteDeterminationService.cs`
+- [ ] T034 [US4] Ensure HomeToSchool packing excludes transfer-only legs from home seat counts in `RoutePacker.cs`
+- [ ] T035 [US4] Add **Generate transfer routes** command in `BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs` (or Students transfer context)
+- [ ] T036 [US4] After transfer route accept, call `IRouteWaypointRebuildService` for affected routes in `RouteDeterminationService.cs`
+
+**Checkpoint**: US4 tests green; transfer generate creates separate drafts
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+**Purpose**: Docs, inventory, architecture, RAG
+
+- [ ] T037 [P] Update `docs/action-items.md` 008 checkboxes and link tasks proof
+- [ ] T038 [P] Update `STEADY-STATE-AND-FINISH-ROADMAP.md` architecture map with RouteDetermination service if structural
+- [ ] T039 [P] Re-scan function inventory / `docs/function-tree.md` for planner surfaces
+- [ ] T040 Run `python -m rag.index` after doc/spec updates
+- [ ] T041 VM smoke per [quickstart.md](./quickstart.md); record Serilog proof lines in action-items
+
+---
+
+## Dependencies & Story Order
+
+```text
+Phase 1 Setup
+    ↓
+Phase 2 Foundational (times + interfaces + DI)
+    ↓
+Phase 3 US1 MVP (generate/pack/override) ──┬──→ Phase 4 US2 (fitness on assign)
+    ↓                                      │
+Phase 5 US3 (schedules) ←── uses US1 packer/order
+    ↓
+Phase 6 US4 (transfer fleet) ←── same packer, separate FleetKind
+    ↓
+Phase 7 Polish
+```
+
+**Story completion order**: US1 → US2 (can partly parallel after T015) → US3 → US4 → Polish
+
+**Parallel examples**:
+- After T009: T010–T012 in parallel
+- After T015: T021 tests while T018–T019 UI proceeds
+- Polish T037–T039 in parallel
+
+## Implementation strategy
+
+1. **MVP**: Phase 1–3 only (year-start generate + override) — delivers SC-001/SC-002
+2. **Increment**: US2 assign toasts (day-to-day safety)
+3. **Increment**: US3 school-time scheduling quality
+4. **Increment**: US4 transfer fleet
+5. **Polish**: docs + VM proof + RAG
+
+## Task count summary
+
+| Phase | Tasks | Notes |
+|-------|-------|-------|
+| Setup | T001–T003 | 3 |
+| Foundational | T004–T009 | 6 |
+| US1 | T010–T020 | 11 (3 tests + 8 impl) |
+| US2 | T021–T026 | 6 |
+| US3 | T027–T031 | 5 |
+| US4 | T032–T036 | 5 |
+| Polish | T037–T041 | 5 |
+| **Total** | **T001–T041** | **41** |
+
+**MVP scope**: T001–T020 (Setup + Foundational + US1)
+
+**Format validation**: All tasks use `- [ ]`, Task IDs, optional `[P]`, story labels on US phases only, and concrete file paths.


### PR DESCRIPTION
## Summary
- Student contact model/form: parent email/cell, distinct emergency contact name/phone, medical flag; aliases for form bindings that previously pointed at missing properties.
- Destinations: `School` type with admin contacts, district, grade/age ranges; `IDestinationService` seeds Wiley campus; map **Show Schools** plots GPS schools; student intake school **dropdown** sets `DestinationId` + `School` for home-to-school routing prep.
- Inter-district / campus transfer: `StudentSchoolTransfer` + `IStudentSchoolTransferService` (from/to school, pickup/dropoff time & location); attending school updated to receiving campus.
- Migration: `20260817140000_StudentContactFieldsAlignment` (apply on Postgres/SQL Server).

## Test plan
- [ ] Apply migration; confirm Wiley school appears in Destinations / intake dropdown
- [ ] Add student: select school, parent + emergency fields save; lat/lon still from Maps when key present
- [ ] Map → Show Schools plots Wiley (and other School destinations with coords)
- [ ] Call `IStudentSchoolTransferService.AssignTransferAsync` (or follow-up UI) with from≠to schools, times, pickup/dropoff
- [ ] CI Build & Test + CodeQL green