### PR TITLE
fix+feat: 008 generate hardenings and US2 assign fitness

### DIFF
--- a/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/BusBuddy.Core/Extensions/ServiceCollectionExtensions.cs
@@ -106,6 +106,7 @@ namespace BusBuddy.Core.Extensions
             services.AddScoped<IBusService, BusService>();
             services.AddScoped<IDriverService, DriverService>();
             services.AddScoped<IActivityService, ActivityService>();
+            services.AddScoped<BusBuddy.Core.Services.RouteDetermination.AssignFitnessEvaluator>();
             services.AddScoped<IRouteService, RouteService>();
             services.AddScoped<IStudentRouteOptimizer, StudentRouteOptimizer>();
             services.AddSingleton<PdfReportService>();

--- a/BusBuddy.Core/Models/StudentRideMode.cs
+++ b/BusBuddy.Core/Models/StudentRideMode.cs
@@ -50,4 +50,11 @@ public static class StudentRideModeHelper
     /// <summary>True when the student should keep a stop on the AM mirror even if PM-only.</summary>
     public static bool RetainStopOnAmMirror(StudentRideMode mode) =>
         mode is StudentRideMode.PM or StudentRideMode.Both or StudentRideMode.Neither;
+
+    /// <summary>
+    /// Year-start PM mirror: assign PMRoute unless the student was already AM-only
+    /// (occasional-rider stop stays on the PM proposal OrderedStudentIds only).
+    /// </summary>
+    public static bool ShouldAssignPmMirror(StudentRideMode priorMode) =>
+        priorMode is not StudentRideMode.AM;
 }

--- a/BusBuddy.Core/Services/IRouteService.cs
+++ b/BusBuddy.Core/Services/IRouteService.cs
@@ -33,6 +33,7 @@ namespace BusBuddy.Core.Services
         Task<Result<List<Driver>>> GetAvailableDriversAsync();
         Task<Result<bool>> AssignStudentToRouteAsync(int studentId, int routeId);
         Task<Result<bool>> AssignStudentToRouteAsync(int studentId, int routeId, RouteTimeSlot timeSlot);
+        Task<Result<bool>> AssignStudentToRouteAsync(int studentId, int routeId, RouteTimeSlot timeSlot, bool overrideSeating);
         Task<Result<bool>> RemoveStudentFromRouteAsync(int studentId, int routeId);
         Task<Result<bool>> RemoveStudentFromRouteAsync(int studentId, int routeId, RouteTimeSlot timeSlot);
         Task<Result<List<Student>>> GetUnassignedStudentsAsync();

