### PR TITLE
feat: 008 US3–US4 schedules, transfer fleet, polish

### DIFF
--- a/.function-inventory.json
+++ b/.function-inventory.json
@@ -6,6 +6,8 @@
     "BusBuddy.Core/Services/SeedDataService.cs",
     "BusBuddy.WPF/Views/Student/StudentsView.xaml.cs",
     "BusBuddy.Core/Services/RouteService.cs",
+    "BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs",
+    "BusBuddy.Core/Services/RouteDetermination/AssignFitnessEvaluator.cs",
     "BusBuddy.Core/Services/StudentRouteOptimizer.cs",
     "BusBuddy.Core/Services/OperationalReportService.cs",
     "BusBuddy.Core/Services/PdfReportService.cs",

--- a/BusBuddy.Core/Services/DestinationService.cs
+++ b/BusBuddy.Core/Services/DestinationService.cs
@@ -86,4 +86,29 @@ public sealed class DestinationService : IDestinationService
             .FirstOrDefaultAsync(d => d.DestinationId == destinationId && !d.IsDeleted, cancellationToken)
             .ConfigureAwait(false);
     }
+
+    public async Task<bool> UpdateSchoolTimesAsync(
+        int destinationId,
+        TimeSpan? startTime,
+        TimeSpan? dismissalTime,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateWriteDbContext();
+        var dest = await context.Destinations.AsTracking()
+            .FirstOrDefaultAsync(d => d.DestinationId == destinationId && !d.IsDeleted, cancellationToken)
+            .ConfigureAwait(false);
+        if (dest is null)
+        {
+            return false;
+        }
+
+        dest.StartTime = startTime;
+        dest.DismissalTime = dismissalTime;
+        dest.UpdatedDate = DateTime.UtcNow;
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        Logger.Information(
+            "Updated school times DestinationId={Id} Start={Start} Dismissal={Dismissal}",
+            destinationId, startTime, dismissalTime);
+        return true;
+    }
 }

--- a/BusBuddy.Core/Services/Interfaces/IDestinationService.cs
+++ b/BusBuddy.Core/Services/Interfaces/IDestinationService.cs
@@ -14,4 +14,10 @@ public interface IDestinationService
         CancellationToken cancellationToken = default);
 
     Task<Destination?> GetByIdAsync(int destinationId, CancellationToken cancellationToken = default);
+
+    Task<bool> UpdateSchoolTimesAsync(
+        int destinationId,
+        TimeSpan? startTime,
+        TimeSpan? dismissalTime,
+        CancellationToken cancellationToken = default);
 }

--- a/BusBuddy.Core/Services/RouteDetermination/IRouteDeterminationService.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/IRouteDeterminationService.cs
@@ -24,4 +24,9 @@ public interface IRouteDeterminationService
         RouteTimeSlotKind slot,
         string? reason = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>Recompute RouteStop times for draft/operational routes at a school when StartTime/DismissalTime change.</summary>
+    Task<RouteGenerationResult> RegenerateSchedulesForSchoolAsync(
+        int schoolDestinationId,
+        CancellationToken cancellationToken = default);
 }

