### PR TITLE
feat: 008 route determination MVP (T001–T020)

### DIFF
--- a/BusBuddy.Core/Configuration/RoutingDistrictSettings.cs
+++ b/BusBuddy.Core/Configuration/RoutingDistrictSettings.cs
@@ -1,0 +1,36 @@
+namespace BusBuddy.Core.Configuration;
+
+/// <summary>
+/// District routing / density planner settings. Bound from the <c>RoutingDistrict</c> config section.
+/// </summary>
+public sealed class RoutingDistrictSettings
+{
+    public const string SectionName = "RoutingDistrict";
+
+    /// <summary>South edge of district frame (degrees). Null ⇒ derive from student homes.</summary>
+    public double? BoundingBoxMinLat { get; set; }
+
+    /// <summary>West edge of district frame (degrees).</summary>
+    public double? BoundingBoxMinLon { get; set; }
+
+    /// <summary>North edge of district frame (degrees).</summary>
+    public double? BoundingBoxMaxLat { get; set; }
+
+    /// <summary>East edge of district frame (degrees).</summary>
+    public double? BoundingBoxMaxLon { get; set; }
+
+    /// <summary>Target riders per density cell (hints N-cell grid). Wiley-scale default ~20.</summary>
+    public int TargetRidersPerCell { get; set; } = 20;
+
+    /// <summary>Estimated travel minutes between consecutive pickups that force an outlier split.</summary>
+    public int MaxPickupGapMinutes { get; set; } = 12;
+
+    /// <summary>Fallback speed for Haversine ETA when Maps routing is unavailable.</summary>
+    public double AverageSpeedMph { get; set; } = 25.0;
+
+    /// <summary>Soft comfort cap (minutes) — warn-and-allow when exceeded.</summary>
+    public int? MaxRideMinutes { get; set; } = 45;
+
+    /// <summary>When false, hard seating block has no UI override path.</summary>
+    public bool AllowSeatingOverride { get; set; } = true;
+}

--- a/BusBuddy.Core/Data/BusBuddyDbContext.cs
+++ b/BusBuddy.Core/Data/BusBuddyDbContext.cs
@@ -675,6 +675,8 @@ public class BusBuddyDbContext : DbContext
             entity.Property(e => e.AdminContactName).HasMaxLength(100);
             entity.Property(e => e.AdminPhone).HasMaxLength(20);
             entity.Property(e => e.AdminEmail).HasMaxLength(100);
+            entity.Property(e => e.StartTime);
+            entity.Property(e => e.DismissalTime);
             entity.HasIndex(e => e.DestinationType).HasDatabaseName("IX_Destinations_Type");
             entity.HasIndex(e => e.IsActive).HasDatabaseName("IX_Destinations_Active");
         });

--- a/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
@@ -115,6 +115,8 @@ namespace BusBuddy.Core.Extensions
             services.AddScoped<IStudentSchoolTransferService, StudentSchoolTransferService>();
             services.AddScoped<IRouteWaypointRebuildService, RouteWaypointRebuildService>();
             services.AddScoped<IDriverTrainingService, DriverTrainingService>();
+            services.AddScoped<BusBuddy.Core.Services.RouteDetermination.IRouteDeterminationService,
+                BusBuddy.Core.Services.RouteDetermination.RouteDeterminationService>();
             services.AddScoped<IFuelService, FuelService>();
             services.AddScoped<IMaintenanceService, MaintenanceService>();
             services.AddScoped<IScheduleService, ScheduleService>();
@@ -125,6 +127,8 @@ namespace BusBuddy.Core.Extensions
             // Geospatial: Google Maps Platform (Address Validation). Do not register OfflineGeocodingService in production.
             services.Configure<BusBuddy.Core.Configuration.GoogleMapsOptions>(
                 configuration.GetSection(BusBuddy.Core.Configuration.GoogleMapsOptions.SectionName));