--- a/BusBuddy.Core/Services/RouteDetermination/AssignFitnessEvaluator.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/AssignFitnessEvaluator.cs
@@ -1,0 +1,263 @@
+using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Serilog;
+
+namespace BusBuddy.Core.Services.RouteDetermination;
+
+/// <summary>Assign-time seating / time / geo fitness (spec 008 US2, Q2:B).</summary>
+public sealed class AssignFitnessEvaluator
+{
+    private static readonly ILogger Logger = Log.ForContext<AssignFitnessEvaluator>();
+
+    private readonly IBusBuddyDbContextFactory _contextFactory;
+    private readonly RoutingDistrictSettings _settings;
+
+    public AssignFitnessEvaluator(
+        IBusBuddyDbContextFactory contextFactory,
+        IOptions<RoutingDistrictSettings>? settings = null)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        _settings = settings?.Value ?? new RoutingDistrictSettings();
+    }
+
+    public async Task<AssignFitnessResult> EvaluateAsync(
+        int studentId,
+        int routeId,
+        RouteTimeSlotKind slot,
+        bool overrideSeating = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (slot == RouteTimeSlotKind.Both)
+        {
+            return Blocked("Specify AM or PM for assign fitness");
+        }
+
+        await using var context = _contextFactory.CreateDbContext();
+        var student = await context.Students.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.StudentId == studentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (student is null)
+        {
+            return Blocked($"Student {studentId} not found");
+        }
+
+        var route = await context.Routes.AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RouteId == routeId, cancellationToken)
+            .ConfigureAwait(false);
+        if (route is null)
+        {
+            return Blocked($"Route {routeId} not found");
+        }
+
+        var timeSlot = slot == RouteTimeSlotKind.AM ? RouteTimeSlot.AM : RouteTimeSlot.PM;
+        var capacity = await ResolveCapacityAsync(context, route, timeSlot, cancellationToken)
+            .ConfigureAwait(false);
+        var assigned = timeSlot == RouteTimeSlot.AM
+            ? await context.Students.AsNoTracking().CountAsync(s => s.AMRoute == route.RouteName, cancellationToken)
+                .ConfigureAwait(false)
+            : await context.Students.AsNoTracking().CountAsync(s => s.PMRoute == route.RouteName, cancellationToken)
+                .ConfigureAwait(false);
+
+        var reasons = new List<string>();
+        var severity = AssignFitnessSeverity.None;
+        var suggestNew = false;
+        var allowed = true;
+
+        if (capacity > 0 && assigned + 1 > capacity)
+        {
+            var msg = $"Seating capacity {capacity} would be exceeded ({assigned} already assigned)";
+            if (overrideSeating && _settings.AllowSeatingOverride)
+            {
+                reasons.Add(msg + " (override recorded)");
+                severity = AssignFitnessSeverity.Warn;
+                Logger.Information(
+                    "Assign fitness Warned Student={Id} Route={RouteId} Reasons={Reasons} Override=true",
+                    studentId, routeId, msg);
+            }
+            else
+            {
+                reasons.Add(msg);
+                severity = AssignFitnessSeverity.Block;
+                allowed = false;
+                suggestNew = true;
+                Logger.Information(
+                    "Assign fitness Blocked Student={Id} Route={RouteId} Reasons={Reasons}",
+                    studentId, routeId, msg);
+            }
+        }
+
+        // Soft: ride-time comfort (Haversine to school campus when available)
+        if (student.Latitude is decimal sLat && student.Longitude is decimal sLon)
+        {
+            Destination? school = null;
+            if (student.DestinationId is int destId)
+            {
+                school = await context.Destinations.AsNoTracking()
+                    .FirstOrDefaultAsync(d => d.DestinationId == destId, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (school?.Latitude is decimal schLat && school.Longitude is decimal schLon)
+            {
+                var miles = RoutePacker.HaversineMiles(
+                    (double)sLat, (double)sLon, (double)schLat, (double)schLon);
+                var minutes = _settings.AverageSpeedMph <= 0
+                    ? 0
+                    : miles / _settings.AverageSpeedMph * 60.0;
+                if (_settings.MaxRideMinutes is int maxRide && minutes > maxRide)
+                {
+                    reasons.Add($"Estimated ride ~{minutes:0} min exceeds soft max {maxRide} min");
+                    if (severity == AssignFitnessSeverity.None)
+                    {
+                        severity = AssignFitnessSeverity.Warn;
+                    }
+
+                    Logger.Information(
+                        "Assign fitness Warned Student={Id} Route={RouteId} Reasons={Reasons}",
+                        studentId, routeId, reasons[^1]);
+                }
+
+                if (slot == RouteTimeSlotKind.AM && school.StartTime is TimeSpan start)
+                {
+                    // Backward estimate: leave home at StartTime - ride; warn if ride alone exceeds soft max already covered.
+                    // Arrival risk: if current time-of-day simulation N/A, flag when estimated minutes leave less than 5 min buffer before start from a nominal 7:00 depot — use MaxRideMinutes only for MVP.
+                    _ = start;
+                }
+            }
+
+            // Geo outlier vs existing assignees on this route/slot
+            var peers = timeSlot == RouteTimeSlot.AM
+                ? await context.Students.AsNoTracking()
+                    .Where(s => s.AMRoute == route.RouteName && s.StudentId != studentId &&
+                                s.Latitude != null && s.Longitude != null)
+                    .ToListAsync(cancellationToken).ConfigureAwait(false)
+                : await context.Students.AsNoTracking()
+                    .Where(s => s.PMRoute == route.RouteName && s.StudentId != studentId &&
+                                s.Latitude != null && s.Longitude != null)
+                    .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            if (peers.Count > 0)
+            {
+                var cLat = peers.Average(p => (double)p.Latitude!.Value);
+                var cLon = peers.Average(p => (double)p.Longitude!.Value);
+                var gapMiles = RoutePacker.HaversineMiles(cLat, cLon, (double)sLat, (double)sLon);
+                var gapMinutes = _settings.AverageSpeedMph <= 0
+                    ? 0
+                    : gapMiles / _settings.AverageSpeedMph * 60.0;
+                if (gapMinutes > _settings.MaxPickupGapMinutes)
+                {
+                    reasons.Add(
+                        $"Geo outlier vs route cluster (~{gapMinutes:0} min gap > {_settings.MaxPickupGapMinutes} min)");
+                    if (severity == AssignFitnessSeverity.None)
+                    {
+                        severity = AssignFitnessSeverity.Warn;
+                    }
+
+                    suggestNew = suggestNew || gapMinutes > _settings.MaxPickupGapMinutes * 2;
+                    Logger.Information(
+                        "Assign fitness Warned Student={Id} Route={RouteId} Reasons={Reasons}",
+                        studentId, routeId, reasons[^1]);
+                }
+            }
+        }
+
+        IReadOnlyList<int> suggested = Array.Empty<int>();
+        if (!allowed || suggestNew)
+        {
+            suggested = await SuggestAlternateRoutesAsync(context, student, routeId, timeSlot, capacity, cancellationToken)
+                .ConfigureAwait(false);
+            if (suggested.Count == 0 && !allowed)
+            {
+                suggestNew = true;
+            }
+        }
+
+        return new AssignFitnessResult
+        {
+            Allowed = allowed,
+            Severity = severity,
+            Reasons = reasons,
+            SuggestedRouteIds = suggested,
+            SuggestNewRoute = suggestNew
+        };
+    }
+
+    private static async Task<IReadOnlyList<int>> SuggestAlternateRoutesAsync(
+        BusBuddyDbContext context,
+        Student student,
+        int excludeRouteId,
+        RouteTimeSlot timeSlot,
+        int neededCapacityHint,
+        CancellationToken cancellationToken)
+    {
+        var routes = await context.Routes.AsNoTracking()
+            .Where(r => r.IsActive && r.RouteId != excludeRouteId)
+            .OrderBy(r => r.RouteName)
+            .Take(40)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var suggestions = new List<int>();
+        foreach (var route in routes)
+        {
+            var cap = await ResolveCapacityAsync(context, route, timeSlot, cancellationToken)
+                .ConfigureAwait(false);
+            var count = timeSlot == RouteTimeSlot.AM
+                ? await context.Students.AsNoTracking().CountAsync(s => s.AMRoute == route.RouteName, cancellationToken)
+                    .ConfigureAwait(false)
+                : await context.Students.AsNoTracking().CountAsync(s => s.PMRoute == route.RouteName, cancellationToken)
+                    .ConfigureAwait(false);
+            if (cap <= 0 || count + 1 <= cap)
+            {
+                suggestions.Add(route.RouteId);
+            }
+
+            if (suggestions.Count >= 5)
+            {
+                break;
+            }
+        }
+
+        _ = student;
+        _ = neededCapacityHint;
+        return suggestions;
+    }
+
+    private static async Task<int> ResolveCapacityAsync(
+        BusBuddyDbContext context,
+        Route route,
+        RouteTimeSlot timeSlot,
+        CancellationToken cancellationToken)
+    {
+        var vehicleId = timeSlot == RouteTimeSlot.AM ? route.AMVehicleId : route.PMVehicleId;
+        if (vehicleId is int id)
+        {
+            var bus = await context.Buses.AsNoTracking()
+                .FirstOrDefaultAsync(b => b.BusId == id, cancellationToken)
+                .ConfigureAwait(false);
+            if (bus is not null && bus.SeatingCapacity > 0)
+            {
+                return bus.SeatingCapacity;
+            }
+        }
+
+        var largest = await context.Buses.AsNoTracking()
+            .Where(b => b.Status == "Active" && b.SeatingCapacity > 0)
+            .OrderByDescending(b => b.SeatingCapacity)
+            .Select(b => b.SeatingCapacity)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return largest > 0 ? largest : 72;
+    }
+
+    private static AssignFitnessResult Blocked(string reason) =>
+        new()
+        {
+            Allowed = false,
+            Severity = AssignFitnessSeverity.Block,
+            Reasons = new[] { reason }
+        };
+}

--- a/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
@@ -39,14 +39,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
 
         if (fleetKind == FleetKind.Transfer)
         {
-            return new RouteGenerationResult
-            {
-                OperationId = opId,
-                SchoolDestinationId = schoolDestinationId,
-                FleetKind = fleetKind,
-                Success = false,
-                Error = "Transfer fleet generation is not in MVP (see US4 / T033)."
-            };
+            return Fail(opId, schoolDestinationId, fleetKind, "Transfer fleet generation is not in MVP (see US4 / T033).");
         }
 
         await using var context = _contextFactory.CreateDbContext();
@@ -59,13 +52,13 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             return Fail(opId, schoolDestinationId, fleetKind, $"School destination {schoolDestinationId} not found");
         }
 
-        if (slot is RouteTimeSlotKind.AM or RouteTimeSlotKind.Both && school.StartTime is null)
+        if ((slot is RouteTimeSlotKind.AM or RouteTimeSlotKind.Both) && school.StartTime is null)
         {
             return Fail(opId, schoolDestinationId, fleetKind,
                 $"School '{school.Name}' is missing StartTime required for AM generation");
         }
 
-        if (slot is RouteTimeSlotKind.PM or RouteTimeSlotKind.Both && school.DismissalTime is null)
+        if ((slot is RouteTimeSlotKind.PM or RouteTimeSlotKind.Both) && school.DismissalTime is null)
         {
             warnings.Add($"School '{school.Name}' has no DismissalTime; PM mirror will still create stop structure");
         }