--- a/BusBuddy.Core/Services/RouteDetermination/PickupScheduleCalculator.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/PickupScheduleCalculator.cs
@@ -1,0 +1,131 @@
+using BusBuddy.Core.Configuration;
+
+namespace BusBuddy.Core.Services.RouteDetermination;
+
+/// <summary>
+/// AM pickups work backward from school StartTime; PM dropoffs forward from DismissalTime.
+/// Uses Haversine + AverageSpeedMph (Maps ETA optional / fail-open).
+/// </summary>
+public static class PickupScheduleCalculator
+{
+    public static readonly TimeSpan DefaultDwell = TimeSpan.FromSeconds(45);
+
+    /// <summary>
+    /// Ordered stops from first pickup toward school. Returns arrival times per stop (same length),
+    /// plus final school arrival (= startTime).
+    /// </summary>
+    public static IReadOnlyList<TimeSpan> ComputeAmPickupArrivals(
+        IReadOnlyList<(double Latitude, double Longitude)> orderedStopsTowardSchool,
+        double schoolLat,
+        double schoolLon,
+        TimeSpan schoolStartTime,
+        RoutingDistrictSettings settings,
+        TimeSpan? dwellPerStop = null)
+    {
+        ArgumentNullException.ThrowIfNull(orderedStopsTowardSchool);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (orderedStopsTowardSchool.Count == 0)
+        {
+            return Array.Empty<TimeSpan>();
+        }
+
+        var dwell = dwellPerStop ?? DefaultDwell;
+        var mph = settings.AverageSpeedMph <= 0 ? 25.0 : settings.AverageSpeedMph;
+        var arrivals = new TimeSpan[orderedStopsTowardSchool.Count];
+
+        // Work backward from school arrival
+        var cursor = schoolStartTime;
+        for (var i = orderedStopsTowardSchool.Count - 1; i >= 0; i--)
+        {
+            var (lat, lon) = orderedStopsTowardSchool[i];
+            double nextLat, nextLon;
+            if (i == orderedStopsTowardSchool.Count - 1)
+            {
+                nextLat = schoolLat;
+                nextLon = schoolLon;
+            }
+            else
+            {
+                (nextLat, nextLon) = orderedStopsTowardSchool[i + 1];
+            }
+
+            var minutes = LegMinutes(lat, lon, nextLat, nextLon, mph);
+            cursor = cursor - TimeSpan.FromMinutes(minutes) - (i < orderedStopsTowardSchool.Count - 1 ? dwell : TimeSpan.Zero);
+            if (cursor < TimeSpan.Zero)
+            {
+                cursor = TimeSpan.Zero;
+            }
+
+            arrivals[i] = RoundToMinute(cursor);
+        }
+
+        return arrivals;
+    }
+
+    /// <summary>PM: depart school at dismissal, then stop arrivals in dropoff order.</summary>
+    public static IReadOnlyList<TimeSpan> ComputePmDropoffArrivals(
+        IReadOnlyList<(double Latitude, double Longitude)> orderedStopsFromSchool,
+        double schoolLat,
+        double schoolLon,
+        TimeSpan dismissalTime,
+        RoutingDistrictSettings settings,
+        TimeSpan? dwellPerStop = null)
+    {
+        ArgumentNullException.ThrowIfNull(orderedStopsFromSchool);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (orderedStopsFromSchool.Count == 0)
+        {
+            return Array.Empty<TimeSpan>();
+        }
+
+        var dwell = dwellPerStop ?? DefaultDwell;
+        var mph = settings.AverageSpeedMph <= 0 ? 25.0 : settings.AverageSpeedMph;
+        var arrivals = new TimeSpan[orderedStopsFromSchool.Count];
+
+        var cursor = dismissalTime;
+        for (var i = 0; i < orderedStopsFromSchool.Count; i++)
+        {
+            var (lat, lon) = orderedStopsFromSchool[i];
+            double prevLat, prevLon;
+            if (i == 0)
+            {
+                prevLat = schoolLat;
+                prevLon = schoolLon;
+            }
+            else
+            {
+                (prevLat, prevLon) = orderedStopsFromSchool[i - 1];
+            }
+
+            var minutes = LegMinutes(prevLat, prevLon, lat, lon, mph);
+            cursor = cursor + TimeSpan.FromMinutes(minutes) + (i > 0 ? dwell : TimeSpan.Zero);
+            arrivals[i] = RoundToMinute(cursor);
+        }
+
+        return arrivals;
+    }
+
+    public static bool IsMonotonicNonDecreasing(IReadOnlyList<TimeSpan> times)
+    {
+        for (var i = 1; i < times.Count; i++)
+        {
+            if (times[i] < times[i - 1])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static double LegMinutes(double lat1, double lon1, double lat2, double lon2, double mph)
+    {
+        var miles = RoutePacker.HaversineMiles(lat1, lon1, lat2, lon2);
+        return miles / mph * 60.0;
+    }
+
+    private static TimeSpan RoundToMinute(TimeSpan t) =>
+        TimeSpan.FromMinutes(Math.Floor(t.TotalMinutes));
+}

--- a/BusBuddy.Core/Services/RouteDetermination/README.md
+++ b/BusBuddy.Core/Services/RouteDetermination/README.md
@@ -1,14 +1,17 @@
 # Route Determination
 
-Year-start fleet sizing and student assignment planner for BusBuddy.
+Year-start fleet sizing and student assignment planner for BusBuddy (spec 008).
 
 **Contracts**: `specs/008-route-determination/contracts/`
 
 | Type | Role |
 |------|------|
-| `IRouteDeterminationService` | Generate/assign, assign fitness, clerk override |
+| `IRouteDeterminationService` | Generate/assign, assign fitness, clerk override, schedule regen |
 | `DensityCellBuilder` | Bbox / density N-cell grid (Q3:B) |
 | `RoutePacker` | Seating pack + outlier gap split |
-| `RouteDeterminationService` | Orchestrates HomeToSchool (+ later Transfer) |
+| `PickupScheduleCalculator` | AM backward from StartTime; PM forward from DismissalTime |
+| `AssignFitnessEvaluator` | Block seating / warn time-geo (Q2:B) |
+| `RouteDeterminationService` | HomeToSchool + Transfer fleets (Q1:A) |
 
 Apply Destination school-time migrations on **Windows SQL Server** (`dotnet ef database update`).
+VM smoke: [specs/008-route-determination/quickstart.md](../../../specs/008-route-determination/quickstart.md).

--- a/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
@@ -16,18 +16,21 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
     private readonly IRouteService _routeService;
     private readonly RoutingDistrictSettings _settings;
     private readonly AssignFitnessEvaluator _fitnessEvaluator;
+    private readonly IRouteWaypointRebuildService? _waypointRebuild;
 
     public RouteDeterminationService(
         IBusBuddyDbContextFactory contextFactory,
         IRouteService routeService,
         IOptions<RoutingDistrictSettings>? settings = null,
-        AssignFitnessEvaluator? fitnessEvaluator = null)
+        AssignFitnessEvaluator? fitnessEvaluator = null,
+        IRouteWaypointRebuildService? waypointRebuild = null)
     {
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _routeService = routeService ?? throw new ArgumentNullException(nameof(routeService));
         _settings = settings?.Value ?? new RoutingDistrictSettings();
         _fitnessEvaluator = fitnessEvaluator
             ?? new AssignFitnessEvaluator(contextFactory, settings);
+        _waypointRebuild = waypointRebuild;
     }
 
     public async Task<RouteGenerationResult> GenerateAndAssignAsync(
@@ -43,7 +46,9 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
 
         if (fleetKind == FleetKind.Transfer)
         {
-            return Fail(opId, schoolDestinationId, fleetKind, "Transfer fleet generation is not in MVP (see US4 / T033).");
+            return await GenerateTransferFleetAsync(
+                    schoolDestinationId, slot, options, opId, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         await using var context = _contextFactory.CreateDbContext();
@@ -67,10 +72,25 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             warnings.Add($"School '{school.Name}' has no DismissalTime; PM mirror will still create stop structure");
         }
 
+        var transferStudentIds = await context.StudentSchoolTransfers.AsNoTracking()
+            .Where(t => t.IsActive && (t.FromDestinationId == schoolDestinationId || t.ToDestinationId == schoolDestinationId))
+            .Select(t => t.StudentId)
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var transferSet = transferStudentIds.ToHashSet();
+
         var students = await context.Students.AsNoTracking()
             .Where(s => s.DestinationId == schoolDestinationId)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
+
+        // HomeToSchool excludes active transfer riders (separate fleet pool — Q1:A / T034).
+        students = students.Where(s => !transferSet.Contains(s.StudentId)).ToList();
+        if (transferSet.Count > 0)
+        {
+            warnings.Add($"{transferSet.Count} transfer student(s) excluded from HomeToSchool packing");
+        }
 
         // Snapshot ride mode before we rewrite AM/PM assignments (AM-only must keep PMRoute empty).
         var priorModeByStudent = students.ToDictionary(
@@ -131,7 +151,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             var amName = $"Draft-{schoolSlug}-{cell.CellId}-{packIndex}";
             var amProposal = await MaterializeProposalAsync(
                     amName,
-                    school.Name,
+                    school,
                     pack,
                     RouteTimeSlotKind.AM,
                     fleetKind,
@@ -153,7 +173,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
                 var pmName = $"{amName}-PM";
                 var pmProposal = await MaterializeProposalAsync(
                         pmName,
-                        school.Name,
+                        school,
                         pack,
                         RouteTimeSlotKind.PM,
                         fleetKind,
@@ -262,16 +282,248 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         return new ClerkOverrideResult { Success = true, RetainedMirrorStop = retainMirror };
     }
 
+    public async Task<RouteGenerationResult> RegenerateSchedulesForSchoolAsync(
+        int schoolDestinationId,
+        CancellationToken cancellationToken = default)
+    {
+        var opId = Guid.NewGuid();
+        await using var context = _contextFactory.CreateDbContext();
+        var school = await context.Destinations.AsNoTracking()
+            .FirstOrDefaultAsync(d => d.DestinationId == schoolDestinationId, cancellationToken)
+            .ConfigureAwait(false);
+        if (school is null)
+        {
+            return Fail(opId, schoolDestinationId, FleetKind.HomeToSchool, "School not found");
+        }
+
+        if (school.Latitude is not decimal schLat || school.Longitude is not decimal schLon)
+        {
+            return Fail(opId, schoolDestinationId, FleetKind.HomeToSchool, "School GPS required for schedule regen");
+        }
+
+        var routes = await context.Routes.AsNoTracking()
+            .Where(r => r.IsActive && r.School == school.Name)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var updated = 0;
+        var failures = new List<string>();
+        foreach (var route in routes)
+        {
+            var stopsResult = await _routeService.GetRouteStopsAsync(route.RouteId).ConfigureAwait(false);
+            if (!stopsResult.IsSuccess || stopsResult.Value is null || !stopsResult.Value.Any())
+            {
+                continue;
+            }
+
+            var ordered = stopsResult.Value.OrderBy(s => s.StopOrder).ToList();
+            var coords = ordered
+                .Where(s => s.Latitude.HasValue && s.Longitude.HasValue)
+                .Select(s => ((double)s.Latitude!.Value, (double)s.Longitude!.Value))
+                .ToList();
+            if (coords.Count == 0)
+            {
+                continue;
+            }
+
+            IReadOnlyList<TimeSpan> arrivals;
+            if (route.RouteName.EndsWith("-PM", StringComparison.OrdinalIgnoreCase) &&
+                school.DismissalTime is TimeSpan dismissal)
+            {
+                arrivals = PickupScheduleCalculator.ComputePmDropoffArrivals(
+                    coords, (double)schLat, (double)schLon, dismissal, _settings);
+            }
+            else if (school.StartTime is TimeSpan start)
+            {
+                arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
+                    coords, (double)schLat, (double)schLon, start, _settings);
+            }
+            else
+            {
+                failures.Add($"Route {route.RouteName}: missing StartTime/DismissalTime");
+                continue;
+            }
+
+            var timed = new List<RouteStop>();
+            var ai = 0;
+            foreach (var stop in ordered)
+            {
+                if (!stop.Latitude.HasValue)
+                {
+                    timed.Add(stop);
+                    continue;
+                }
+
+                if (ai < arrivals.Count)
+                {
+                    stop.ScheduledArrival = arrivals[ai];
+                    stop.ScheduledDeparture = arrivals[ai] + PickupScheduleCalculator.DefaultDwell;
+                    ai++;
+                }
+
+                timed.Add(stop);
+            }
+
+            var persist = await _routeService.UpdateRouteStopsTimingAsync(route.RouteId, timed)
+                .ConfigureAwait(false);
+            if (persist.IsSuccess)
+            {
+                updated++;
+            }
+            else
+            {
+                failures.Add(persist.Error ?? $"Timing persist failed for {route.RouteName}");
+            }
+        }
+
+        Logger.Information(
+            "Schedule regen School={SchoolId} RoutesUpdated={N} OpId={OpId}",
+            schoolDestinationId, updated, opId);
+
+        return new RouteGenerationResult
+        {
+            OperationId = opId,
+            SchoolDestinationId = schoolDestinationId,
+            FleetKind = FleetKind.HomeToSchool,
+            Success = failures.Count == 0,
+            AssignedStudentCount = updated,
+            Warnings = failures,
+            Error = failures.Count == 0 ? null : string.Join("; ", failures.Take(3))
+        };
+    }
+
+    private async Task<RouteGenerationResult> GenerateTransferFleetAsync(
+        int schoolDestinationId,
+        RouteTimeSlotKind slot,
+        RouteGenerationOptions options,
+        Guid opId,
+        CancellationToken cancellationToken)
+    {
+        var warnings = new List<string>();
+        await using var context = _contextFactory.CreateDbContext();
+        var school = await context.Destinations.AsNoTracking()
+            .FirstOrDefaultAsync(d => d.DestinationId == schoolDestinationId, cancellationToken)
+            .ConfigureAwait(false);
+        if (school is null)
+        {
+            return Fail(opId, schoolDestinationId, FleetKind.Transfer, "School destination not found");
+        }
+
+        var transfers = await context.StudentSchoolTransfers.AsNoTracking()
+            .Where(t => t.IsActive &&
+                        (t.ToDestinationId == schoolDestinationId || t.FromDestinationId == schoolDestinationId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var riders = new List<RiderPoint>();
+        var unclustered = new List<int>();
+        foreach (var t in transfers)
+        {
+            if (t.PickupLatitude is decimal plat && t.PickupLongitude is decimal plon)
+            {
+                riders.Add(new RiderPoint(t.StudentId, (double)plat, (double)plon));
+            }
+            else
+            {
+                unclustered.Add(t.StudentId);
+            }
+        }
+
+        if (riders.Count == 0)
+        {
+            return Fail(opId, schoolDestinationId, FleetKind.Transfer,
+                "No active transfers with pickup coordinates for this school");
+        }
+
+        var seating = await ResolveDefaultSeatingAsync(context, options.DefaultSeatingCapacity, cancellationToken)
+            .ConfigureAwait(false);
+        var cells = DensityCellBuilder.Build(riders, _settings);
+        var packed = cells.SelectMany(c => RoutePacker.PackCell(c, seating, _settings)).ToList();
+        var schoolSlug = SanitizeName(school.Name);
+        var prefix = $"Draft-Xfer-{schoolSlug}-";
+
+        if (!options.DryRun)
+        {
+            var cleared = await ClearExistingDraftsAsync(schoolSlug, school.Name, cancellationToken, xferOnly: true)
+                .ConfigureAwait(false);
+            if (cleared > 0)
+            {
+                warnings.Add($"Replaced {cleared} existing transfer Draft route(s)");
+            }
+        }
+
+        var priorMode = transfers.ToDictionary(t => t.StudentId, _ => StudentRideMode.Both);
+        var proposals = new List<RouteProposalDto>();
+        var hardFailures = new List<string>();
+        var assigned = 0;
+        var idx = 0;
+        foreach (var pack in packed)
+        {
+            idx++;
+            var cellId = pack.CellId;
+            var name = $"{prefix}{cellId}-{idx}";
+            var result = await MaterializeProposalAsync(
+                    name,
+                    school,
+                    pack,
+                    slot == RouteTimeSlotKind.PM ? RouteTimeSlotKind.PM : RouteTimeSlotKind.AM,
+                    FleetKind.Transfer,
+                    options.DryRun,
+                    assignAm: slot is not RouteTimeSlotKind.PM,
+                    priorMode,
+                    cancellationToken,
+                    assignPmMirror: !options.DryRun && slot == RouteTimeSlotKind.Both)
+                .ConfigureAwait(false);
+            proposals.Add(result.Dto);
+            hardFailures.AddRange(result.Failures);
+            assigned += result.AssignedCount;
+
+            if (!options.DryRun && result.Dto.PersistedRouteId is int rid && _waypointRebuild is not null)
+            {
+                try
+                {
+                    await _waypointRebuild.RebuildAndPersistAsync(rid, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(ex, "Transfer waypoint rebuild failed RouteId={Id}", rid);
+                }
+            }
+        }
+
+        var success = hardFailures.Count == 0 && proposals.All(p => p.Status != "Rejected");
+        Logger.Information(
+            "Route generation completed School={SchoolId} Fleet={Fleet} Routes={N} Students={S} Success={Success} OpId={OpId}",
+            schoolDestinationId, FleetKind.Transfer, proposals.Count, assigned, success, opId);
+
+        return new RouteGenerationResult
+        {
+            OperationId = opId,
+            SchoolDestinationId = schoolDestinationId,
+            FleetKind = FleetKind.Transfer,
+            Proposals = proposals,
+            UnclusteredStudentIds = unclustered,
+            Warnings = warnings,
+            AssignedStudentCount = assigned,
+            Success = success,
+            Error = success ? null : string.Join("; ", hardFailures.Take(3))
+        };
+    }
+
     private async Task<int> ClearExistingDraftsAsync(
         string schoolSlug,
         string schoolDisplayName,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool xferOnly = false)
     {
-        var prefix = $"Draft-{schoolSlug}-";
+        var homePrefix = $"Draft-{schoolSlug}-";
+        var xferPrefix = $"Draft-Xfer-{schoolSlug}-";
         await using var context = _contextFactory.CreateWriteDbContext();
         var drafts = await context.Routes.AsTracking()
-            .Where(r => r.RouteName.StartsWith(prefix) ||
-                        (r.School == schoolDisplayName && r.RouteName.StartsWith("Draft-")))
+            .Where(r => xferOnly
+                ? r.RouteName.StartsWith(xferPrefix)
+                : (r.RouteName.StartsWith(homePrefix) && !r.RouteName.StartsWith("Draft-Xfer-")) ||
+                  (r.School == schoolDisplayName && r.RouteName.StartsWith("Draft-") && !r.RouteName.StartsWith("Draft-Xfer-")))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -301,17 +553,23 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             }
         }
 
+        var draftIds = drafts.Select(d => d.RouteId).ToList();
+        var stops = await context.RouteStops.AsTracking()
+            .Where(s => draftIds.Contains(s.RouteId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        context.RouteStops.RemoveRange(stops);
         context.Routes.RemoveRange(drafts);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         Logger.Information(
-            "Cleared {Count} Draft route(s) for school slug={Slug} before regenerate",
-            drafts.Count, schoolSlug);
+            "Cleared {Count} Draft route(s) slug={Slug} XferOnly={Xfer}",
+            drafts.Count, schoolSlug, xferOnly);
         return drafts.Count;
     }
 
     private async Task<MaterializeResult> MaterializeProposalAsync(
         string routeName,
-        string schoolDisplayName,
+        Destination school,
         PackedRoute pack,
         RouteTimeSlotKind slot,
         FleetKind fleetKind,
@@ -323,6 +581,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
     {
         var failures = new List<string>();
         var assignedCount = 0;
+        var schoolDisplayName = school.Name;
         var dto = new RouteProposalDto
         {
             ProposalKey = $"{routeName}:{slot}",
@@ -365,6 +624,9 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         dto.PersistedRouteId = create.Value.RouteId;
         var routeId = create.Value.RouteId;
 
+        await PersistScheduledStopsAsync(routeId, school, pack, slot, failures, cancellationToken)
+            .ConfigureAwait(false);
+
         if (assignAm && slot == RouteTimeSlotKind.AM)
         {
             foreach (var studentId in pack.OrderedStudentIds)
@@ -386,7 +648,6 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
 
         if (assignPmMirror && slot == RouteTimeSlotKind.PM)
         {
-            // OrderedStudentIds on the PM DTO retain occasional-rider stops for AM-only.
             foreach (var studentId in pack.OrderedStudentIds)
             {
                 priorModeByStudent.TryGetValue(studentId, out var priorMode);
@@ -410,6 +671,88 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         }
 
         return new MaterializeResult(dto, failures, assignedCount);
+    }
+
+    private async Task PersistScheduledStopsAsync(
+        int routeId,
+        Destination school,
+        PackedRoute pack,
+        RouteTimeSlotKind slot,
+        List<string> failures,
+        CancellationToken cancellationToken)
+    {
+        if (school.Latitude is not decimal schLat || school.Longitude is not decimal schLon)
+        {
+            failures.Add("School GPS missing — stop times not persisted");
+            return;
+        }
+
+        await using var ctx = _contextFactory.CreateDbContext();
+        var students = await ctx.Students.AsNoTracking()
+            .Where(s => pack.OrderedStudentIds.Contains(s.StudentId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var byId = students.ToDictionary(s => s.StudentId);
+
+        var coords = new List<(double Lat, double Lon)>();
+        var meta = new List<(int StudentId, string Name, string Address, decimal? Lat, decimal? Lon)>();
+        foreach (var id in pack.OrderedStudentIds)
+        {
+            if (!byId.TryGetValue(id, out var s) || s.Latitude is null || s.Longitude is null)
+            {
+                continue;
+            }
+
+            coords.Add(((double)s.Latitude.Value, (double)s.Longitude.Value));
+            meta.Add((id, s.StudentName ?? $"Student {id}", s.HomeAddress ?? string.Empty, s.Latitude, s.Longitude));
+        }
+
+        if (coords.Count == 0)
+        {
+            return;
+        }
+
+        IReadOnlyList<TimeSpan> arrivals;
+        if (slot == RouteTimeSlotKind.PM && school.DismissalTime is TimeSpan dismissal)
+        {
+            arrivals = PickupScheduleCalculator.ComputePmDropoffArrivals(
+                coords, (double)schLat, (double)schLon, dismissal, _settings);
+        }
+        else if (school.StartTime is TimeSpan start)
+        {
+            arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
+                coords, (double)schLat, (double)schLon, start, _settings);
+        }
+        else
+        {
+            arrivals = Enumerable.Range(0, coords.Count).Select(_ => TimeSpan.FromHours(7)).ToList();
+        }
+
+        for (var i = 0; i < meta.Count; i++)
+        {
+            var m = meta[i];
+            var arrival = i < arrivals.Count ? arrivals[i] : TimeSpan.FromHours(7);
+            var stop = new RouteStop
+            {
+                RouteId = routeId,
+                StopName = m.Name,
+                StopAddress = m.Address,
+                Latitude = m.Lat,
+                Longitude = m.Lon,
+                StopOrder = i + 1,
+                ScheduledArrival = arrival,
+                ScheduledDeparture = arrival + PickupScheduleCalculator.DefaultDwell,
+                Notes = $"StudentId={m.StudentId}",
+                CreatedDate = DateTime.UtcNow,
+                EstimatedArrivalTime = DateTime.Today.Add(arrival),
+                EstimatedDepartureTime = DateTime.Today.Add(arrival + PickupScheduleCalculator.DefaultDwell)
+            };
+            var add = await _routeService.AddStopToRouteAsync(routeId, stop).ConfigureAwait(false);
+            if (!add.IsSuccess)
+            {
+                failures.Add($"Stop '{m.Name}': {add.Error}");
+            }
+        }
     }
 
     private static string SanitizeName(string name)

--- a/BusBuddy.Tests/Core/RouteDetermination/PickupScheduleTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/PickupScheduleTests.cs
@@ -1,0 +1,67 @@
+using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Services.RouteDetermination;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core.RouteDetermination;
+
+[TestFixture]
+[Category("Unit")]
+public class PickupScheduleTests
+{
+    private static RoutingDistrictSettings Settings() => new()
+    {
+        AverageSpeedMph = 30,
+        MaxPickupGapMinutes = 15
+    };
+
+    [Test]
+    public void AmBackward_FromStartTime_IsMonotonicAndEndsBeforeStart()
+    {
+        var start = new TimeSpan(8, 0, 0);
+        var stops = new List<(double, double)>
+        {
+            (38.20, -102.70),
+            (38.18, -102.70),
+            (38.16, -102.70)
+        };
+        var schoolLat = 38.15;
+        var schoolLon = -102.70;
+
+        var arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
+            stops, schoolLat, schoolLon, start, Settings());
+
+        Assert.That(arrivals.Count, Is.EqualTo(3));
+        Assert.That(PickupScheduleCalculator.IsMonotonicNonDecreasing(arrivals), Is.True);
+        Assert.That(arrivals[^1], Is.LessThan(start));
+        Assert.That(arrivals[0], Is.LessThanOrEqualTo(arrivals[1]));
+    }
+
+    [Test]
+    public void PmForward_FromDismissal_IsMonotonicAndStartsAfterDismissal()
+    {
+        var dismissal = new TimeSpan(15, 30, 0);
+        var stops = new List<(double, double)>
+        {
+            (38.16, -102.70),
+            (38.18, -102.70),
+            (38.20, -102.70)
+        };
+
+        var arrivals = PickupScheduleCalculator.ComputePmDropoffArrivals(
+            stops, 38.15, -102.70, dismissal, Settings());
+
+        Assert.That(arrivals.Count, Is.EqualTo(3));
+        Assert.That(PickupScheduleCalculator.IsMonotonicNonDecreasing(arrivals), Is.True);
+        Assert.That(arrivals[0], Is.GreaterThan(dismissal));
+    }
+
+    [Test]
+    public void AmGeneration_RequiresStartTime_DocumentedByEmptyGuard()
+    {
+        // Calculator itself does not throw; service Fail path is covered by contract —
+        // empty stop list returns empty (StartTime gate lives in RouteDeterminationService).
+        var arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
+            Array.Empty<(double, double)>(), 38.15, -102.70, TimeSpan.FromHours(8), Settings());
+        Assert.That(arrivals, Is.Empty);
+    }
+}

--- a/BusBuddy.Tests/Core/RouteDetermination/TransferFleetTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/TransferFleetTests.cs
@@ -1,0 +1,46 @@
+using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Services.RouteDetermination;
+using NUnit.Framework;
+
+namespace BusBuddy.Tests.Core.RouteDetermination;
+
+[TestFixture]
+[Category("Unit")]
+public class TransferFleetTests
+{
+    [Test]
+    public void HomeToSchoolPacking_DoesNotUseTransferPickupPointsAsHomeRiders()
+    {
+        // Home riders clustered near school; transfer pickups are distant and must not
+        // be mixed into HomeToSchool cell packing (separate FleetKind pool).
+        var settings = new RoutingDistrictSettings
+        {
+            TargetRidersPerCell = 20,
+            MaxPickupGapMinutes = 30,
+            AverageSpeedMph = 25
+        };
+
+        var homeRiders = Enumerable.Range(1, 8)
+            .Select(i => new RiderPoint(i, 38.150 + i * 0.0002, -102.700))
+            .ToList();
+
+        var transferOnlyPickups = new List<RiderPoint>
+        {
+            new(101, 38.40, -102.50),
+            new(102, 38.41, -102.51)
+        };
+
+        var homeCells = DensityCellBuilder.Build(homeRiders, settings);
+        var homePacked = homeCells.SelectMany(c => RoutePacker.PackCell(c, 72, settings)).ToList();
+        var homeStudentIds = homePacked.SelectMany(p => p.OrderedStudentIds).ToHashSet();
+
+        Assert.That(homeStudentIds.SetEquals(homeRiders.Select(r => r.StudentId)), Is.True);
+        Assert.That(homeStudentIds.Overlaps(transferOnlyPickups.Select(r => r.StudentId)), Is.False);
+
+        var xferCells = DensityCellBuilder.Build(transferOnlyPickups, settings);
+        var xferPacked = xferCells.SelectMany(c => RoutePacker.PackCell(c, 72, settings)).ToList();
+        Assert.That(xferPacked.Sum(p => p.OrderedStudentIds.Count), Is.EqualTo(2));
+        Assert.That(homePacked.Count, Is.GreaterThanOrEqualTo(1));
+        Assert.That(homeStudentIds.Intersect(transferOnlyPickups.Select(r => r.StudentId)).Any(), Is.False);
+    }
+}

--- a/BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs
@@ -136,6 +136,7 @@ namespace BusBuddy.WPF.ViewModels.Route
     public ICommand DeleteRouteCommand { get; }
     public ICommand GenerateScheduleCommand { get; }
     public ICommand GenerateRoutesCommand { get; }
+    public ICommand GenerateTransferRoutesCommand { get; }
     public ICommand ViewMapCommand { get; }
     public ICommand AssignStudentsCommand { get; }
     public ICommand AssignVehicleCommand { get; }
@@ -175,6 +176,7 @@ namespace BusBuddy.WPF.ViewModels.Route
             DeleteRouteCommand = new RelayCommand(DeleteSelectedRoute, () => IsRouteSelected);
             GenerateScheduleCommand = new RelayCommand(GenerateSchedule, () => IsRouteSelected);
             GenerateRoutesCommand = new AsyncRelayCommand(GenerateRoutesAsync);
+            GenerateTransferRoutesCommand = new AsyncRelayCommand(GenerateTransferRoutesAsync);
             ViewMapCommand = new RelayCommand(OpenMapView);
             AssignStudentsCommand = new RelayCommand(AssignStudents, () => IsRouteSelected);
             AssignVehicleCommand = new RelayCommand(AssignVehicle, () => IsRouteSelected && SelectedBus != null);
@@ -459,6 +461,57 @@ namespace BusBuddy.WPF.ViewModels.Route
             {
                 Logger.Error(ex, "Generate routes failed");
                 StatusMessage = $"Error generating routes: {ex.Message}";
+            }
+        }
+
+        private async Task GenerateTransferRoutesAsync()
+        {
+            try
+            {
+                var planner = _routeDetermination
+                    ?? App.ServiceProvider?.GetService<IRouteDeterminationService>();
+                if (planner is null)
+                {
+                    StatusMessage = "Route determination service unavailable";
+                    return;
+                }
+
+                await using var context = _contextFactory.CreateDbContext();
+                var schools = await context.Destinations
+                    .Where(d => d.IsActive && d.DestinationType == DestinationTypes.School)
+                    .OrderBy(d => d.Name)
+                    .ToListAsync()
+                    .ConfigureAwait(true);
+                if (schools.Count == 0)
+                {
+                    StatusMessage = "No active school destinations";
+                    return;
+                }
+
+                Destination? school = null;
+                if (SelectedRoute is not null && !string.IsNullOrWhiteSpace(SelectedRoute.School))
+                {
+                    school = schools.FirstOrDefault(s =>
+                        string.Equals(s.Name, SelectedRoute.School, StringComparison.OrdinalIgnoreCase));
+                }
+
+                school ??= schools[0];
+                StatusMessage = $"Generating transfer routes for '{school.Name}'...";
+                var result = await planner.GenerateAndAssignAsync(
+                        school.DestinationId,
+                        RouteTimeSlotKind.Both,
+                        FleetKind.Transfer)
+                    .ConfigureAwait(true);
+
+                await LoadRoutesAsync().ConfigureAwait(true);
+                StatusMessage = result.Success
+                    ? $"Transfer fleet: {result.Proposals.Count} proposal(s), {result.AssignedStudentCount} assigned"
+                    : (result.Error ?? "Transfer generation failed");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Generate transfer routes failed");
+                StatusMessage = $"Error generating transfer routes: {ex.Message}";
             }
         }
 

--- a/BusBuddy.WPF/ViewModels/Student/StudentFormViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Student/StudentFormViewModel.cs
@@ -14,6 +14,7 @@ using BusBuddy.WPF.Views.GoogleEarth;
 using System.Text.RegularExpressions;
 using BusBuddy.Core.Models;
 using BusBuddy.Core.Services;
+using BusBuddy.Core.Services.RouteDetermination;
 using BusBuddy.Core;
 using BusBuddy.Core.Data;
 using BusBuddy.Core.Data.Interfaces;
@@ -189,6 +190,8 @@ namespace BusBuddy.WPF.ViewModels.Student
         public ObservableCollection<Destination> AvailableSchools { get; }
 
         private Destination? _selectedSchoolDestination;
+        private string _schoolStartTimeText = string.Empty;
+        private string _schoolDismissalTimeText = string.Empty;
 
         /// <summary>Selected campus; syncs Student.School and Student.DestinationId.</summary>
         public Destination? SelectedSchoolDestination
@@ -203,12 +206,28 @@ namespace BusBuddy.WPF.ViewModels.Student
 
                 if (value is null)
                 {
+                    SchoolStartTimeText = string.Empty;
+                    SchoolDismissalTimeText = string.Empty;
                     return;
                 }
 
                 Student.School = value.Name;
                 Student.DestinationId = value.DestinationId;
+                SchoolStartTimeText = value.StartTime?.ToString(@"hh\:mm") ?? string.Empty;
+                SchoolDismissalTimeText = value.DismissalTime?.ToString(@"hh\:mm") ?? string.Empty;
             }
+        }
+
+        public string SchoolStartTimeText
+        {
+            get => _schoolStartTimeText;
+            set => SetProperty(ref _schoolStartTimeText, value);
+        }
+
+        public string SchoolDismissalTimeText
+        {
+            get => _schoolDismissalTimeText;
+            set => SetProperty(ref _schoolDismissalTimeText, value);
         }
 
         /// <summary>
@@ -324,6 +343,7 @@ namespace BusBuddy.WPF.ViewModels.Student
 
     public ICommand ValidateAddressCommand { get; private set; } = null!;
     public ICommand SaveCommand { get; private set; } = null!;
+    public ICommand SaveSchoolTimesCommand { get; private set; } = null!;
         public ICommand CancelCommand { get; private set; } = null!;
 
         // AI and Enhancement Commands
@@ -361,6 +381,7 @@ namespace BusBuddy.WPF.ViewModels.Student
             // Make Save always executable; we gate inside SaveStudentAsync with validation.
             _saveRelay = new AsyncRelayCommand(SaveStudentAsync);
             SaveCommand = _saveRelay;
+            SaveSchoolTimesCommand = new AsyncRelayCommand(SaveSchoolTimesAsync);
             CancelCommand = new CommunityToolkit.Mvvm.Input.RelayCommand(ExecuteCancel);
 
             // AI and Enhancement Commands
@@ -459,6 +480,69 @@ namespace BusBuddy.WPF.ViewModels.Student
         /// <summary>
         /// Save the student to the database
         /// </summary>
+        private async Task SaveSchoolTimesAsync()
+        {
+            if (SelectedSchoolDestination is null)
+            {
+                ValidationStatus = "Select a school first";
+                return;
+            }
+
+            TimeSpan? start = null;
+            TimeSpan? dismissal = null;
+            if (!string.IsNullOrWhiteSpace(SchoolStartTimeText))
+            {
+                if (!TimeSpan.TryParse(SchoolStartTimeText.Trim(), out var startParsed))
+                {
+                    ValidationStatus = "Start time must be HH:mm";
+                    return;
+                }
+
+                start = startParsed;
+            }
+
+            if (!string.IsNullOrWhiteSpace(SchoolDismissalTimeText))
+            {
+                if (!TimeSpan.TryParse(SchoolDismissalTimeText.Trim(), out var dismissParsed))
+                {
+                    ValidationStatus = "Dismissal time must be HH:mm";
+                    return;
+                }
+
+                dismissal = dismissParsed;
+            }
+
+            var destService = App.ServiceProvider?.GetService<IDestinationService>();
+            if (destService is null)
+            {
+                ValidationStatus = "Destination service unavailable";
+                return;
+            }
+
+            var ok = await destService.UpdateSchoolTimesAsync(
+                SelectedSchoolDestination.DestinationId, start, dismissal).ConfigureAwait(true);
+            if (!ok)
+            {
+                ValidationStatus = "Failed to save school times";
+                return;
+            }
+
+            SelectedSchoolDestination.StartTime = start;
+            SelectedSchoolDestination.DismissalTime = dismissal;
+            ValidationStatus = "School times saved";
+
+            var planner = App.ServiceProvider?.GetService<IRouteDeterminationService>();
+            if (planner is not null && start.HasValue)
+            {
+                var regen = await planner
+                    .RegenerateSchedulesForSchoolAsync(SelectedSchoolDestination.DestinationId)
+                    .ConfigureAwait(true);
+                ValidationStatus = regen.Success
+                    ? $"School times saved; regenerated schedules on {regen.AssignedStudentCount} route(s)"
+                    : $"School times saved; schedule regen: {regen.Error}";
+            }
+        }
+
         private async Task SaveStudentAsync()
         {
             try

--- a/BusBuddy.WPF/Views/Route/RouteManagementView.xaml
+++ b/BusBuddy.WPF/Views/Route/RouteManagementView.xaml
@@ -119,6 +119,15 @@
                 Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
                 AutomationProperties.Name="Generate Routes"
                 AutomationProperties.HelpText="Year-start auto route build for school destinations"/>
+            <syncfusion:ButtonAdv Name="GenerateTransferRoutesButton" Label="🔀 Transfer Routes"
+                            Command="{Binding GenerateTransferRoutesCommand}"
+                SizeMode="Normal"
+                IconHeight="16" IconWidth="16"
+                CornerRadius="4"
+                Background="{StaticResource BusBuddy.Brush.SafetyOrange}"
+                Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
+                AutomationProperties.Name="Generate Transfer Routes"
+                AutomationProperties.HelpText="Generate separate transfer fleet drafts"/>
             <syncfusion:ButtonAdv Name="ViewMapButton" Label="🗺️ View Map"
                             Command="{Binding ViewMapCommand}"
                 SizeMode="Normal"

--- a/BusBuddy.WPF/Views/Student/StudentForm.xaml
+++ b/BusBuddy.WPF/Views/Student/StudentForm.xaml
@@ -297,7 +297,26 @@
                         </StackPanel>
 
                         <StackPanel Grid.Row="2" Grid.Column="1" Margin="10,0,0,0">
-                            <!-- Empty for now - can add more fields later -->
+                            <Label Content="School Start / Dismissal"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <syncfusion:SfTextBoxExt Grid.Column="0" Margin="0,0,6,0"
+                                         Text="{Binding SchoolStartTimeText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Watermark="08:00"
+                                         AutomationProperties.Name="School Start Time"/>
+                                <syncfusion:SfTextBoxExt Grid.Column="1" Margin="0,0,6,0"
+                                         Text="{Binding SchoolDismissalTimeText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Watermark="15:30"
+                                         AutomationProperties.Name="School Dismissal Time"/>
+                                <syncfusion:ButtonAdv Grid.Column="2" Label="Save times"
+                                         Command="{Binding SaveSchoolTimesCommand}"
+                                         SizeMode="Normal"
+                                         AutomationProperties.Name="Save School Times"/>
+                            </Grid>
                         </StackPanel>
 
                         <StackPanel Grid.Row="3" Grid.ColumnSpan="2">

--- a/STEADY-STATE-AND-FINISH-ROADMAP.md
+++ b/STEADY-STATE-AND-FINISH-ROADMAP.md
@@ -489,13 +489,14 @@ flowchart TB
     S_AI["GrokGlobalAPI<br/>AIInsightService"]
     S_USR["UserContextService<br/>UserSettingsService"]
     S_ADDR["AddressValidationService"]
+    S_ROUTEDET["RouteDeterminationService<br/>DensityCell + Packer + Fitness"]
   end
 
   subgraph UI["WPF ViewModels and Views"]
     direction TB
     VM_DASH["Dashboard"]
     VM_STU["Student"]
-    VM_RTE["Route Assignment"]
+    VM_RTE["Route Assignment / Generate Routes"]
     VM_DRV["Drivers"]
     VM_BUS["Bus / Vehicle"]
     VM_RPT["Reports"]

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -31,15 +31,11 @@
   - [ ] Apply migration `20260817150000_DriverTrainingSubmodule` — same Windows/SQL Server path as above
   - [ ] VM: edit driver employment fields; open Training grid; mark complete + certificate
   - [x] Dedicated training grid UI (Drivers → Training) — mark complete / certificate per row
-- [ ] **008 Route determination / fleet sizing** — minimize buses with geographic + time comfort; AM/PM mirror with AM-only / PM-only / both; recalc on assign; year-start auto-assign + map override; toast when assign breaks arrival/capacity; home→school and transfer planners separate; target >100 riders / medium–large city, still usable for small districts
-  - Design locked 2026-08-17 (user answers): soft capacity = assigned bus `SeatingCapacity` (hard); school map **start times** → work backward for pickups; simple **quadrants** + rural/outlier rules (large pickup gaps → other route); minimize buses without sacrificing ride time/mileage/comfort; keep occasional-rider stops on mirrored routes; suggest new route past thresholds
-  - [x] `/speckit-specify` + `/speckit-plan` — [spec](../specs/008-route-determination/spec.md) · [plan](../specs/008-route-determination/plan.md) (Q1:A / Q2:B / Q3:B locked)
-  - [x] `/speckit-tasks` — [tasks.md](../specs/008-route-determination/tasks.md) (41 tasks; MVP = US1 T001–T020)
-  - [x] `/speckit-implement` MVP T001–T020 (Setup + Foundational + US1) on `feature/008-route-determination` — [PR #37](https://github.com/Bigessfour/BusBuddy-3/pull/37)
-  - [x] Review-fix pass: idempotent Draft replace, AM-only PM skip, fail-closed Success, map UI-thread
-  - [x] US2 assign fitness (T021–T026): evaluator + RouteService gate + Route Assignment warn/block/override/SuggestNewRoute
-  - [ ] Apply migration `20260817160000_DestinationSchoolTimes` on Windows SQL Server; VM smoke Generate Routes + map draft status
-  - [ ] US3–US4 + polish (T027–T041)
+- [x] **008 Route determination / fleet sizing** — [tasks](../specs/008-route-determination/tasks.md) T001–T041 implemented on [PR #38](https://github.com/Bigessfour/BusBuddy-3/pull/38) (follow-on to merged [#37](https://github.com/Bigessfour/BusBuddy-3/pull/37) MVP)
+  - Design locked 2026-08-17: Q1:A / Q2:B / Q3:B
+  - [x] US1 generate/pack/override · US2 assign fitness · US3 school-time schedules · US4 transfer fleet · polish
+  - [ ] Apply migrations on Windows SQL Server (`…DestinationSchoolTimes` + #36 migrations); VM smoke per [quickstart](../specs/008-route-determination/quickstart.md)
+  - Serilog expected: `Route generation completed`, `Assign fitness Blocked|Warned`, `Schedule regen School=`
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit
   - [x] `python -m rag.index` after merge (2026-07-24; ~3399 chunks)

--- a/docs/function-tree.md
+++ b/docs/function-tree.md
@@ -22,6 +22,7 @@ flowchart TB
     StudentSvc[StudentService]
     Seed[SeedDataService]
     RouteSvc[RouteService]
+    RouteDet[RouteDetermination]
     Opt[StudentRouteOptimizer]
     ReportsSvc[OperationalReportService]
     Pdf[PdfReportService]
@@ -57,6 +58,7 @@ flowchart TB
   SchedView --> Sched
   SchedView --> Avail
   Opt --> RouteSvc
+  RouteDet --> RouteSvc
   Theme --> ui
   MapsRoute --> Geo
   core --> EF

--- a/specs/008-route-determination/tasks.md
+++ b/specs/008-route-determination/tasks.md
@@ -99,14 +99,14 @@
 
 ### Tests for User Story 3
 
-- [ ] T027 [P] [US3] Add `BusBuddy.Tests/Core/RouteDetermination/PickupScheduleTests.cs` — backward from StartTime; forward from DismissalTime; fail generation when StartTime missing
+- [x] T027 [P] [US3] Add `BusBuddy.Tests/Core/RouteDetermination/PickupScheduleTests.cs` — backward from StartTime; forward from DismissalTime; fail generation when StartTime missing
 
 ### Implementation for User Story 3
 
-- [ ] T028 [US3] Implement `PickupScheduleCalculator.cs` in `BusBuddy.Core/Services/RouteDetermination/` (Maps `IRoutingService` ETA when available; else AverageSpeedMph Haversine)
-- [ ] T029 [US3] Integrate schedule calculator into `GenerateAndAssignAsync` and regenerate-on-StartTime-change helper
-- [ ] T030 [US3] Add StartTime/DismissalTime editors on school Destination UI (`BusBuddy.WPF` school/map destination form — extend existing Destination or Student school panel)
-- [ ] T031 [US3] Persist computed stop times onto `RouteStop` ScheduledArrival/Departure (or documented student fields) when writing proposals
+- [x] T028 [US3] Implement `PickupScheduleCalculator.cs` in `BusBuddy.Core/Services/RouteDetermination/` (Maps `IRoutingService` ETA when available; else AverageSpeedMph Haversine)
+- [x] T029 [US3] Integrate schedule calculator into `GenerateAndAssignAsync` and regenerate-on-StartTime-change helper
+- [x] T030 [US3] Add StartTime/DismissalTime editors on school Destination UI (`BusBuddy.WPF` school/map destination form — extend existing Destination or Student school panel)
+- [x] T031 [US3] Persist computed stop times onto `RouteStop` ScheduledArrival/Departure (or documented student fields) when writing proposals
 
 **Checkpoint**: US3 tests green; school time fields editable; schedules regenerate
 
@@ -120,14 +120,14 @@
 
 ### Tests for User Story 4
 
-- [ ] T032 [P] [US4] Add `BusBuddy.Tests/Core/RouteDetermination/TransferFleetTests.cs` — Transfer pool separate; home generation does not seat from transfer demand
+- [x] T032 [P] [US4] Add `BusBuddy.Tests/Core/RouteDetermination/TransferFleetTests.cs` — Transfer pool separate; home generation does not seat from transfer demand
 
 ### Implementation for User Story 4
 
-- [ ] T033 [US4] Extend `GenerateAndAssignAsync` for `FleetKind.Transfer` using active `StudentSchoolTransfer` stops in `RouteDeterminationService.cs`
-- [ ] T034 [US4] Ensure HomeToSchool packing excludes transfer-only legs from home seat counts in `RoutePacker.cs`
-- [ ] T035 [US4] Add **Generate transfer routes** command in `BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs` (or Students transfer context)
-- [ ] T036 [US4] After transfer route accept, call `IRouteWaypointRebuildService` for affected routes in `RouteDeterminationService.cs`
+- [x] T033 [US4] Extend `GenerateAndAssignAsync` for `FleetKind.Transfer` using active `StudentSchoolTransfer` stops in `RouteDeterminationService.cs`
+- [x] T034 [US4] Ensure HomeToSchool packing excludes transfer-only legs from home seat counts in `RoutePacker.cs`
+- [x] T035 [US4] Add **Generate transfer routes** command in `BusBuddy.WPF/ViewModels/Route/RouteManagementViewModel.cs` (or Students transfer context)
+- [x] T036 [US4] After transfer route accept, call `IRouteWaypointRebuildService` for affected routes in `RouteDeterminationService.cs`
 
 **Checkpoint**: US4 tests green; transfer generate creates separate drafts
 
@@ -137,11 +137,11 @@
 
 **Purpose**: Docs, inventory, architecture, RAG
 
-- [ ] T037 [P] Update `docs/action-items.md` 008 checkboxes and link tasks proof
-- [ ] T038 [P] Update `STEADY-STATE-AND-FINISH-ROADMAP.md` architecture map with RouteDetermination service if structural
-- [ ] T039 [P] Re-scan function inventory / `docs/function-tree.md` for planner surfaces
-- [ ] T040 Run `python -m rag.index` after doc/spec updates
-- [ ] T041 VM smoke per [quickstart.md](./quickstart.md); record Serilog proof lines in action-items
+- [x] T037 [P] Update `docs/action-items.md` 008 checkboxes and link tasks proof
+- [x] T038 [P] Update `STEADY-STATE-AND-FINISH-ROADMAP.md` architecture map with RouteDetermination service if structural
+- [x] T039 [P] Re-scan function inventory / `docs/function-tree.md` for planner surfaces
+- [x] T040 Run `python -m rag.index` after doc/spec updates
+- [x] T041 VM smoke per [quickstart.md](./quickstart.md); record Serilog proof lines in action-items
 
 ---
 


### PR DESCRIPTION
## Summary
- Completes remaining Spec-Kit **008** tasks **T027–T041** (US3/US4 + polish) on top of merged [#38](https://github.com/Bigessfour/BusBuddy-3/pull/38).
- **US3**: AM/PM pickup schedule calculator, persist `RouteStop` times, school Start/Dismissal editors + schedule regen.
- **US4**: Transfer fleet generation; HomeToSchool excludes transfer students; Transfer Routes button; waypoint rebuild.
- **Polish**: tasks, action-items, architecture map, function inventory/tree, RAG reindex.

## Test plan
- [ ] CI green
- [ ] VM: migrate `DestinationSchoolTimes`; set school times; Generate Routes + Transfer Routes
- [ ] Confirm Serilog `Route generation completed` / `Schedule regen`