+            services.Configure<BusBuddy.Core.Configuration.RoutingDistrictSettings>(
+                configuration.GetSection(BusBuddy.Core.Configuration.RoutingDistrictSettings.SectionName));
             services.AddSingleton(sp =>
             {
                 var opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<BusBuddy.Core.Configuration.GoogleMapsOptions>>();

--- a/BusBuddy.Core/Migrations/20260817160000_DestinationSchoolTimes.cs
+++ b/BusBuddy.Core/Migrations/20260817160000_DestinationSchoolTimes.cs
@@ -1,0 +1,36 @@
+using BusBuddy.Core.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BusBuddy.Core.Migrations;
+
+/// <summary>
+/// Destination school StartTime / DismissalTime for route determination (spec 008).
+/// Apply on Windows SQL Server: <c>dotnet ef database update --project BusBuddy.Core --startup-project BusBuddy.WPF</c>.
+/// Snapshot may lag older migrations; this Up/Down is authoritative for these columns.
+/// </summary>
+[DbContext(typeof(BusBuddyDbContext))]
+[Migration("20260817160000_DestinationSchoolTimes")]
+public partial class DestinationSchoolTimes : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<TimeSpan>(
+            name: "StartTime",
+            table: "Destinations",
+            nullable: true);
+
+        migrationBuilder.AddColumn<TimeSpan>(
+            name: "DismissalTime",
+            table: "Destinations",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(name: "StartTime", table: "Destinations");
+        migrationBuilder.DropColumn(name: "DismissalTime", table: "Destinations");
+    }
+}

--- a/BusBuddy.Core/Migrations/BusBuddyDbContextModelSnapshot.cs
+++ b/BusBuddy.Core/Migrations/BusBuddyDbContextModelSnapshot.cs
@@ -646,6 +646,12 @@ namespace BusBuddy.Core.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
 
+                    b.Property<TimeSpan?>("StartTime")
+                        .HasColumnType("time");
+
+                    b.Property<TimeSpan?>("DismissalTime")
+                        .HasColumnType("time");
+
                     b.Property<string>("State")
                         .IsRequired()
                         .ValueGeneratedOnAdd()

--- a/BusBuddy.Core/Models/Destination.cs
+++ b/BusBuddy.Core/Models/Destination.cs
@@ -133,6 +133,12 @@ namespace BusBuddy.Core.Models
         [Column(TypeName = "decimal(11,8)")]
         public decimal? Longitude { get; set; }
 
+        /// <summary>School bell / first period start — required for AM route generation (spec 008).</summary>
+        public TimeSpan? StartTime { get; set; }
+
+        /// <summary>School dismissal — drives PM mirror schedule (spec 008).</summary>
+        public TimeSpan? DismissalTime { get; set; }
+
         /// <summary>
         /// Whether this destination is currently active
         /// </summary>

--- a/BusBuddy.Core/Models/StudentRideMode.cs
+++ b/BusBuddy.Core/Models/StudentRideMode.cs
@@ -1,0 +1,53 @@
+namespace BusBuddy.Core.Models;
+
+/// <summary>
+/// AM / PM / Both ride participation derived from student route assignments.
+/// Occasional-rider stops are retained on the unused slot's mirror route.
+/// </summary>
+public enum StudentRideMode
+{
+    Neither = 0,
+    AM = 1,
+    PM = 2,
+    Both = 3
+}
+
+/// <summary>Helpers to derive <see cref="StudentRideMode"/> from AM/PM route name fields.</summary>
+public static class StudentRideModeHelper
+{
+    public static StudentRideMode FromRouteNames(string? amRoute, string? pmRoute)
+    {
+        var hasAm = !string.IsNullOrWhiteSpace(amRoute);
+        var hasPm = !string.IsNullOrWhiteSpace(pmRoute);
+        if (hasAm && hasPm)
+        {
+            return StudentRideMode.Both;
+        }
+
+        if (hasAm)
+        {
+            return StudentRideMode.AM;
+        }
+
+        if (hasPm)
+        {
+            return StudentRideMode.PM;
+        }
+
+        return StudentRideMode.Neither;
+    }
+
+    public static StudentRideMode FromStudent(Student student)
+    {
+        ArgumentNullException.ThrowIfNull(student);
+        return FromRouteNames(student.AMRoute, student.PMRoute);
+    }
+
+    /// <summary>True when the student should keep a stop on the PM mirror even if AM-only.</summary>
+    public static bool RetainStopOnPmMirror(StudentRideMode mode) =>
+        mode is StudentRideMode.AM or StudentRideMode.Both or StudentRideMode.Neither;
+
+    /// <summary>True when the student should keep a stop on the AM mirror even if PM-only.</summary>
+    public static bool RetainStopOnAmMirror(StudentRideMode mode) =>
+        mode is StudentRideMode.PM or StudentRideMode.Both or StudentRideMode.Neither;
+}

--- a/BusBuddy.Core/Services/RouteDetermination/DensityCellBuilder.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/DensityCellBuilder.cs
@@ -1,0 +1,93 @@
+using BusBuddy.Core.Configuration;
+
+namespace BusBuddy.Core.Services.RouteDetermination;
+
+/// <summary>Student point used by density / packing.</summary>
+public readonly record struct RiderPoint(int StudentId, double Latitude, double Longitude);
+
+/// <summary>One density grid cell and its riders.</summary>
+public sealed class DensityCell
+{
+    public string CellId { get; init; } = string.Empty;
+    public int Row { get; init; }
+    public int Col { get; init; }
+    public List<RiderPoint> Riders { get; } = new();
+}
+
+/// <summary>
+/// Builds an N-cell density grid over a bbox (settings or rider extent) — Q3:B.
+/// </summary>
+public static class DensityCellBuilder
+{
+    public static IReadOnlyList<DensityCell> Build(
+        IEnumerable<RiderPoint> riders,
+        RoutingDistrictSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(riders);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var withCoords = riders
+            .Where(r => IsFinite(r.Latitude) && IsFinite(r.Longitude))
+            .ToList();
+
+        if (withCoords.Count == 0)
+        {
+            return Array.Empty<DensityCell>();
+        }
+
+        var (minLat, maxLat, minLon, maxLon) = ResolveBbox(withCoords, settings);
+        var target = Math.Max(1, settings.TargetRidersPerCell);
+        var cellCountHint = Math.Max(1, (int)Math.Ceiling(withCoords.Count / (double)target));
+        var gridSide = Math.Max(1, (int)Math.Ceiling(Math.Sqrt(cellCountHint)));
+
+        var latSpan = Math.Max(maxLat - minLat, 1e-6);
+        var lonSpan = Math.Max(maxLon - minLon, 1e-6);
+        var cells = new Dictionary<(int Row, int Col), DensityCell>();
+
+        foreach (var rider in withCoords)
+        {
+            var row = Math.Min(gridSide - 1, (int)((rider.Latitude - minLat) / latSpan * gridSide));
+            var col = Math.Min(gridSide - 1, (int)((rider.Longitude - minLon) / lonSpan * gridSide));
+            row = Math.Max(0, row);
+            col = Math.Max(0, col);
+            var key = (row, col);
+            if (!cells.TryGetValue(key, out var cell))
+            {
+                cell = new DensityCell
+                {
+                    CellId = $"R{row}C{col}",
+                    Row = row,
+                    Col = col
+                };
+                cells[key] = cell;
+            }
+
+            cell.Riders.Add(rider);
+        }
+
+        return cells.Values.OrderBy(c => c.Row).ThenBy(c => c.Col).ToList();
+    }
+
+    private static (double MinLat, double MaxLat, double MinLon, double MaxLon) ResolveBbox(
+        IReadOnlyList<RiderPoint> riders,
+        RoutingDistrictSettings settings)
+    {
+        if (settings.BoundingBoxMinLat is double minLatCfg &&
+            settings.BoundingBoxMaxLat is double maxLatCfg &&
+            settings.BoundingBoxMinLon is double minLonCfg &&
+            settings.BoundingBoxMaxLon is double maxLonCfg &&
+            maxLatCfg > minLatCfg &&
+            maxLonCfg > minLonCfg)
+        {
+            return (minLatCfg, maxLatCfg, minLonCfg, maxLonCfg);
+        }
+
+        return (
+            riders.Min(r => r.Latitude),
+            riders.Max(r => r.Latitude),
+            riders.Min(r => r.Longitude),
+            riders.Max(r => r.Longitude));
+    }
+
+    private static bool IsFinite(double v) => !double.IsNaN(v) && !double.IsInfinity(v);
+}

--- a/BusBuddy.Core/Services/RouteDetermination/IRouteDeterminationService.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/IRouteDeterminationService.cs
@@ -1,0 +1,27 @@
+namespace BusBuddy.Core.Services.RouteDetermination;
+
+/// <summary>Year-start route build, assign fitness, and clerk override (spec 008).</summary>
+public interface IRouteDeterminationService
+{
+    Task<RouteGenerationResult> GenerateAndAssignAsync(
+        int schoolDestinationId,
+        RouteTimeSlotKind slot,
+        FleetKind fleetKind,
+        RouteGenerationOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    Task<AssignFitnessResult> RecalculateOnAssignAsync(
+        int studentId,
+        int routeId,
+        RouteTimeSlotKind slot,
+        bool overrideSeating = false,
+        CancellationToken cancellationToken = default);
+
+    Task<ClerkOverrideResult> ApplyClerkOverrideAsync(
+        int studentId,
+        int fromRouteId,
+        int toRouteId,
+        RouteTimeSlotKind slot,
+        string? reason = null,
+        CancellationToken cancellationToken = default);
+}

--- a/BusBuddy.Core/Services/RouteDetermination/README.md
+++ b/BusBuddy.Core/Services/RouteDetermination/README.md
@@ -1,0 +1,14 @@
+# Route Determination
+
+Year-start fleet sizing and student assignment planner for BusBuddy.
+
+**Contracts**: `specs/008-route-determination/contracts/`
+
+| Type | Role |
+|------|------|
+| `IRouteDeterminationService` | Generate/assign, assign fitness, clerk override |
+| `DensityCellBuilder` | Bbox / density N-cell grid (Q3:B) |
+| `RoutePacker` | Seating pack + outlier gap split |
+| `RouteDeterminationService` | Orchestrates HomeToSchool (+ later Transfer) |
+
+Apply Destination school-time migrations on **Windows SQL Server** (`dotnet ef database update`).

--- a/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationModels.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationModels.cs
@@ -1,0 +1,74 @@
+namespace BusBuddy.Core.Services.RouteDetermination;
+
+public enum RouteTimeSlotKind
+{
+    AM,
+    PM,
+    Both
+}
+
+public enum FleetKind
+{
+    HomeToSchool,
+    Transfer
+}
+
+public enum AssignFitnessSeverity
+{
+    None,
+    Warn,
+    Block
+}
+
+public sealed class RouteGenerationOptions
+{
+    /// <summary>When true, return proposals without creating routes or assigning students.</summary>
+    public bool DryRun { get; set; }
+
+    /// <summary>Preferred seating capacity when no bus is assigned yet (default 72).</summary>
+    public int DefaultSeatingCapacity { get; set; } = 72;
+}
+
+public sealed class RouteProposalDto
+{
+    public string ProposalKey { get; set; } = string.Empty;
+    public string SuggestedRouteName { get; set; } = string.Empty;
+    public int? PersistedRouteId { get; set; }
+    public RouteTimeSlotKind Slot { get; set; }
+    public FleetKind FleetKind { get; set; }
+    public string CellId { get; set; } = string.Empty;
+    public IReadOnlyList<int> OrderedStudentIds { get; set; } = Array.Empty<int>();
+    public int SuggestedBusSeatingCapacity { get; set; }
+    public double EstimatedMiles { get; set; }
+    public double EstimatedMinutes { get; set; }
+    public string Status { get; set; } = "Draft";
+}
+
+public sealed class RouteGenerationResult
+{
+    public Guid OperationId { get; set; }
+    public int SchoolDestinationId { get; set; }
+    public FleetKind FleetKind { get; set; }
+    public IReadOnlyList<RouteProposalDto> Proposals { get; set; } = Array.Empty<RouteProposalDto>();
+    public IReadOnlyList<int> UnclusteredStudentIds { get; set; } = Array.Empty<int>();
+    public IReadOnlyList<string> Warnings { get; set; } = Array.Empty<string>();
+    public int AssignedStudentCount { get; set; }
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+}
+
+public sealed class AssignFitnessResult
+{
+    public bool Allowed { get; set; } = true;
+    public AssignFitnessSeverity Severity { get; set; } = AssignFitnessSeverity.None;
+    public IReadOnlyList<string> Reasons { get; set; } = Array.Empty<string>();
+    public IReadOnlyList<int> SuggestedRouteIds { get; set; } = Array.Empty<int>();
+    public bool SuggestNewRoute { get; set; }
+}
+
+public sealed class ClerkOverrideResult
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+    public bool RetainedMirrorStop { get; set; }
+}

--- a/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
@@ -1,0 +1,469 @@
+using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Serilog;
+
+namespace BusBuddy.Core.Services.RouteDetermination;
+
+/// <summary>Spec 008 year-start generate/assign and clerk override.</summary>
+public sealed class RouteDeterminationService : IRouteDeterminationService
+{
+    private static readonly ILogger Logger = Log.ForContext<RouteDeterminationService>();
+
+    private readonly IBusBuddyDbContextFactory _contextFactory;
+    private readonly IRouteService _routeService;
+    private readonly RoutingDistrictSettings _settings;
+
+    public RouteDeterminationService(
+        IBusBuddyDbContextFactory contextFactory,
+        IRouteService routeService,
+        IOptions<RoutingDistrictSettings>? settings = null)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        _routeService = routeService ?? throw new ArgumentNullException(nameof(routeService));
+        _settings = settings?.Value ?? new RoutingDistrictSettings();
+    }
+
+    public async Task<RouteGenerationResult> GenerateAndAssignAsync(
+        int schoolDestinationId,
+        RouteTimeSlotKind slot,
+        FleetKind fleetKind,
+        RouteGenerationOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var opId = Guid.NewGuid();
+        options ??= new RouteGenerationOptions();
+        var warnings = new List<string>();
+
+        if (fleetKind == FleetKind.Transfer)
+        {
+            return new RouteGenerationResult
+            {
+                OperationId = opId,
+                SchoolDestinationId = schoolDestinationId,
+                FleetKind = fleetKind,
+                Success = false,
+                Error = "Transfer fleet generation is not in MVP (see US4 / T033)."
+            };
+        }
+
+        await using var context = _contextFactory.CreateDbContext();
+        var school = await context.Destinations.AsNoTracking()
+            .FirstOrDefaultAsync(d => d.DestinationId == schoolDestinationId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (school is null)
+        {
+            return Fail(opId, schoolDestinationId, fleetKind, $"School destination {schoolDestinationId} not found");
+        }
+
+        if (slot is RouteTimeSlotKind.AM or RouteTimeSlotKind.Both && school.StartTime is null)
+        {
+            return Fail(opId, schoolDestinationId, fleetKind,
+                $"School '{school.Name}' is missing StartTime required for AM generation");
+        }
+
+        if (slot is RouteTimeSlotKind.PM or RouteTimeSlotKind.Both && school.DismissalTime is null)
+        {
+            warnings.Add($"School '{school.Name}' has no DismissalTime; PM mirror will still create stop structure");
+        }
+
+        var students = await context.Students.AsNoTracking()
+            .Where(s => s.DestinationId == schoolDestinationId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var riders = new List<RiderPoint>();
+        var unclustered = new List<int>();
+        foreach (var s in students)
+        {
+            if (s.Latitude is decimal lat && s.Longitude is decimal lon)
+            {
+                riders.Add(new RiderPoint(s.StudentId, (double)lat, (double)lon));
+            }
+            else
+            {
+                unclustered.Add(s.StudentId);
+            }
+        }
+
+        if (unclustered.Count > 0)
+        {
+            warnings.Add($"{unclustered.Count} student(s) lack coordinates and were left unclustered");
+        }
+
+        var seating = await ResolveDefaultSeatingAsync(context, options.DefaultSeatingCapacity, cancellationToken)
+            .ConfigureAwait(false);
+
+        var cells = DensityCellBuilder.Build(riders, _settings);
+        var packed = new List<(DensityCell Cell, PackedRoute Pack)>();
+        foreach (var cell in cells)
+        {
+            foreach (var pack in RoutePacker.PackCell(cell, seating, _settings))
+            {
+                packed.Add((cell, pack));
+            }
+        }
+
+        var proposals = new List<RouteProposalDto>();
+        var assigned = 0;
+        var schoolSlug = SanitizeName(school.Name);
+        var packIndex = 0;
+
+        foreach (var (cell, pack) in packed)
+        {
+            packIndex++;
+            var amName = $"Draft-{schoolSlug}-{cell.CellId}-{packIndex}";
+            var amProposal = await MaterializeProposalAsync(
+                    amName,
+                    pack,
+                    RouteTimeSlotKind.AM,
+                    fleetKind,
+                    options.DryRun,
+                    assignAm: slot is RouteTimeSlotKind.AM or RouteTimeSlotKind.Both,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            proposals.Add(amProposal);
+            if (amProposal.PersistedRouteId is not null &&
+                slot is RouteTimeSlotKind.AM or RouteTimeSlotKind.Both)
+            {
+                assigned += pack.OrderedStudentIds.Count;
+            }
+
+            if (slot is RouteTimeSlotKind.PM or RouteTimeSlotKind.Both)
+            {
+                var pmName = $"{amName}-PM";
+                var pmProposal = await MaterializeProposalAsync(
+                        pmName,
+                        pack,
+                        RouteTimeSlotKind.PM,
+                        fleetKind,
+                        options.DryRun,
+                        assignAm: false,
+                        cancellationToken,
+                        assignPmMirror: !options.DryRun && slot == RouteTimeSlotKind.Both,
+                        amRouteNameForMirror: amName)
+                    .ConfigureAwait(false);
+                proposals.Add(pmProposal);
+            }
+        }
+
+        Logger.Information(
+            "Route generation completed School={SchoolId} Fleet={Fleet} Routes={N} Students={S} OpId={OpId}",
+            schoolDestinationId,
+            fleetKind,
+            proposals.Count,
+            assigned,
+            opId);
+
+        return new RouteGenerationResult
+        {
+            OperationId = opId,
+            SchoolDestinationId = schoolDestinationId,
+            FleetKind = fleetKind,
+            Proposals = proposals,
+            UnclusteredStudentIds = unclustered,
+            Warnings = warnings,
+            AssignedStudentCount = assigned,
+            Success = true
+        };
+    }
+
+    public async Task<AssignFitnessResult> RecalculateOnAssignAsync(
+        int studentId,
+        int routeId,
+        RouteTimeSlotKind slot,
+        bool overrideSeating = false,
+        CancellationToken cancellationToken = default)
+    {
+        // Full toast policy is US2; MVP exposes seating hard-block for callers.
+        if (slot == RouteTimeSlotKind.Both)
+        {
+            return new AssignFitnessResult
+            {
+                Allowed = false,
+                Severity = AssignFitnessSeverity.Block,
+                Reasons = new[] { "Specify AM or PM for assign fitness" }
+            };
+        }
+
+        await using var context = _contextFactory.CreateDbContext();
+        var route = await context.Routes.AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RouteId == routeId, cancellationToken)
+            .ConfigureAwait(false);
+        if (route is null)
+        {
+            return new AssignFitnessResult
+            {
+                Allowed = false,
+                Severity = AssignFitnessSeverity.Block,
+                Reasons = new[] { $"Route {routeId} not found" }
+            };
+        }
+
+        var timeSlot = slot == RouteTimeSlotKind.AM ? RouteTimeSlot.AM : RouteTimeSlot.PM;
+        var capacity = await GetCapacityAsync(context, route, timeSlot, cancellationToken).ConfigureAwait(false);
+        var assigned = await CountAssignedAsync(context, route.RouteName, timeSlot, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (capacity > 0 && assigned + 1 > capacity && !overrideSeating)
+        {
+            var reasons = new[] { $"Seating capacity {capacity} would be exceeded ({assigned} already assigned)" };
+            Logger.Information(
+                "Assign fitness Blocked Student={Id} Route={RouteId} Reasons={Reasons}",
+                studentId, routeId, string.Join("; ", reasons));
+            return new AssignFitnessResult
+            {
+                Allowed = false,
+                Severity = AssignFitnessSeverity.Block,
+                Reasons = reasons,
+                SuggestNewRoute = true
+            };
+        }
+
+        return new AssignFitnessResult
+        {
+            Allowed = true,
+            Severity = AssignFitnessSeverity.None
+        };
+    }
+
+    public async Task<ClerkOverrideResult> ApplyClerkOverrideAsync(
+        int studentId,
+        int fromRouteId,
+        int toRouteId,
+        RouteTimeSlotKind slot,
+        string? reason = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (slot == RouteTimeSlotKind.Both)
+        {
+            return new ClerkOverrideResult { Success = false, Error = "Specify AM or PM for override" };
+        }
+
+        var timeSlot = slot == RouteTimeSlotKind.AM ? RouteTimeSlot.AM : RouteTimeSlot.PM;
+
+        await using var context = _contextFactory.CreateDbContext();
+        var student = await context.Students.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.StudentId == studentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (student is null)
+        {
+            return new ClerkOverrideResult { Success = false, Error = $"Student {studentId} not found" };
+        }
+
+        var mode = StudentRideModeHelper.FromStudent(student);
+        var remove = await _routeService.RemoveStudentFromRouteAsync(studentId, fromRouteId, timeSlot)
+            .ConfigureAwait(false);
+        if (!remove.IsSuccess)
+        {
+            // Allow override when student was not on from-route (already moved)
+            Logger.Warning("Override remove soft-fail Student={Id}: {Error}", studentId, remove.Error);
+        }
+
+        var assign = await _routeService.AssignStudentToRouteAsync(studentId, toRouteId, timeSlot)
+            .ConfigureAwait(false);
+        if (!assign.IsSuccess)
+        {
+            return new ClerkOverrideResult { Success = false, Error = assign.Error };
+        }
+
+        var retainMirror = slot == RouteTimeSlotKind.AM
+            ? StudentRideModeHelper.RetainStopOnPmMirror(mode)
+            : StudentRideModeHelper.RetainStopOnAmMirror(mode);
+
+        Logger.Information(
+            "Clerk override Student={StudentId} From={From} To={To} Slot={Slot} Reason={Reason} RetainMirror={Retain}",
+            studentId, fromRouteId, toRouteId, slot, reason ?? "(none)", retainMirror);
+
+        return new ClerkOverrideResult { Success = true, RetainedMirrorStop = retainMirror };
+    }
+
+    private async Task<RouteProposalDto> MaterializeProposalAsync(
+        string routeName,
+        PackedRoute pack,
+        RouteTimeSlotKind slot,
+        FleetKind fleetKind,
+        bool dryRun,
+        bool assignAm,
+        CancellationToken cancellationToken,
+        bool assignPmMirror = false,
+        string? amRouteNameForMirror = null)
+    {
+        var dto = new RouteProposalDto
+        {
+            ProposalKey = $"{routeName}:{slot}",
+            SuggestedRouteName = routeName,
+            Slot = slot,
+            FleetKind = fleetKind,
+            CellId = pack.CellId,
+            OrderedStudentIds = pack.OrderedStudentIds.ToList(),
+            SuggestedBusSeatingCapacity = pack.SeatingCapacity,
+            EstimatedMiles = pack.EstimatedMiles,
+            EstimatedMinutes = pack.EstimatedMinutes,
+            Status = dryRun ? "Draft" : "Accepted"
+        };
+
+        if (dryRun)
+        {
+            return dto;
+        }
+
+        var create = await _routeService.CreateRouteAsync(new Route
+        {
+            RouteName = routeName,
+            Date = DateTime.Today,
+            Description = $"008 {fleetKind} {slot} cell {pack.CellId}",
+            IsActive = true,
+            School = routeName.StartsWith("Draft-", StringComparison.Ordinal)
+                ? ExtractSchoolFromDraft(routeName)
+                : null,
+            AMRiders = slot == RouteTimeSlotKind.AM ? pack.OrderedStudentIds.Count : null,
+            PMRiders = slot == RouteTimeSlotKind.PM ? pack.OrderedStudentIds.Count : null
+        }).ConfigureAwait(false);
+
+        if (!create.IsSuccess || create.Value is null)
+        {
+            dto.Status = "Rejected";
+            Logger.Warning("Failed to persist draft route {Name}: {Error}", routeName, create.Error);
+            return dto;
+        }
+
+        dto.PersistedRouteId = create.Value.RouteId;
+        var routeId = create.Value.RouteId;
+
+        if (assignAm && slot == RouteTimeSlotKind.AM)
+        {
+            foreach (var studentId in pack.OrderedStudentIds)
+            {
+                var result = await _routeService.AssignStudentToRouteAsync(studentId, routeId, RouteTimeSlot.AM)
+                    .ConfigureAwait(false);
+                if (!result.IsSuccess)
+                {
+                    Logger.Warning("Assign AM failed Student={Id} Route={Route}: {Error}",
+                        studentId, routeName, result.Error);
+                }
+            }
+        }
+
+        if (assignPmMirror && slot == RouteTimeSlotKind.PM)
+        {
+            // Mirror: assign PM for Both riders; keep AM-only as stop-retained (AM assignment already set).
+            await using var ctx = _contextFactory.CreateDbContext();
+            foreach (var studentId in pack.OrderedStudentIds)
+            {
+                var student = await ctx.Students.AsNoTracking()
+                    .FirstOrDefaultAsync(s => s.StudentId == studentId, cancellationToken)
+                    .ConfigureAwait(false);
+                if (student is null)
+                {
+                    continue;
+                }
+
+                var mode = StudentRideModeHelper.FromRouteNames(
+                    string.IsNullOrWhiteSpace(student.AMRoute) ? amRouteNameForMirror : student.AMRoute,
+                    student.PMRoute);
+
+                // Year-start: treat newly AM-assigned as Both unless previously PM-only preference existed.
+                // AM-only retention: do not clear AM; assign PM only when mode is Both or Neither (new).
+                if (mode is StudentRideMode.PM)
+                {
+                    continue;
+                }
+
+                // Default year-start: assign PM mirror for all packed AM students (Both).
+                // AM-only students still retain presence via ordered stop list on this PM draft.
+                var result = await _routeService.AssignStudentToRouteAsync(studentId, routeId, RouteTimeSlot.PM)
+                    .ConfigureAwait(false);
+                if (!result.IsSuccess)
+                {
+                    Logger.Debug(
+                        "PM mirror assign skipped/failed Student={Id} (may be AM-only retention): {Error}",
+                        studentId, result.Error);
+                }
+            }
+        }
+
+        return dto;
+    }
+
+    private static string ExtractSchoolFromDraft(string routeName)
+    {
+        // Draft-{School}-{Cell}-{n} or Draft-{School}-{Cell}-{n}-PM
+        var parts = routeName.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2 ? parts[1] : routeName;
+    }
+
+    private static string SanitizeName(string name)
+    {
+        var cleaned = new string(name.Where(ch => char.IsLetterOrDigit(ch) || ch == ' ').ToArray())
+            .Trim()
+            .Replace(' ', '_');
+        return string.IsNullOrWhiteSpace(cleaned) ? "School" : cleaned;
+    }
+
+    private static async Task<int> ResolveDefaultSeatingAsync(
+        BusBuddyDbContext context,
+        int fallback,
+        CancellationToken cancellationToken)
+    {
+        var bus = await context.Buses.AsNoTracking()
+            .Where(b => b.Status == "Active" && b.SeatingCapacity > 0)
+            .OrderByDescending(b => b.SeatingCapacity)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return bus?.SeatingCapacity > 0 ? bus.SeatingCapacity : fallback;
+    }
+
+    private static async Task<int> GetCapacityAsync(
+        BusBuddyDbContext context,
+        Route route,
+        RouteTimeSlot slot,
+        CancellationToken cancellationToken)
+    {
+        var vehicleId = slot == RouteTimeSlot.AM ? route.AMVehicleId : route.PMVehicleId;
+        if (vehicleId is int id)
+        {
+            var bus = await context.Buses.AsNoTracking()
+                .FirstOrDefaultAsync(b => b.BusId == id, cancellationToken)
+                .ConfigureAwait(false);
+            if (bus is not null)
+            {
+                return bus.SeatingCapacity;
+            }
+        }
+
+        return 72;
+    }
+
+    private static async Task<int> CountAssignedAsync(
+        BusBuddyDbContext context,
+        string routeName,
+        RouteTimeSlot slot,
+        CancellationToken cancellationToken)
+    {
+        if (slot == RouteTimeSlot.AM)
+        {
+            return await context.Students.AsNoTracking()
+                .CountAsync(s => s.AMRoute == routeName, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return await context.Students.AsNoTracking()
+            .CountAsync(s => s.PMRoute == routeName, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static RouteGenerationResult Fail(
+        Guid opId, int schoolId, FleetKind fleet, string error) =>
+        new()
+        {
+            OperationId = opId,
+            SchoolDestinationId = schoolId,
+            FleetKind = fleet,
+            Success = false,
+            Error = error
+        };
+}

--- a/BusBuddy.Core/Services/RouteDetermination/RoutePacker.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/RoutePacker.cs
@@ -1,0 +1,129 @@
+using BusBuddy.Core.Configuration;
+
+namespace BusBuddy.Core.Services.RouteDetermination;
+
+/// <summary>One packed route proposal within a density cell.</summary>
+public sealed class PackedRoute
+{
+    public string CellId { get; init; } = string.Empty;
+    public List<int> OrderedStudentIds { get; } = new();
+    public int SeatingCapacity { get; init; }
+    public double EstimatedMiles { get; set; }
+    public double EstimatedMinutes { get; set; }
+}
+
+/// <summary>
+/// Greedy seating packer with outlier gap splits (hard capacity = bus seating).
+/// </summary>
+public static class RoutePacker
+{
+    public static IReadOnlyList<PackedRoute> PackCell(
+        DensityCell cell,
+        int seatingCapacity,
+        RoutingDistrictSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(cell);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var capacity = Math.Max(1, seatingCapacity);
+        if (cell.Riders.Count == 0)
+        {
+            return Array.Empty<PackedRoute>();
+        }
+
+        // Nearest-neighbor order from cell centroid
+        var centroidLat = cell.Riders.Average(r => r.Latitude);
+        var centroidLon = cell.Riders.Average(r => r.Longitude);
+        var ordered = cell.Riders
+            .OrderBy(r => HaversineMiles(centroidLat, centroidLon, r.Latitude, r.Longitude))
+            .ToList();
+
+        var routes = new List<PackedRoute>();
+        var current = NewRoute(cell.CellId, capacity);
+        RiderPoint? previous = null;
+
+        foreach (var rider in ordered)
+        {
+            var gapMinutes = previous is null
+                ? 0
+                : EstimateMinutes(previous.Value, rider, settings.AverageSpeedMph);
+
+            var wouldExceedGap = previous is not null && gapMinutes > settings.MaxPickupGapMinutes;
+            var wouldExceedSeats = current.OrderedStudentIds.Count >= capacity;
+
+            if ((wouldExceedSeats || wouldExceedGap) && current.OrderedStudentIds.Count > 0)
+            {
+                FinalizeEstimates(current, cell.Riders, settings.AverageSpeedMph);
+                routes.Add(current);
+                current = NewRoute(cell.CellId, capacity);
+                previous = null;
+            }
+
+            current.OrderedStudentIds.Add(rider.StudentId);
+            previous = rider;
+        }
+
+        if (current.OrderedStudentIds.Count > 0)
+        {
+            FinalizeEstimates(current, cell.Riders, settings.AverageSpeedMph);
+            routes.Add(current);
+        }
+
+        return routes;
+    }
+
+    private static PackedRoute NewRoute(string cellId, int capacity) =>
+        new() { CellId = cellId, SeatingCapacity = capacity };
+
+    private static void FinalizeEstimates(
+        PackedRoute route,
+        IReadOnlyList<RiderPoint> allRiders,
+        double avgMph)
+    {
+        var byId = allRiders.ToDictionary(r => r.StudentId);
+        double miles = 0;
+        RiderPoint? prev = null;
+        foreach (var id in route.OrderedStudentIds)
+        {
+            if (!byId.TryGetValue(id, out var pt))
+            {
+                continue;
+            }
+
+            if (prev is not null)
+            {
+                miles += HaversineMiles(prev.Value.Latitude, prev.Value.Longitude, pt.Latitude, pt.Longitude);
+            }
+
+            prev = pt;
+        }
+
+        route.EstimatedMiles = Math.Round(miles, 2);
+        route.EstimatedMinutes = avgMph <= 0 ? 0 : Math.Round(miles / avgMph * 60.0, 1);
+    }
+
+    private static double EstimateMinutes(RiderPoint a, RiderPoint b, double avgMph)
+    {
+        if (avgMph <= 0)
+        {
+            return 0;
+        }
+
+        var miles = HaversineMiles(a.Latitude, a.Longitude, b.Latitude, b.Longitude);
+        return miles / avgMph * 60.0;
+    }
+
+    /// <summary>Great-circle distance in miles.</summary>
+    public static double HaversineMiles(double lat1, double lon1, double lat2, double lon2)
+    {
+        const double R = 3958.8;
+        static double ToRad(double d) => d * Math.PI / 180.0;
+        var dLat = ToRad(lat2 - lat1);
+        var dLon = ToRad(lon2 - lon1);
+        var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
+                Math.Cos(ToRad(lat1)) * Math.Cos(ToRad(lat2)) *
+                Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        var c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+        return R * c;
+    }
+}

--- a/BusBuddy.Core/appsettings.json
+++ b/BusBuddy.Core/appsettings.json
@@ -13,6 +13,17 @@
     "EnableUspsCass": true,
     "RegionCode": "US"
   },
+  "RoutingDistrict": {
+    "BoundingBoxMinLat": 38.10,
+    "BoundingBoxMinLon": -102.80,
+    "BoundingBoxMaxLat": 38.30,
+    "BoundingBoxMaxLon": -102.60,
+    "TargetRidersPerCell": 20,
+    "MaxPickupGapMinutes": 12,
+    "AverageSpeedMph": 25,
+    "MaxRideMinutes": 45,
+    "AllowSeatingOverride": true
+  },
   "XAI": {
     "ApiKey": "${XAI_API_KEY}",
     "BaseUrl": "https://api.x.ai/v1",

--- a/BusBuddy.Tests/Core/RouteDetermination/DensityCellBuilderTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/DensityCellBuilderTests.cs
@@ -1,0 +1,46 @@
+using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Services.RouteDetermination;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core.RouteDetermination;
+
+[TestFixture]
+[Category("Unit")]
+public class DensityCellBuilderTests
+{
+    [Test]
+    public void Build_NearbyRiders_YieldsCellsAndExcludesEmptyCoords()
+    {
+        var settings = new RoutingDistrictSettings
+        {
+            TargetRidersPerCell = 6,
+            BoundingBoxMinLat = 38.0,
+            BoundingBoxMaxLat = 38.2,
+            BoundingBoxMinLon = -102.8,
+            BoundingBoxMaxLon = -102.6
+        };
+
+        var riders = new List<RiderPoint>();
+        for (var i = 0; i < 12; i++)
+        {
+            riders.Add(new RiderPoint(i + 1, 38.10 + (i % 4) * 0.01, -102.70 + (i / 4) * 0.01));
+        }
+
+        // Invalid / empty coords should be excluded by builder (NaN)
+        riders.Add(new RiderPoint(999, double.NaN, -102.7));
+
+        var cells = DensityCellBuilder.Build(riders, settings);
+
+        Assert.That(cells, Is.Not.Empty);
+        Assert.That(cells.Sum(c => c.Riders.Count), Is.EqualTo(12));
+        Assert.That(cells.SelectMany(c => c.Riders).Any(r => r.StudentId == 999), Is.False);
+        Assert.That(cells.Count, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test]
+    public void Build_EmptyInput_ReturnsEmpty()
+    {
+        var cells = DensityCellBuilder.Build(Array.Empty<RiderPoint>(), new RoutingDistrictSettings());
+        Assert.That(cells, Is.Empty);
+    }
+}

--- a/BusBuddy.Tests/Core/RouteDetermination/RideModeMirrorTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/RideModeMirrorTests.cs
@@ -1,0 +1,35 @@
+using BusBuddy.Core.Models;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core.RouteDetermination;
+
+[TestFixture]
+[Category("Unit")]
+public class RideModeMirrorTests
+{
+    [Test]
+    public void AmOnly_RetainsStopOnPmMirror()
+    {
+        var mode = StudentRideModeHelper.FromRouteNames("Draft-School-R0C0-1", null);
+        Assert.That(mode, Is.EqualTo(StudentRideMode.AM));
+        Assert.That(StudentRideModeHelper.RetainStopOnPmMirror(mode), Is.True);
+        Assert.That(StudentRideModeHelper.RetainStopOnAmMirror(mode), Is.False);
+    }
+
+    [Test]
+    public void PmOnly_RetainsStopOnAmMirror()
+    {
+        var mode = StudentRideModeHelper.FromRouteNames(null, "Draft-School-R0C0-1-PM");
+        Assert.That(mode, Is.EqualTo(StudentRideMode.PM));
+        Assert.That(StudentRideModeHelper.RetainStopOnAmMirror(mode), Is.True);
+    }
+
+    [Test]
+    public void Both_RetainsOnBothMirrors()
+    {
+        var mode = StudentRideModeHelper.FromRouteNames("AM-1", "PM-1");
+        Assert.That(mode, Is.EqualTo(StudentRideMode.Both));
+        Assert.That(StudentRideModeHelper.RetainStopOnPmMirror(mode), Is.True);
+        Assert.That(StudentRideModeHelper.RetainStopOnAmMirror(mode), Is.True);
+    }
+}

--- a/BusBuddy.Tests/Core/RouteDetermination/RoutePackingTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/RoutePackingTests.cs
@@ -1,0 +1,60 @@
+using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Services.RouteDetermination;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core.RouteDetermination;
+
+[TestFixture]
+[Category("Unit")]
+public class RoutePackingTests
+{
+    [Test]
+    public void Pack_TwelveNearbyUnderSeating_SingleRoute()
+    {
+        var settings = new RoutingDistrictSettings
+        {
+            TargetRidersPerCell = 20,
+            MaxPickupGapMinutes = 30,
+            AverageSpeedMph = 25
+        };
+
+        var riders = new List<RiderPoint>();
+        for (var i = 0; i < 12; i++)
+        {
+            // ~0.2 mile spacing — well under gap threshold
+            riders.Add(new RiderPoint(i + 1, 38.150 + i * 0.0003, -102.700));
+        }
+
+        var cells = DensityCellBuilder.Build(riders, settings);
+        Assert.That(cells.Count, Is.EqualTo(1));
+
+        var packed = RoutePacker.PackCell(cells[0], seatingCapacity: 72, settings);
+        Assert.That(packed.Count, Is.EqualTo(1), "SC-001: 12 nearby riders pack into one route");
+        Assert.That(packed[0].OrderedStudentIds.Count, Is.EqualTo(12));
+    }
+
+    [Test]
+    public void Pack_OutlierGap_ForcesSplit()
+    {
+        var settings = new RoutingDistrictSettings
+        {
+            TargetRidersPerCell = 50,
+            MaxPickupGapMinutes = 5,
+            AverageSpeedMph = 25
+        };
+
+        // Cluster A near 38.15, outlier ~10+ miles north → long gap minutes
+        var riders = new List<RiderPoint>
+        {
+            new(1, 38.150, -102.700),
+            new(2, 38.151, -102.701),
+            new(3, 38.152, -102.700),
+            new(4, 38.300, -102.700) // distant outlier
+        };
+
+        var cells = DensityCellBuilder.Build(riders, settings);
+        var packed = cells.SelectMany(c => RoutePacker.PackCell(c, seatingCapacity: 72, settings)).ToList();
+
+        Assert.That(packed.Count, Is.GreaterThan(1), "SC-002: distant gap forces >1 route");
+    }
+}

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -433,6 +433,10 @@ namespace BusBuddy.WPF
                 services.AddScoped<BusBuddy.Core.Services.IStudentSchoolTransferService, BusBuddy.Core.Services.StudentSchoolTransferService>();
                 services.AddScoped<BusBuddy.Core.Services.IRouteWaypointRebuildService, BusBuddy.Core.Services.RouteWaypointRebuildService>();
                 services.AddScoped<BusBuddy.Core.Services.IDriverTrainingService, BusBuddy.Core.Services.DriverTrainingService>();
+                services.AddScoped<BusBuddy.Core.Services.RouteDetermination.IRouteDeterminationService,
+                    BusBuddy.Core.Services.RouteDetermination.RouteDeterminationService>();
+                services.Configure<BusBuddy.Core.Configuration.RoutingDistrictSettings>(
+                    configuration.GetSection(BusBuddy.Core.Configuration.RoutingDistrictSettings.SectionName));
                 services.AddScoped<IDriverService, DriverService>();
                 services.AddScoped<IRouteService, RouteService>();
                 services.AddScoped<BusBuddy.Core.Services.Interfaces.IBusService, BusService>();
@@ -484,7 +488,11 @@ namespace BusBuddy.WPF
                 services.AddTransient<BusBuddy.WPF.ViewModels.Driver.DriverScheduleViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Reports.ReportsViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Student.StudentsViewModel>();
-                services.AddTransient<BusBuddy.WPF.ViewModels.Route.RouteManagementViewModel>();
+                services.AddTransient<BusBuddy.WPF.ViewModels.Route.RouteManagementViewModel>(sp =>
+                    new BusBuddy.WPF.ViewModels.Route.RouteManagementViewModel(
+                        sp.GetRequiredService<IBusBuddyDbContextFactory>(),
+                        sp.GetService<IRouteService>(),
+                        sp.GetService<BusBuddy.Core.Services.RouteDetermination.IRouteDeterminationService>()));
                 services.AddTransient<BusBuddy.WPF.ViewModels.Driver.DriverFormViewModel>();
                 services.AddTransient<BusBuddy.WPF.ViewModels.Driver.DriversViewModel>();
                 // Shared map VM: singleton + IServiceScopeFactory so scoped student/bus services are not captured
@@ -504,7 +512,11 @@ namespace BusBuddy.WPF
                             services.AddTransient<BusBuddy.WPF.ViewModels.MainWindowViewModel>();
                             services.AddTransient<BusBuddy.WPF.ViewModels.Dashboard.DashboardViewModel>();
                             services.AddTransient<BusBuddy.WPF.ViewModels.Student.StudentsViewModel>();
-                            services.AddTransient<BusBuddy.WPF.ViewModels.Route.RouteManagementViewModel>();
+                            services.AddTransient<BusBuddy.WPF.ViewModels.Route.RouteManagementViewModel>(sp =>
+                                new BusBuddy.WPF.ViewModels.Route.RouteManagementViewModel(
+                                    sp.GetRequiredService<IBusBuddyDbContextFactory>(),
+                                    sp.GetService<IRouteService>(),
+                                    sp.GetService<BusBuddy.Core.Services.RouteDetermination.IRouteDeterminationService>()));
                             services.AddTransient<BusBuddy.WPF.ViewModels.Driver.DriverFormViewModel>();
                             services.AddTransient<BusBuddy.WPF.ViewModels.Bus.BusFormViewModel>();
                             services.AddTransient<BusBuddy.WPF.Views.Bus.BusForm>();

--- a/BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs
@@ -180,6 +180,46 @@ namespace BusBuddy.WPF.ViewModels.GoogleEarth
         }
 
         /// <summary>
+        /// Surfaces year-start draft proposals on the map status line and selects the first draft route when present.
+        /// </summary>
+        public void ApplyGenerationResult(BusBuddy.Core.Services.RouteDetermination.RouteGenerationResult result)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+            if (!result.Success)
+            {
+                StatusMessage = result.Error ?? "Route generation failed";
+                return;
+            }
+
+            var draftNames = result.Proposals
+                .Select(p => p.SuggestedRouteName)
+                .Where(n => n.StartsWith("Draft-", StringComparison.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            StatusMessage =
+                $"Draft proposals: {result.Proposals.Count} route(s), {result.AssignedStudentCount} assigned, " +
+                $"{result.UnclusteredStudentIds.Count} unclustered — select a Draft-* route to review / override";
+
+            Logger.Information(
+                "Map status updated for generation OpId={OpId} Drafts={DraftCount}",
+                result.OperationId,
+                draftNames.Count);
+
+            _ = Task.Run(async () =>
+            {
+                await LoadRoutesAsync().ConfigureAwait(true);
+                var draft = Routes.FirstOrDefault(r =>
+                    draftNames.Any(n => string.Equals(n, r.RouteName, StringComparison.OrdinalIgnoreCase))
+                    || r.RouteName.StartsWith("Draft-", StringComparison.OrdinalIgnoreCase));
+                if (draft is not null)
+                {
+                    SelectedRoute = draft;
+                }
+            });
+        }
+
+        /// <summary>
         /// Collection of routes to display on the map
         /// </summary>
         public ObservableCollection<RouteModel> Routes

--- a/BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs
@@ -6,6 +6,7 @@ using BusBuddy.Core;
 using BusBuddy.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using BusBuddy.Core.Services;
+using BusBuddy.Core.Services.RouteDetermination;
 using BusBuddy.Core.Models;
 using Serilog;
 using System.Windows.Input;
@@ -13,6 +14,8 @@ using CommunityToolkit.Mvvm.Input;
 using System.Threading.Tasks;
 using System.IO;
 using Serilog.Context;
+using Microsoft.Extensions.DependencyInjection;
+using BusBuddy.WPF;
 
 namespace BusBuddy.WPF.ViewModels.Route
 {
@@ -36,6 +39,7 @@ namespace BusBuddy.WPF.ViewModels.Route
         // Entity Framework context for data access
         private readonly IBusBuddyDbContextFactory _contextFactory;
         private readonly RouteService _routeService; // lightweight direct use for assignment (Phase 1)
+        private readonly IRouteDeterminationService? _routeDetermination;
 
         /// <summary>
         /// Buses available for assignment (Active only) — loaded lazily when first needed.
@@ -131,6 +135,7 @@ namespace BusBuddy.WPF.ViewModels.Route
     public ICommand EditRouteCommand { get; }
     public ICommand DeleteRouteCommand { get; }
     public ICommand GenerateScheduleCommand { get; }
+    public ICommand GenerateRoutesCommand { get; }
     public ICommand ViewMapCommand { get; }
     public ICommand AssignStudentsCommand { get; }
     public ICommand AssignVehicleCommand { get; }
@@ -142,12 +147,22 @@ namespace BusBuddy.WPF.ViewModels.Route
     public ICommand CopyRouteCommand { get; }
 
         public RouteManagementViewModel()
+            : this(
+                new BusBuddyDbContextFactory(),
+                null,
+                App.ServiceProvider?.GetService<IRouteDeterminationService>())
         {
-            // Initialize EF context factory
-            _contextFactory = new BusBuddyDbContextFactory();
-            // Direct instantiation (Phase 1) — in later phase migrate to DI container.
-            // RouteService expects an IBusBuddyDbContextFactory, not a delegate
-            _routeService = new RouteService(_contextFactory);
+        }
+
+        public RouteManagementViewModel(
+            IBusBuddyDbContextFactory contextFactory,
+            IRouteService? routeService,
+            IRouteDeterminationService? routeDetermination)
+        {
+            _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+            _routeService = routeService as RouteService
+                ?? new RouteService(_contextFactory);
+            _routeDetermination = routeDetermination;
             RoutesView = CollectionViewSource.GetDefaultView(Routes);
             RoutesView.Filter = FilterRoutes;
 
@@ -159,6 +174,7 @@ namespace BusBuddy.WPF.ViewModels.Route
             EditRouteCommand = new RelayCommand(EditSelectedRoute, () => IsRouteSelected);
             DeleteRouteCommand = new RelayCommand(DeleteSelectedRoute, () => IsRouteSelected);
             GenerateScheduleCommand = new RelayCommand(GenerateSchedule, () => IsRouteSelected);
+            GenerateRoutesCommand = new AsyncRelayCommand(GenerateRoutesAsync);
             ViewMapCommand = new RelayCommand(OpenMapView);
             AssignStudentsCommand = new RelayCommand(AssignStudents, () => IsRouteSelected);
             AssignVehicleCommand = new RelayCommand(AssignVehicle, () => IsRouteSelected && SelectedBus != null);
@@ -375,6 +391,77 @@ namespace BusBuddy.WPF.ViewModels.Route
             }
         }
     private void GenerateSchedule() => PrintSchedule();
+
+        private async Task GenerateRoutesAsync()
+        {
+            try
+            {
+                var planner = _routeDetermination
+                    ?? App.ServiceProvider?.GetService<IRouteDeterminationService>();
+                if (planner is null)
+                {
+                    StatusMessage = "Route determination service unavailable";
+                    return;
+                }
+
+                await using var context = _contextFactory.CreateDbContext();
+                var schools = await context.Destinations
+                    .Where(d => d.IsActive && d.DestinationType == DestinationTypes.School)
+                    .OrderBy(d => d.Name)
+                    .ToListAsync()
+                    .ConfigureAwait(true);
+
+                if (schools.Count == 0)
+                {
+                    StatusMessage = "No active school destinations — add a school first";
+                    return;
+                }
+
+                Destination? school = null;
+                if (SelectedRoute is not null && !string.IsNullOrWhiteSpace(SelectedRoute.School))
+                {
+                    school = schools.FirstOrDefault(s =>
+                        string.Equals(s.Name, SelectedRoute.School, StringComparison.OrdinalIgnoreCase));
+                }
+
+                school ??= schools.FirstOrDefault(s => s.StartTime.HasValue) ?? schools[0];
+
+                StatusMessage = $"Generating routes for '{school.Name}'...";
+                var result = await planner.GenerateAndAssignAsync(
+                        school.DestinationId,
+                        RouteTimeSlotKind.Both,
+                        FleetKind.HomeToSchool)
+                    .ConfigureAwait(true);
+
+                if (!result.Success)
+                {
+                    StatusMessage = result.Error ?? "Route generation failed";
+                    return;
+                }
+
+                await LoadRoutesAsync().ConfigureAwait(true);
+
+                var draft = Routes.FirstOrDefault(r =>
+                    r.RouteName.StartsWith("Draft-", StringComparison.OrdinalIgnoreCase));
+                if (draft is not null)
+                {
+                    SelectedRoute = draft;
+                }
+
+                var mapVm = App.ServiceProvider?.GetService<BusBuddy.WPF.ViewModels.GoogleEarth.GoogleEarthViewModel>();
+                mapVm?.ApplyGenerationResult(result);
+
+                StatusMessage =
+                    $"Generated {result.Proposals.Count} proposal(s), assigned {result.AssignedStudentCount} student(s)" +
+                    (result.Warnings.Count > 0 ? $" — {result.Warnings[0]}" : string.Empty);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Generate routes failed");
+                StatusMessage = $"Error generating routes: {ex.Message}";
+            }
+        }
+
     private void OpenMapView() => AssignStudents();
     private void PrintMaps()
     {

--- a/BusBuddy.WPF/Views/Route/RouteManagementView.xaml
+++ b/BusBuddy.WPF/Views/Route/RouteManagementView.xaml
@@ -110,6 +110,15 @@
                 Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
                 AutomationProperties.Name="Generate Schedule"
                 AutomationProperties.HelpText="Generate printable schedule for the selected route"/>
+            <syncfusion:ButtonAdv Name="GenerateRoutesButton" Label="🚌 Generate Routes"
+                            Command="{Binding GenerateRoutesCommand}"
+                SizeMode="Normal"
+                IconHeight="16" IconWidth="16"
+                CornerRadius="4"
+                Background="{StaticResource BusBuddy.Brush.FleetGreen}"
+                Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
+                AutomationProperties.Name="Generate Routes"
+                AutomationProperties.HelpText="Year-start auto route build for school destinations"/>
             <syncfusion:ButtonAdv Name="ViewMapButton" Label="🗺️ View Map"
                             Command="{Binding ViewMapCommand}"
                 SizeMode="Normal"

--- a/BusBuddy.WPF/appsettings.json
+++ b/BusBuddy.WPF/appsettings.json
@@ -12,6 +12,17 @@
     "EnableUspsCass": true,
     "RegionCode": "US"
   },
+  "RoutingDistrict": {
+    "BoundingBoxMinLat": 38.10,
+    "BoundingBoxMinLon": -102.80,
+    "BoundingBoxMaxLat": 38.30,
+    "BoundingBoxMaxLon": -102.60,
+    "TargetRidersPerCell": 20,
+    "MaxPickupGapMinutes": 12,
+    "AverageSpeedMph": 25,
+    "MaxRideMinutes": 45,
+    "AllowSeatingOverride": true
+  },
   "XAI": {
     "Provider": "Ollama",
     "ApiKey": "${XAI_API_KEY}",

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -22,20 +22,22 @@
   - [x] US3: Routes API drive polyline (fail-open optimizer)
   - [x] US4: Places type-ahead — skipped (MVP cut)
   - [x] Docs for US2; Maps clients wired
-- [ ] **Student contact + school destinations** — parent/emergency fields, Destination School catalog, intake school dropdown, map schools, inter-district `StudentSchoolTransfer` (timed pickup/dropoff)
+- [x] **Student contact + school destinations** — parent/emergency fields, Destination School catalog, intake school dropdown, map schools, inter-district `StudentSchoolTransfer` (timed pickup/dropoff) — merged [PR #36](https://github.com/Bigessfour/BusBuddy-3/pull/36)
   - [ ] Apply migration `20260817140000_StudentContactFieldsAlignment` — **Mac Postgres `dotnet ef database update` blocked** (InitialCreate seed uses SQL Server `bit` / unspecified timestamps). Apply on **Windows VM SQL Server**, or use EnsureCreated for local Postgres smoke only.
   - [ ] VM: assign school on intake; Show Schools on map; create transfer home→campus
   - [x] Transfer UI (Students → School Transfer) — pickup/dropoff location + times required; waypoints rebuild on assign/transfer
   - [x] Mac smoke 2026-08-17: InMemory services OK (schools, training 17 rows, transfer validation, waypoints). Postgres Migrate blocked as above.
-- [ ] **Driver employment + CDE training sub-module** — contact/address/hire; [CDE 2024-25 License/Training Matrix](https://resources.finalsite.net/images/v1764086158/cdestatecous/mpcomjjt3zryb1vussig/2024-25-License-Training-Matrix.pdf) checklist via `DriverTrainingRecord` / `IDriverTrainingService`
+- [x] **Driver employment + CDE training sub-module** — contact/address/hire; [CDE 2024-25 License/Training Matrix](https://resources.finalsite.net/images/v1764086158/cdestatecous/mpcomjjt3zryb1vussig/2024-25-License-Training-Matrix.pdf) checklist via `DriverTrainingRecord` / `IDriverTrainingService` — merged [PR #36](https://github.com/Bigessfour/BusBuddy-3/pull/36) (NoTracking write fix for Upsert)
   - [ ] Apply migration `20260817150000_DriverTrainingSubmodule` — same Windows/SQL Server path as above
   - [ ] VM: edit driver employment fields; open Training grid; mark complete + certificate
   - [x] Dedicated training grid UI (Drivers → Training) — mark complete / certificate per row
-- [ ] **008 Route determination / fleet sizing** (Spec-Kit next) — minimize buses with geographic + time comfort; AM/PM mirror with AM-only / PM-only / both; recalc on assign; year-start auto-assign + map override; toast when assign breaks arrival/capacity; home→school and transfer planners separate; target >100 riders / medium–large city, still usable for small districts
+- [ ] **008 Route determination / fleet sizing** — minimize buses with geographic + time comfort; AM/PM mirror with AM-only / PM-only / both; recalc on assign; year-start auto-assign + map override; toast when assign breaks arrival/capacity; home→school and transfer planners separate; target >100 riders / medium–large city, still usable for small districts
   - Design locked 2026-08-17 (user answers): soft capacity = assigned bus `SeatingCapacity` (hard); school map **start times** → work backward for pickups; simple **quadrants** + rural/outlier rules (large pickup gaps → other route); minimize buses without sacrificing ride time/mileage/comfort; keep occasional-rider stops on mirrored routes; suggest new route past thresholds
   - [x] `/speckit-specify` + `/speckit-plan` — [spec](../specs/008-route-determination/spec.md) · [plan](../specs/008-route-determination/plan.md) (Q1:A / Q2:B / Q3:B locked)
   - [x] `/speckit-tasks` — [tasks.md](../specs/008-route-determination/tasks.md) (41 tasks; MVP = US1 T001–T020)
-  - [ ] `/speckit-implement` (prefer after #36 merge) + school start/dismissal on Destination + VM migrate
+  - [x] `/speckit-implement` MVP T001–T020 (Setup + Foundational + US1) on `feature/008-route-determination`
+  - [ ] Apply migration `20260817160000_DestinationSchoolTimes` on Windows SQL Server; VM smoke Generate Routes + map draft status
+  - [ ] US2–US4 + polish (T021–T041)
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit
   - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)

--- a/specs/008-route-determination/tasks.md
+++ b/specs/008-route-determination/tasks.md
@@ -19,9 +19,9 @@
 
 **Purpose**: Folder + DI registration surface for the planner
 
-- [ ] T001 Create directory `BusBuddy.Core/Services/RouteDetermination/` and add placeholder `README.md` noting contracts in `specs/008-route-determination/contracts/`
-- [ ] T002 [P] Add `RoutingDistrictSettings` options class in `BusBuddy.Core/Configuration/RoutingDistrictSettings.cs` (bbox or extent keys, TargetRidersPerCell, MaxPickupGapMinutes, AverageSpeedMph, MaxRideMinutes, AllowSeatingOverride) per [data-model.md](./data-model.md)
-- [ ] T003 [P] Bind `RoutingDistrictSettings` section in `BusBuddy.WPF/appsettings.json` and `BusBuddy.Core/appsettings.json` with Wiley-scale defaults
+- [x] T001 Create directory `BusBuddy.Core/Services/RouteDetermination/` and add placeholder `README.md` noting contracts in `specs/008-route-determination/contracts/`
+- [x] T002 [P] Add `RoutingDistrictSettings` options class in `BusBuddy.Core/Configuration/RoutingDistrictSettings.cs` (bbox or extent keys, TargetRidersPerCell, MaxPickupGapMinutes, AverageSpeedMph, MaxRideMinutes, AllowSeatingOverride) per [data-model.md](./data-model.md)
+- [x] T003 [P] Bind `RoutingDistrictSettings` section in `BusBuddy.WPF/appsettings.json` and `BusBuddy.Core/appsettings.json` with Wiley-scale defaults
 
 ---
 
@@ -31,12 +31,12 @@
 
 **⚠️ CRITICAL**: No user story work until this phase is complete
 
-- [ ] T004 Add `StartTime` and `DismissalTime` (`TimeSpan?`) to `BusBuddy.Core/Models/Destination.cs` and configure in `BusBuddy.Core/Data/BusBuddyDbContext.cs`
-- [ ] T005 Add EF migration under `BusBuddy.Core/Migrations/` for Destination school times; update snapshot; note Windows SQL Server apply path
-- [ ] T006 [P] Add ride-mode helper in `BusBuddy.Core/Models/StudentRideMode.cs` (AM / PM / Both derived from `AMRoute`/`PMRoute`, with optional future enum)
-- [ ] T007 Create `IRouteDeterminationService` in `BusBuddy.Core/Services/RouteDetermination/IRouteDeterminationService.cs` matching [contracts/route-determination.md](./contracts/route-determination.md) (`GenerateAndAssignAsync`, `RecalculateOnAssignAsync`, `ApplyClerkOverrideAsync`)
-- [ ] T008 [P] Create DTOs `RouteGenerationResult`, `RouteProposalDto`, `AssignFitnessResult` in `BusBuddy.Core/Services/RouteDetermination/RouteDeterminationModels.cs` per [data-model.md](./data-model.md) and [contracts/assign-fitness.md](./contracts/assign-fitness.md)
-- [ ] T009 Register `IRouteDeterminationService` (stub or real) in `BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs` and `BusBuddy.WPF/App.xaml.cs`
+- [x] T004 Add `StartTime` and `DismissalTime` (`TimeSpan?`) to `BusBuddy.Core/Models/Destination.cs` and configure in `BusBuddy.Core/Data/BusBuddyDbContext.cs`
+- [x] T005 Add EF migration under `BusBuddy.Core/Migrations/` for Destination school times; update snapshot; note Windows SQL Server apply path
+- [x] T006 [P] Add ride-mode helper in `BusBuddy.Core/Models/StudentRideMode.cs` (AM / PM / Both derived from `AMRoute`/`PMRoute`, with optional future enum)
+- [x] T007 Create `IRouteDeterminationService` in `BusBuddy.Core/Services/RouteDetermination/IRouteDeterminationService.cs` matching [contracts/route-determination.md](./contracts/route-determination.md) (`GenerateAndAssignAsync`, `RecalculateOnAssignAsync`, `ApplyClerkOverrideAsync`)
+- [x] T008 [P] Create DTOs `RouteGenerationResult`, `RouteProposalDto`, `AssignFitnessResult` in `BusBuddy.Core/Services/RouteDetermination/RouteDeterminationModels.cs` per [data-model.md](./data-model.md) and [contracts/assign-fitness.md](./contracts/assign-fitness.md)
+- [x] T009 Register `IRouteDeterminationService` (stub or real) in `BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs` and `BusBuddy.WPF/App.xaml.cs`
 
 **Checkpoint**: Build succeeds; Destination times migrate on SQL Server; DI resolves `IRouteDeterminationService`
 
@@ -50,20 +50,20 @@
 
 ### Tests for User Story 1
 
-- [ ] T010 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/DensityCellBuilderTests.cs` — bbox/density yields N cells; empty coords excluded
-- [ ] T011 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/RoutePackingTests.cs` — 12 nearby riders pack into one route under seating; outlier gap forces split (SC-001/SC-002)
-- [ ] T012 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/RideModeMirrorTests.cs` — AM-only retains stop on PM mirror proposal
+- [x] T010 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/DensityCellBuilderTests.cs` — bbox/density yields N cells; empty coords excluded
+- [x] T011 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/RoutePackingTests.cs` — 12 nearby riders pack into one route under seating; outlier gap forces split (SC-001/SC-002)
+- [x] T012 [P] [US1] Add `BusBuddy.Tests/Core/RouteDetermination/RideModeMirrorTests.cs` — AM-only retains stop on PM mirror proposal
 
 ### Implementation for User Story 1
 
-- [ ] T013 [US1] Implement density/bbox cell builder in `BusBuddy.Core/Services/RouteDetermination/DensityCellBuilder.cs` (Q3:B)
-- [ ] T014 [US1] Implement outlier gap split + greedy seating packer in `BusBuddy.Core/Services/RouteDetermination/RoutePacker.cs` (hard capacity = suggested/assigned bus seating)
-- [ ] T015 [US1] Implement `RouteDeterminationService.GenerateAndAssignAsync` for `FleetKind.HomeToSchool` in `BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs` (create draft routes + AM assignments; mirror PM stop structure)
-- [ ] T016 [US1] Implement `ApplyClerkOverrideAsync` in `RouteDeterminationService.cs` (move student between proposals/routes; Serilog override)
-- [ ] T017 [US1] Persist accepted drafts via `IRouteService` / route create helpers in `RouteDeterminationService.cs` (naming `Draft-{School}-{Cell}-{n}` or accept-into-existing)
-- [ ] T018 [US1] Add year-start **Generate routes** command on `BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs` (or Students) calling `GenerateAndAssignAsync`
-- [ ] T019 [US1] Show draft proposals on map / status in `BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs` (or Route map path) for override selection
-- [ ] T020 [US1] Serilog `Route generation completed School={SchoolId} Fleet={Fleet} Routes={N} Students={S}` in `RouteDeterminationService.cs`
+- [x] T013 [US1] Implement density/bbox cell builder in `BusBuddy.Core/Services/RouteDetermination/DensityCellBuilder.cs` (Q3:B)
+- [x] T014 [US1] Implement outlier gap split + greedy seating packer in `BusBuddy.Core/Services/RouteDetermination/RoutePacker.cs` (hard capacity = suggested/assigned bus seating)
+- [x] T015 [US1] Implement `RouteDeterminationService.GenerateAndAssignAsync` for `FleetKind.HomeToSchool` in `BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs` (create draft routes + AM assignments; mirror PM stop structure)
+- [x] T016 [US1] Implement `ApplyClerkOverrideAsync` in `RouteDeterminationService.cs` (move student between proposals/routes; Serilog override)
+- [x] T017 [US1] Persist accepted drafts via `IRouteService` / route create helpers in `RouteDeterminationService.cs` (naming `Draft-{School}-{Cell}-{n}` or accept-into-existing)
+- [x] T018 [US1] Add year-start **Generate routes** command on `BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs` (or Students) calling `GenerateAndAssignAsync`
+- [x] T019 [US1] Show draft proposals on map / status in `BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs` (or Route map path) for override selection
+- [x] T020 [US1] Serilog `Route generation completed School={SchoolId} Fleet={Fleet} Routes={N} Students={S}` in `RouteDeterminationService.cs`
 
 **Checkpoint**: US1 unit tests green; year-start generate produces drafts for one school
 


### PR DESCRIPTION
## Summary
- Implements Spec-Kit **008** MVP (**T001–T020**): `RoutingDistrictSettings`, Destination `StartTime`/`DismissalTime` + migration, density cell builder, route packer, `IRouteDeterminationService` generate/assign + clerk override, Route Management **Generate Routes**, map draft status.
- Unit tests for density cells, packing (SC-001/SC-002), and AM-only PM mirror retention.
- Follows merge of [#36](https://github.com/Bigessfour/BusBuddy-3/pull/36) (student/school/transfer + driver training).

## Test plan
- [ ] CI Build & Test + CodeQL green
- [ ] Windows VM: `dotnet ef database update` including `20260817160000_DestinationSchoolTimes`
- [ ] Set school StartTime/DismissalTime; seed students with home coords + DestinationId
- [ ] Route Management → **Generate Routes** → Draft-* routes appear; Serilog `Route generation completed`
- [ ] Map status shows draft proposal summary; select Draft route
- [ ] VM: re-smoke #36 School Transfer + Drivers Training grid after SQL migrate
- [ ] Run `RouteDetermination` unit tests on Windows testhost

## Out of scope (later)
US2 assign toasts (T021–T026), US3 pickup schedule (T027–T031), US4 transfer fleet (T032–T036), polish T037–T041.