@@ -74,6 +67,11 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             .Where(s => s.DestinationId == schoolDestinationId)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
+
+        // Snapshot ride mode before we rewrite AM/PM assignments (AM-only must keep PMRoute empty).
+        var priorModeByStudent = students.ToDictionary(
+            s => s.StudentId,
+            s => StudentRideModeHelper.FromStudent(s));
 
         var riders = new List<RiderPoint>();
         var unclustered = new List<int>();
@@ -107,9 +105,20 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             }
         }
 
+        var schoolSlug = SanitizeName(school.Name);
+        if (!options.DryRun)
+        {
+            var cleared = await ClearExistingDraftsAsync(schoolSlug, school.Name, cancellationToken)
+                .ConfigureAwait(false);
+            if (cleared > 0)
+            {
+                warnings.Add($"Replaced {cleared} existing Draft route(s) for this school");
+            }
+        }
+
         var proposals = new List<RouteProposalDto>();
         var assigned = 0;
-        var schoolSlug = SanitizeName(school.Name);
+        var hardFailures = new List<string>();
         var packIndex = 0;
 
         foreach (var (cell, pack) in packed)
@@ -118,18 +127,21 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             var amName = $"Draft-{schoolSlug}-{cell.CellId}-{packIndex}";
             var amProposal = await MaterializeProposalAsync(
                     amName,
+                    school.Name,
                     pack,
                     RouteTimeSlotKind.AM,
                     fleetKind,
                     options.DryRun,
                     assignAm: slot is RouteTimeSlotKind.AM or RouteTimeSlotKind.Both,
+                    priorModeByStudent,
                     cancellationToken)
                 .ConfigureAwait(false);
-            proposals.Add(amProposal);
-            if (amProposal.PersistedRouteId is not null &&
+            proposals.Add(amProposal.Dto);
+            hardFailures.AddRange(amProposal.Failures);
+            if (amProposal.Dto.PersistedRouteId is not null &&
                 slot is RouteTimeSlotKind.AM or RouteTimeSlotKind.Both)
             {
-                assigned += pack.OrderedStudentIds.Count;
+                assigned += amProposal.AssignedCount;
             }
 
             if (slot is RouteTimeSlotKind.PM or RouteTimeSlotKind.Both)
@@ -137,25 +149,39 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
                 var pmName = $"{amName}-PM";
                 var pmProposal = await MaterializeProposalAsync(
                         pmName,
+                        school.Name,
                         pack,
                         RouteTimeSlotKind.PM,
                         fleetKind,
                         options.DryRun,
                         assignAm: false,
+                        priorModeByStudent,
                         cancellationToken,
-                        assignPmMirror: !options.DryRun && slot == RouteTimeSlotKind.Both,
-                        amRouteNameForMirror: amName)
+                        assignPmMirror: !options.DryRun && slot == RouteTimeSlotKind.Both)
                     .ConfigureAwait(false);
-                proposals.Add(pmProposal);
+                proposals.Add(pmProposal.Dto);
+                hardFailures.AddRange(pmProposal.Failures);
+            }
+        }
+
+        var rejected = proposals.Count(p => p.Status == "Rejected");
+        var success = hardFailures.Count == 0 && rejected == 0;
+        if (!success)
+        {
+            warnings.AddRange(hardFailures.Take(5));
+            if (hardFailures.Count > 5)
+            {
+                warnings.Add($"…and {hardFailures.Count - 5} more failure(s)");
             }
         }
 
         Logger.Information(
-            "Route generation completed School={SchoolId} Fleet={Fleet} Routes={N} Students={S} OpId={OpId}",
+            "Route generation completed School={SchoolId} Fleet={Fleet} Routes={N} Students={S} Success={Success} OpId={OpId}",
             schoolDestinationId,
             fleetKind,
             proposals.Count,
             assigned,
+            success,
             opId);
 
         return new RouteGenerationResult
@@ -167,7 +193,10 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             UnclusteredStudentIds = unclustered,
             Warnings = warnings,
             AssignedStudentCount = assigned,
-            Success = true
+            Success = success,
+            Error = success
+                ? null
+                : $"Generation incomplete: {rejected} rejected proposal(s), {hardFailures.Count} assign/create failure(s)"
         };
     }
 
@@ -178,7 +207,6 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         bool overrideSeating = false,
         CancellationToken cancellationToken = default)
     {
-        // Full toast policy is US2; MVP exposes seating hard-block for callers.
         if (slot == RouteTimeSlotKind.Both)
         {
             return new AssignFitnessResult
@@ -259,7 +287,6 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             .ConfigureAwait(false);
         if (!remove.IsSuccess)
         {
-            // Allow override when student was not on from-route (already moved)
             Logger.Warning("Override remove soft-fail Student={Id}: {Error}", studentId, remove.Error);
         }
 
@@ -281,17 +308,67 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         return new ClerkOverrideResult { Success = true, RetainedMirrorStop = retainMirror };
     }
 
-    private async Task<RouteProposalDto> MaterializeProposalAsync(
+    private async Task<int> ClearExistingDraftsAsync(
+        string schoolSlug,
+        string schoolDisplayName,
+        CancellationToken cancellationToken)
+    {
+        var prefix = $"Draft-{schoolSlug}-";
+        await using var context = _contextFactory.CreateWriteDbContext();
+        var drafts = await context.Routes.AsTracking()
+            .Where(r => r.RouteName.StartsWith(prefix) ||
+                        (r.School == schoolDisplayName && r.RouteName.StartsWith("Draft-")))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (drafts.Count == 0)
+        {
+            return 0;
+        }
+
+        var draftNames = drafts.Select(d => d.RouteName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var students = await context.Students.AsTracking()
+            .Where(s =>
+                (s.AMRoute != null && draftNames.Contains(s.AMRoute)) ||
+                (s.PMRoute != null && draftNames.Contains(s.PMRoute)))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var student in students)
+        {
+            if (student.AMRoute is not null && draftNames.Contains(student.AMRoute))
+            {
+                student.AMRoute = null;
+            }
+
+            if (student.PMRoute is not null && draftNames.Contains(student.PMRoute))
+            {
+                student.PMRoute = null;
+            }
+        }
+
+        context.Routes.RemoveRange(drafts);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        Logger.Information(
+            "Cleared {Count} Draft route(s) for school slug={Slug} before regenerate",
+            drafts.Count, schoolSlug);
+        return drafts.Count;
+    }
+
+    private async Task<MaterializeResult> MaterializeProposalAsync(
         string routeName,
+        string schoolDisplayName,
         PackedRoute pack,
         RouteTimeSlotKind slot,
         FleetKind fleetKind,
         bool dryRun,
         bool assignAm,
+        IReadOnlyDictionary<int, StudentRideMode> priorModeByStudent,
         CancellationToken cancellationToken,
-        bool assignPmMirror = false,
-        string? amRouteNameForMirror = null)
+        bool assignPmMirror = false)
     {
+        var failures = new List<string>();
+        var assignedCount = 0;
         var dto = new RouteProposalDto
         {
             ProposalKey = $"{routeName}:{slot}",
@@ -308,7 +385,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
 
         if (dryRun)
         {
-            return dto;
+            return new MaterializeResult(dto, failures, 0);
         }
 
         var create = await _routeService.CreateRouteAsync(new Route
@@ -317,9 +394,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             Date = DateTime.Today,
             Description = $"008 {fleetKind} {slot} cell {pack.CellId}",
             IsActive = true,
-            School = routeName.StartsWith("Draft-", StringComparison.Ordinal)
-                ? ExtractSchoolFromDraft(routeName)
-                : null,
+            School = schoolDisplayName,
             AMRiders = slot == RouteTimeSlotKind.AM ? pack.OrderedStudentIds.Count : null,
             PMRiders = slot == RouteTimeSlotKind.PM ? pack.OrderedStudentIds.Count : null
         }).ConfigureAwait(false);
@@ -327,8 +402,10 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         if (!create.IsSuccess || create.Value is null)
         {
             dto.Status = "Rejected";
-            Logger.Warning("Failed to persist draft route {Name}: {Error}", routeName, create.Error);
-            return dto;
+            var msg = $"Create '{routeName}' failed: {create.Error}";
+            failures.Add(msg);
+            Logger.Warning("{Message}", msg);
+            return new MaterializeResult(dto, failures, 0);
         }
 
         dto.PersistedRouteId = create.Value.RouteId;
@@ -342,58 +419,43 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
                     .ConfigureAwait(false);
                 if (!result.IsSuccess)
                 {
-                    Logger.Warning("Assign AM failed Student={Id} Route={Route}: {Error}",
-                        studentId, routeName, result.Error);
+                    var msg = $"Assign AM Student={studentId} Route={routeName}: {result.Error}";
+                    failures.Add(msg);
+                    Logger.Warning("{Message}", msg);
+                }
+                else
+                {
+                    assignedCount++;
                 }
             }
         }
 
         if (assignPmMirror && slot == RouteTimeSlotKind.PM)
         {
-            // Mirror: assign PM for Both riders; keep AM-only as stop-retained (AM assignment already set).
-            await using var ctx = _contextFactory.CreateDbContext();
+            // OrderedStudentIds on the PM DTO retain occasional-rider stops for AM-only.
             foreach (var studentId in pack.OrderedStudentIds)
             {
-                var student = await ctx.Students.AsNoTracking()
-                    .FirstOrDefaultAsync(s => s.StudentId == studentId, cancellationToken)
-                    .ConfigureAwait(false);
-                if (student is null)
+                priorModeByStudent.TryGetValue(studentId, out var priorMode);
+                if (!StudentRideModeHelper.ShouldAssignPmMirror(priorMode))
                 {
+                    Logger.Debug(
+                        "PM mirror stop retained without PMRoute Student={Id} PriorMode={Mode}",
+                        studentId, priorMode);
                     continue;
                 }
 
-                var mode = StudentRideModeHelper.FromRouteNames(
-                    string.IsNullOrWhiteSpace(student.AMRoute) ? amRouteNameForMirror : student.AMRoute,
-                    student.PMRoute);
-
-                // Year-start: treat newly AM-assigned as Both unless previously PM-only preference existed.
-                // AM-only retention: do not clear AM; assign PM only when mode is Both or Neither (new).
-                if (mode is StudentRideMode.PM)
-                {
-                    continue;
-                }
-
-                // Default year-start: assign PM mirror for all packed AM students (Both).
-                // AM-only students still retain presence via ordered stop list on this PM draft.
                 var result = await _routeService.AssignStudentToRouteAsync(studentId, routeId, RouteTimeSlot.PM)
                     .ConfigureAwait(false);
                 if (!result.IsSuccess)
                 {
-                    Logger.Debug(
-                        "PM mirror assign skipped/failed Student={Id} (may be AM-only retention): {Error}",
-                        studentId, result.Error);
+                    var msg = $"Assign PM Student={studentId} Route={routeName}: {result.Error}";
+                    failures.Add(msg);
+                    Logger.Warning("{Message}", msg);
                 }
             }
         }
 
-        return dto;
-    }
-
-    private static string ExtractSchoolFromDraft(string routeName)
-    {
-        // Draft-{School}-{Cell}-{n} or Draft-{School}-{Cell}-{n}-PM
-        var parts = routeName.Split('-', StringSplitOptions.RemoveEmptyEntries);
-        return parts.Length >= 2 ? parts[1] : routeName;
+        return new MaterializeResult(dto, failures, assignedCount);
     }
 
     private static string SanitizeName(string name)
@@ -417,7 +479,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         return bus?.SeatingCapacity > 0 ? bus.SeatingCapacity : fallback;
     }
 
-    private static async Task<int> GetCapacityAsync(
+    private async Task<int> GetCapacityAsync(
         BusBuddyDbContext context,
         Route route,
         RouteTimeSlot slot,
@@ -429,13 +491,14 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             var bus = await context.Buses.AsNoTracking()
                 .FirstOrDefaultAsync(b => b.BusId == id, cancellationToken)
                 .ConfigureAwait(false);
-            if (bus is not null)
+            if (bus is not null && bus.SeatingCapacity > 0)
             {
                 return bus.SeatingCapacity;
             }
         }
 
-        return 72;
+        return await ResolveDefaultSeatingAsync(context, fallback: 72, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static async Task<int> CountAssignedAsync(
@@ -466,4 +529,9 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             Success = false,
             Error = error
         };
+
+    private readonly record struct MaterializeResult(
+        RouteProposalDto Dto,
+        List<string> Failures,
+        int AssignedCount);
 }

--- a/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
@@ -15,15 +15,19 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
     private readonly IBusBuddyDbContextFactory _contextFactory;
     private readonly IRouteService _routeService;
     private readonly RoutingDistrictSettings _settings;
+    private readonly AssignFitnessEvaluator _fitnessEvaluator;
 
     public RouteDeterminationService(
         IBusBuddyDbContextFactory contextFactory,
         IRouteService routeService,
-        IOptions<RoutingDistrictSettings>? settings = null)
+        IOptions<RoutingDistrictSettings>? settings = null,
+        AssignFitnessEvaluator? fitnessEvaluator = null)
     {
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _routeService = routeService ?? throw new ArgumentNullException(nameof(routeService));
         _settings = settings?.Value ?? new RoutingDistrictSettings();
+        _fitnessEvaluator = fitnessEvaluator
+            ?? new AssignFitnessEvaluator(contextFactory, settings);
     }
 
     public async Task<RouteGenerationResult> GenerateAndAssignAsync(
@@ -200,63 +204,13 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         };
     }
 
-    public async Task<AssignFitnessResult> RecalculateOnAssignAsync(
+    public Task<AssignFitnessResult> RecalculateOnAssignAsync(
         int studentId,
         int routeId,
         RouteTimeSlotKind slot,
         bool overrideSeating = false,
-        CancellationToken cancellationToken = default)
-    {
-        if (slot == RouteTimeSlotKind.Both)
-        {
-            return new AssignFitnessResult
-            {
-                Allowed = false,
-                Severity = AssignFitnessSeverity.Block,
-                Reasons = new[] { "Specify AM or PM for assign fitness" }
-            };
-        }
-
-        await using var context = _contextFactory.CreateDbContext();
-        var route = await context.Routes.AsNoTracking()
-            .FirstOrDefaultAsync(r => r.RouteId == routeId, cancellationToken)
-            .ConfigureAwait(false);
-        if (route is null)
-        {
-            return new AssignFitnessResult
-            {
-                Allowed = false,
-                Severity = AssignFitnessSeverity.Block,
-                Reasons = new[] { $"Route {routeId} not found" }
-            };
-        }
-
-        var timeSlot = slot == RouteTimeSlotKind.AM ? RouteTimeSlot.AM : RouteTimeSlot.PM;
-        var capacity = await GetCapacityAsync(context, route, timeSlot, cancellationToken).ConfigureAwait(false);
-        var assigned = await CountAssignedAsync(context, route.RouteName, timeSlot, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (capacity > 0 && assigned + 1 > capacity && !overrideSeating)
-        {
-            var reasons = new[] { $"Seating capacity {capacity} would be exceeded ({assigned} already assigned)" };
-            Logger.Information(
-                "Assign fitness Blocked Student={Id} Route={RouteId} Reasons={Reasons}",
-                studentId, routeId, string.Join("; ", reasons));
-            return new AssignFitnessResult
-            {
-                Allowed = false,
-                Severity = AssignFitnessSeverity.Block,
-                Reasons = reasons,
-                SuggestNewRoute = true
-            };
-        }
-
-        return new AssignFitnessResult
-        {
-            Allowed = true,
-            Severity = AssignFitnessSeverity.None
-        };
-    }
+        CancellationToken cancellationToken = default) =>
+        _fitnessEvaluator.EvaluateAsync(studentId, routeId, slot, overrideSeating, cancellationToken);
 
     public async Task<ClerkOverrideResult> ApplyClerkOverrideAsync(
         int studentId,
@@ -477,46 +431,6 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
         return bus?.SeatingCapacity > 0 ? bus.SeatingCapacity : fallback;
-    }
-
-    private async Task<int> GetCapacityAsync(
-        BusBuddyDbContext context,
-        Route route,
-        RouteTimeSlot slot,
-        CancellationToken cancellationToken)
-    {
-        var vehicleId = slot == RouteTimeSlot.AM ? route.AMVehicleId : route.PMVehicleId;
-        if (vehicleId is int id)
-        {
-            var bus = await context.Buses.AsNoTracking()
-                .FirstOrDefaultAsync(b => b.BusId == id, cancellationToken)
-                .ConfigureAwait(false);
-            if (bus is not null && bus.SeatingCapacity > 0)
-            {
-                return bus.SeatingCapacity;
-            }
-        }
-
-        return await ResolveDefaultSeatingAsync(context, fallback: 72, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    private static async Task<int> CountAssignedAsync(
-        BusBuddyDbContext context,
-        string routeName,
-        RouteTimeSlot slot,
-        CancellationToken cancellationToken)
-    {
-        if (slot == RouteTimeSlot.AM)
-        {
-            return await context.Students.AsNoTracking()
-                .CountAsync(s => s.AMRoute == routeName, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return await context.Students.AsNoTracking()
-            .CountAsync(s => s.PMRoute == routeName, cancellationToken)
-            .ConfigureAwait(false);
     }
 
     private static RouteGenerationResult Fail(

--- a/BusBuddy.Core/Services/RouteService.cs
+++ b/BusBuddy.Core/Services/RouteService.cs
@@ -1,6 +1,7 @@
 using BusBuddy.Core.Models;
 using BusBuddy.Core.Data;
 using BusBuddy.Core.Utilities;
+using BusBuddy.Core.Services.RouteDetermination;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using System;
@@ -24,6 +25,7 @@ namespace BusBuddy.Core.Services
         private static readonly ILogger Logger = Log.ForContext<RouteService>();
         private readonly IBusBuddyDbContextFactory _contextFactory;
         private readonly IRouteWaypointRebuildService? _waypointRebuild;
+        private readonly AssignFitnessEvaluator? _fitnessEvaluator;
 
         // Minimal op timing helper (basic only; can expand later)
         private static (Guid OpId, Stopwatch Sw) StartOp(string name, object? routeId = null)
@@ -48,16 +50,25 @@ namespace BusBuddy.Core.Services
         }
 
         public RouteService(IBusBuddyDbContextFactory contextFactory)
-            : this(contextFactory, null)
+            : this(contextFactory, null, null)
         {
         }
 
         public RouteService(
             IBusBuddyDbContextFactory contextFactory,
             IRouteWaypointRebuildService? waypointRebuild)
+            : this(contextFactory, waypointRebuild, null)
+        {
+        }
+
+        public RouteService(
+            IBusBuddyDbContextFactory contextFactory,
+            IRouteWaypointRebuildService? waypointRebuild,
+            AssignFitnessEvaluator? fitnessEvaluator)
         {
             _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
             _waypointRebuild = waypointRebuild;
+            _fitnessEvaluator = fitnessEvaluator;
         }
 
         // Context helpers: only dispose when using the concrete runtime factory
@@ -779,6 +790,16 @@ namespace BusBuddy.Core.Services
 
         public async Task<Result<bool>> AssignStudentToRouteAsync(int studentId, int routeId, RouteTimeSlot timeSlot)
         {
+            return await AssignStudentToRouteAsync(studentId, routeId, timeSlot, overrideSeating: false)
+                .ConfigureAwait(false);
+        }
+
+        public async Task<Result<bool>> AssignStudentToRouteAsync(
+            int studentId,
+            int routeId,
+            RouteTimeSlot timeSlot,
+            bool overrideSeating)
+        {
             try
             {
                 if (studentId <= 0 || routeId <= 0)
@@ -789,6 +810,30 @@ namespace BusBuddy.Core.Services
                 if (timeSlot == RouteTimeSlot.Both)
                 {
                     return Result.FailureResult<bool>("Specify AM or PM time slot for assignment");
+                }
+
+                if (_fitnessEvaluator is not null)
+                {
+                    var slotKind = timeSlot == RouteTimeSlot.AM
+                        ? RouteTimeSlotKind.AM
+                        : RouteTimeSlotKind.PM;
+                    var fitness = await _fitnessEvaluator
+                        .EvaluateAsync(studentId, routeId, slotKind, overrideSeating)
+                        .ConfigureAwait(false);
+                    if (!fitness.Allowed)
+                    {
+                        var detail = fitness.Reasons.Count > 0
+                            ? string.Join("; ", fitness.Reasons)
+                            : "Assignment blocked by fitness check";
+                        return Result.FailureResult<bool>(detail);
+                    }
+
+                    if (fitness.Severity == AssignFitnessSeverity.Warn && fitness.Reasons.Count > 0)
+                    {
+                        Logger.Information(
+                            "Assign proceeding with warnings Student={StudentId} Route={RouteId}: {Reasons}",
+                            studentId, routeId, string.Join("; ", fitness.Reasons));
+                    }
                 }
 
                 var (context, dispose) = GetWriteContext();
@@ -816,11 +861,15 @@ namespace BusBuddy.Core.Services
                         return Result.FailureResult<bool>($"Student already has a {timeSlot} route assigned: {currentSlotRoute}");
                     }
 
-                    var capacity = await GetCapacityForSlotAsync(context, route, timeSlot);
-                    var assignedCount = await GetAssignedCountForSlotAsync(context, route, timeSlot);
-                    if (capacity > 0 && assignedCount >= capacity)
+                    // Fallback seating gate when evaluator not registered
+                    if (_fitnessEvaluator is null)
                     {
-                        return Result.FailureResult<bool>($"Route '{route.RouteName}' is at {timeSlot} capacity");
+                        var capacity = await GetCapacityForSlotAsync(context, route, timeSlot);
+                        var assignedCount = await GetAssignedCountForSlotAsync(context, route, timeSlot);
+                        if (capacity > 0 && assignedCount >= capacity && !overrideSeating)
+                        {
+                            return Result.FailureResult<bool>($"Route '{route.RouteName}' is at {timeSlot} capacity");
+                        }
                     }
 
                     SetStudentRouteForSlot(student, timeSlot, route.RouteName);

--- a/BusBuddy.Tests/Core/RouteDetermination/AssignFitnessTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/AssignFitnessTests.cs
@@ -1,0 +1,178 @@
+using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Data;
+using BusBuddy.Core.Models;
+using BusBuddy.Core.Services.RouteDetermination;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core.RouteDetermination;
+
+[TestFixture]
+[Category("Unit")]
+public class AssignFitnessTests
+{
+    private sealed class TestDbContextFactory : IBusBuddyDbContextFactory
+    {
+        private readonly DbContextOptions<BusBuddyDbContext> _options;
+
+        public TestDbContextFactory(DbContextOptions<BusBuddyDbContext> options) => _options = options;
+
+        public BusBuddyDbContext CreateDbContext() => new(_options);
+
+        public BusBuddyDbContext CreateWriteDbContext()
+        {
+            var ctx = new BusBuddyDbContext(_options);
+            ctx.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+            return ctx;
+        }
+    }
+
+    private static DbContextOptions<BusBuddyDbContext> CreateOptions() =>
+        new DbContextOptionsBuilder<BusBuddyDbContext>()
+            .UseInMemoryDatabase($"AssignFitness_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+    private static async Task<(TestDbContextFactory Factory, int StudentId, int RouteId)> SeedAsync(
+        int seatingCapacity,
+        int alreadyAssigned,
+        bool distantStudent = false)
+    {
+        BusBuddyDbContext.SkipGlobalSeedData = true;
+        var options = CreateOptions();
+        var factory = new TestDbContextFactory(options);
+
+        await using (var ctx = factory.CreateWriteDbContext())
+        {
+            var bus = new Bus
+            {
+                BusNumber = "B1",
+                SeatingCapacity = seatingCapacity,
+                Status = "Active",
+                Year = 2020,
+                Make = "IC",
+                Model = "CE",
+                VINNumber = "1HGBH41JXMN109186",
+                LicenseNumber = "TEST1",
+                CreatedDate = DateTime.UtcNow
+            };
+            ctx.Buses.Add(bus);
+            await ctx.SaveChangesAsync();
+
+            var route = new Route
+            {
+                RouteName = "Test-Route",
+                Date = DateTime.Today,
+                IsActive = true,
+                AMVehicleId = bus.BusId
+            };
+            ctx.Routes.Add(route);
+
+            var school = new Destination
+            {
+                Name = "Test School",
+                Address = "1 Main",
+                City = "Wiley",
+                State = "CO",
+                ZipCode = "81092",
+                DestinationType = DestinationTypes.School,
+                Latitude = 38.15m,
+                Longitude = -102.70m,
+                StartTime = TimeSpan.FromHours(8),
+                IsActive = true
+            };
+            ctx.Destinations.Add(school);
+            await ctx.SaveChangesAsync();
+
+            for (var i = 0; i < alreadyAssigned; i++)
+            {
+                ctx.Students.Add(new Student
+                {
+                    StudentName = $"Peer {i}",
+                    StudentNumber = $"P{i}",
+                    Grade = "5",
+                    HomeAddress = "Addr",
+                    City = "Wiley",
+                    State = "CO",
+                    Zip = "81092",
+                    DestinationId = school.DestinationId,
+                    Latitude = 38.150m + i * 0.0001m,
+                    Longitude = -102.700m,
+                    AMRoute = route.RouteName
+                });
+            }
+
+            var subject = new Student
+            {
+                StudentName = "Subject",
+                StudentNumber = "S1",
+                Grade = "5",
+                HomeAddress = "Addr",
+                City = "Wiley",
+                State = "CO",
+                Zip = "81092",
+                DestinationId = school.DestinationId,
+                Latitude = distantStudent ? 38.40m : 38.151m,
+                Longitude = -102.700m
+            };
+            ctx.Students.Add(subject);
+            await ctx.SaveChangesAsync();
+
+            return (factory, subject.StudentId, route.RouteId);
+        }
+    }
+
+    [Test]
+    public async Task Evaluate_SeatingOverload_BlocksWithoutOverride()
+    {
+        var (factory, studentId, routeId) = await SeedAsync(seatingCapacity: 2, alreadyAssigned: 2);
+        var evaluator = new AssignFitnessEvaluator(
+            factory,
+            Options.Create(new RoutingDistrictSettings { AllowSeatingOverride = true }));
+
+        var result = await evaluator.EvaluateAsync(studentId, routeId, RouteTimeSlotKind.AM);
+
+        Assert.That(result.Allowed, Is.False);
+        Assert.That(result.Severity, Is.EqualTo(AssignFitnessSeverity.Block));
+        Assert.That(result.SuggestNewRoute, Is.True);
+        Assert.That(result.Reasons.Any(r => r.Contains("Seating", StringComparison.OrdinalIgnoreCase)), Is.True);
+    }
+
+    [Test]
+    public async Task Evaluate_SeatingOverload_AllowsWithOverride()
+    {
+        var (factory, studentId, routeId) = await SeedAsync(seatingCapacity: 2, alreadyAssigned: 2);
+        var evaluator = new AssignFitnessEvaluator(
+            factory,
+            Options.Create(new RoutingDistrictSettings { AllowSeatingOverride = true }));
+
+        var result = await evaluator.EvaluateAsync(studentId, routeId, RouteTimeSlotKind.AM, overrideSeating: true);
+
+        Assert.That(result.Allowed, Is.True);
+        Assert.That(result.Severity, Is.EqualTo(AssignFitnessSeverity.Warn));
+        Assert.That(result.Reasons.Any(r => r.Contains("override", StringComparison.OrdinalIgnoreCase)), Is.True);
+    }
+
+    [Test]
+    public async Task Evaluate_GeoOutlier_WarnsAndAllows()
+    {
+        var (factory, studentId, routeId) = await SeedAsync(
+            seatingCapacity: 72, alreadyAssigned: 3, distantStudent: true);
+        var evaluator = new AssignFitnessEvaluator(
+            factory,
+            Options.Create(new RoutingDistrictSettings
+            {
+                MaxPickupGapMinutes = 5,
+                AverageSpeedMph = 25,
+                MaxRideMinutes = 120
+            }));
+
+        var result = await evaluator.EvaluateAsync(studentId, routeId, RouteTimeSlotKind.AM);
+
+        Assert.That(result.Allowed, Is.True);
+        Assert.That(result.Severity, Is.EqualTo(AssignFitnessSeverity.Warn));
+        Assert.That(result.Reasons.Any(r => r.Contains("outlier", StringComparison.OrdinalIgnoreCase)), Is.True);
+    }
+}

--- a/BusBuddy.Tests/Core/RouteDetermination/RideModeMirrorTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/RideModeMirrorTests.cs
@@ -32,4 +32,13 @@ public class RideModeMirrorTests
         Assert.That(StudentRideModeHelper.RetainStopOnPmMirror(mode), Is.True);
         Assert.That(StudentRideModeHelper.RetainStopOnAmMirror(mode), Is.True);
     }
+
+    [Test]
+    public void ShouldAssignPmMirror_SkipsAmOnly_AllowsNeitherAndBoth()
+    {
+        Assert.That(StudentRideModeHelper.ShouldAssignPmMirror(StudentRideMode.AM), Is.False);
+        Assert.That(StudentRideModeHelper.ShouldAssignPmMirror(StudentRideMode.Neither), Is.True);
+        Assert.That(StudentRideModeHelper.ShouldAssignPmMirror(StudentRideMode.Both), Is.True);
+        Assert.That(StudentRideModeHelper.ShouldAssignPmMirror(StudentRideMode.PM), Is.True);
+    }
 }

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -433,6 +433,7 @@ namespace BusBuddy.WPF
                 services.AddScoped<BusBuddy.Core.Services.IStudentSchoolTransferService, BusBuddy.Core.Services.StudentSchoolTransferService>();
                 services.AddScoped<BusBuddy.Core.Services.IRouteWaypointRebuildService, BusBuddy.Core.Services.RouteWaypointRebuildService>();
                 services.AddScoped<BusBuddy.Core.Services.IDriverTrainingService, BusBuddy.Core.Services.DriverTrainingService>();
+                services.AddScoped<BusBuddy.Core.Services.RouteDetermination.AssignFitnessEvaluator>();
                 services.AddScoped<BusBuddy.Core.Services.RouteDetermination.IRouteDeterminationService,
                     BusBuddy.Core.Services.RouteDetermination.RouteDeterminationService>();
                 services.Configure<BusBuddy.Core.Configuration.RoutingDistrictSettings>(

--- a/BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/GoogleEarth/GoogleEarthViewModel.cs
@@ -206,7 +206,7 @@ namespace BusBuddy.WPF.ViewModels.GoogleEarth
                 result.OperationId,
                 draftNames.Count);
 
-            _ = Task.Run(async () =>
+            async Task SelectDraftOnUiAsync()
             {
                 await LoadRoutesAsync().ConfigureAwait(true);
                 var draft = Routes.FirstOrDefault(r =>
@@ -216,7 +216,17 @@ namespace BusBuddy.WPF.ViewModels.GoogleEarth
                 {
                     SelectedRoute = draft;
                 }
-            });
+            }
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher is null || dispatcher.CheckAccess())
+            {
+                _ = SelectDraftOnUiAsync();
+            }
+            else
+            {
+                _ = dispatcher.InvokeAsync(SelectDraftOnUiAsync);
+            }
         }
 
         /// <summary>

--- a/BusBuddy.WPF/ViewModels/Route/RouteAssignmentViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Route/RouteAssignmentViewModel.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Input;
 using BusBuddy.Core.Models;
 using BusBuddy.Core.Services;
+using BusBuddy.Core.Services.RouteDetermination;
 using BusBuddy.Core.Utilities;
 using BusBuddy.WPF.Commands;
 using Serilog;
@@ -54,6 +55,7 @@ namespace BusBuddy.WPF.ViewModels.Route
         private int? _preselectedRouteId;
         private string _startTimeString = "07:30";
         private readonly IRouteService? _routeService;
+        private readonly IRouteDeterminationService? _routeDetermination;
         private static readonly ILogger Logger = Log.ForContext<RouteAssignmentViewModel>();
     private Timer? _retimeDebounceTimer; // Debounce timer for auto-retiming after structural stop changes
     private const int RetimeDebounceMs = 600; // Delay before auto timing after modifications
@@ -69,6 +71,7 @@ namespace BusBuddy.WPF.ViewModels.Route
             {
                 // Try resolve IRouteService from DI if available
                 _routeService = App.ServiceProvider?.GetService<IRouteService>();
+                _routeDetermination = App.ServiceProvider?.GetService<IRouteDeterminationService>();
             }
             catch { }
             Initialize();
@@ -92,12 +95,14 @@ namespace BusBuddy.WPF.ViewModels.Route
         public RouteAssignmentViewModel(IRouteService? routeService)
         {
             _routeService = routeService;
+            _routeDetermination = App.ServiceProvider?.GetService<IRouteDeterminationService>();
             Initialize();
         }
 
         public RouteAssignmentViewModel(IRouteService? routeService, BusBuddy.Core.Models.Route preselectedRoute)
         {
             _routeService = routeService;
+            _routeDetermination = App.ServiceProvider?.GetService<IRouteDeterminationService>();
             _preselectedRouteId = preselectedRoute?.RouteId;
             Initialize();
             // If the route collection already loaded synchronously (mock), select it
@@ -741,7 +746,79 @@ namespace BusBuddy.WPF.ViewModels.Route
 
                 if (_routeService != null)
                 {
-                    var result = await _routeService.AssignStudentToRouteAsync(student.StudentId, route.RouteId, slot);
+                    var overrideSeating = false;
+                    if (_routeDetermination is not null)
+                    {
+                        var slotKind = slot == RouteTimeSlot.AM
+                            ? RouteTimeSlotKind.AM
+                            : RouteTimeSlotKind.PM;
+                        var fitness = await _routeDetermination
+                            .RecalculateOnAssignAsync(student.StudentId, route.RouteId, slotKind)
+                            .ConfigureAwait(true);
+
+                        if (fitness.Severity == AssignFitnessSeverity.Warn && fitness.Reasons.Count > 0)
+                        {
+                            StatusMessage = string.Join("; ", fitness.Reasons);
+                            MessageBox.Show(
+                                string.Join("\n", fitness.Reasons),
+                                "Assignment warning",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Warning);
+                        }
+
+                        if (!fitness.Allowed)
+                        {
+                            var body = string.Join("\n", fitness.Reasons);
+                            if (fitness.SuggestedRouteIds.Count > 0)
+                            {
+                                body += "\n\nSuggested route IDs: " + string.Join(", ", fitness.SuggestedRouteIds);
+                            }
+
+                            if (fitness.SuggestNewRoute && student.DestinationId is int schoolId)
+                            {
+                                var gen = MessageBox.Show(
+                                    body + "\n\nCreate new draft routes for this student's school?",
+                                    "Assignment blocked",
+                                    MessageBoxButton.YesNoCancel,
+                                    MessageBoxImage.Warning);
+                                if (gen == MessageBoxResult.Yes)
+                                {
+                                    var genResult = await _routeDetermination.GenerateAndAssignAsync(
+                                            schoolId,
+                                            RouteTimeSlotKind.Both,
+                                            FleetKind.HomeToSchool)
+                                        .ConfigureAwait(true);
+                                    StatusMessage = genResult.Success
+                                        ? $"Generated {genResult.Proposals.Count} draft route(s)"
+                                        : (genResult.Error ?? "Route generation failed");
+                                    await LoadDataFromServiceAsync().ConfigureAwait(true);
+                                    return false;
+                                }
+
+                                if (gen == MessageBoxResult.Cancel)
+                                {
+                                    StatusMessage = "Assignment cancelled";
+                                    return false;
+                                }
+                            }
+
+                            var askOverride = MessageBox.Show(
+                                body + "\n\nOverride seating capacity and assign anyway?",
+                                "Assignment blocked",
+                                MessageBoxButton.YesNo,
+                                MessageBoxImage.Warning);
+                            if (askOverride != MessageBoxResult.Yes)
+                            {
+                                StatusMessage = "Assignment blocked: " + string.Join("; ", fitness.Reasons);
+                                return false;
+                            }
+
+                            overrideSeating = true;
+                        }
+                    }
+
+                    var result = await _routeService.AssignStudentToRouteAsync(
+                        student.StudentId, route.RouteId, slot, overrideSeating);
                     if (!result.IsSuccess)
                     {
                         StatusMessage = $"Failed to assign student: {result.Error}";

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -35,7 +35,8 @@
   - Design locked 2026-08-17 (user answers): soft capacity = assigned bus `SeatingCapacity` (hard); school map **start times** → work backward for pickups; simple **quadrants** + rural/outlier rules (large pickup gaps → other route); minimize buses without sacrificing ride time/mileage/comfort; keep occasional-rider stops on mirrored routes; suggest new route past thresholds
   - [x] `/speckit-specify` + `/speckit-plan` — [spec](../specs/008-route-determination/spec.md) · [plan](../specs/008-route-determination/plan.md) (Q1:A / Q2:B / Q3:B locked)
   - [x] `/speckit-tasks` — [tasks.md](../specs/008-route-determination/tasks.md) (41 tasks; MVP = US1 T001–T020)
-  - [x] `/speckit-implement` MVP T001–T020 (Setup + Foundational + US1) on `feature/008-route-determination`
+  - [x] `/speckit-implement` MVP T001–T020 (Setup + Foundational + US1) on `feature/008-route-determination` — [PR #37](https://github.com/Bigessfour/BusBuddy-3/pull/37)
+  - [x] Review-fix pass: idempotent Draft replace, AM-only PM skip, fail-closed Success, map UI-thread
   - [ ] Apply migration `20260817160000_DestinationSchoolTimes` on Windows SQL Server; VM smoke Generate Routes + map draft status
   - [ ] US2–US4 + polish (T021–T041)
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -37,8 +37,9 @@
   - [x] `/speckit-tasks` — [tasks.md](../specs/008-route-determination/tasks.md) (41 tasks; MVP = US1 T001–T020)
   - [x] `/speckit-implement` MVP T001–T020 (Setup + Foundational + US1) on `feature/008-route-determination` — [PR #37](https://github.com/Bigessfour/BusBuddy-3/pull/37)
   - [x] Review-fix pass: idempotent Draft replace, AM-only PM skip, fail-closed Success, map UI-thread
+  - [x] US2 assign fitness (T021–T026): evaluator + RouteService gate + Route Assignment warn/block/override/SuggestNewRoute
   - [ ] Apply migration `20260817160000_DestinationSchoolTimes` on Windows SQL Server; VM smoke Generate Routes + map draft status
-  - [ ] US2–US4 + polish (T021–T041)
+  - [ ] US3–US4 + polish (T027–T041)
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit
   - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)

--- a/specs/008-route-determination/tasks.md
+++ b/specs/008-route-determination/tasks.md
@@ -77,15 +77,15 @@
 
 ### Tests for User Story 2
 
-- [ ] T021 [P] [US2] Add `BusBuddy.Tests/Core/RouteDetermination/AssignFitnessTests.cs` — seating block without override; seating allow with override; warn on arrival/geo; SuggestNewRoute flag
+- [x] T021 [P] [US2] Add `BusBuddy.Tests/Core/RouteDetermination/AssignFitnessTests.cs` — seating block without override; seating allow with override; warn on arrival/geo; SuggestNewRoute flag
 
 ### Implementation for User Story 2
 
-- [ ] T022 [US2] Implement `RecalculateOnAssignAsync` / fitness evaluator in `BusBuddy.Core/Services/RouteDetermination/AssignFitnessEvaluator.cs` per [contracts/assign-fitness.md](./contracts/assign-fitness.md) (Q2:B)
-- [ ] T023 [US2] Wrap `AssignStudentToRouteAsync` path in `BusBuddy.Core/Services/RouteService.cs` (or caller) to consult fitness before persist; record seating override when requested
-- [ ] T024 [US2] Surface Syncfusion toast/status from `AssignFitnessResult` in `BusBuddy.WPF/ViewModels/Student/StudentsViewModel.cs` (bulk/single assign) and/or Route assign UI
-- [ ] T025 [US2] When `SuggestNewRoute`, offer command to call generation for that school cell in the same ViewModel
-- [ ] T026 [US2] Serilog `Assign fitness Blocked|Warned Student={Id} Route={Id} Reasons={Reasons}` in fitness evaluator
+- [x] T022 [US2] Implement `RecalculateOnAssignAsync` / fitness evaluator in `BusBuddy.Core/Services/RouteDetermination/AssignFitnessEvaluator.cs` per [contracts/assign-fitness.md](./contracts/assign-fitness.md) (Q2:B)
+- [x] T023 [US2] Wrap `AssignStudentToRouteAsync` path in `BusBuddy.Core/Services/RouteService.cs` (or caller) to consult fitness before persist; record seating override when requested
+- [x] T024 [US2] Surface Syncfusion toast/status from `AssignFitnessResult` in `BusBuddy.WPF/ViewModels/Student/StudentsViewModel.cs` (bulk/single assign) and/or Route assign UI
+- [x] T025 [US2] When `SuggestNewRoute`, offer command to call generation for that school cell in the same ViewModel
+- [x] T026 [US2] Serilog `Assign fitness Blocked|Warned Student={Id} Route={Id} Reasons={Reasons}` in fitness evaluator
 
 **Checkpoint**: US2 tests green; UI blocks overload and warns on time/geo
 


### PR DESCRIPTION
## Summary
- **Review fixes** that landed after #37 auto-merged: idempotent Draft replace, AM-only PM skip, fail-closed generation Success, map draft selection on UI thread.
- **US2 (T021–T026)**: `AssignFitnessEvaluator`, `RouteService.AssignStudentToRouteAsync(..., overrideSeating)`, Route Assignment warn/block/override + SuggestNewRoute → generate drafts.
- Unit tests for seating block/override and geo outlier warn.

## Test plan
- [ ] CI green
- [ ] Windows VM: migrate `DestinationSchoolTimes`; Generate Routes twice (second run replaces drafts)
- [ ] Assign student onto full bus → block dialog; Yes on override assigns; Yes on generate creates drafts
- [ ] Distant student → warn toast, assign still proceeds
- [ ] Run `AssignFitnessTests` + `RideModeMirrorTests` on Windows testhost