### PR TITLE
fix: 008 review hardenings (regen, transfer stops, Both)

### DIFF
--- a/BusBuddy.Core/Services/RouteDetermination/PickupScheduleCalculator.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/PickupScheduleCalculator.cs
@@ -1,4 +1,5 @@
 using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Models;
 
 namespace BusBuddy.Core.Services.RouteDetermination;
 
@@ -11,8 +12,41 @@ public static class PickupScheduleCalculator
     public static readonly TimeSpan DefaultDwell = TimeSpan.FromSeconds(45);
 
     /// <summary>
-    /// Ordered stops from first pickup toward school. Returns arrival times per stop (same length),
-    /// plus final school arrival (= startTime).
+    /// Transfer AM uses pickup; PM uses dropoff when present, otherwise pickup.
+    /// </summary>
+    public static bool TryResolveTransferStop(
+        StudentSchoolTransfer transfer,
+        RouteTimeSlotKind slot,
+        out decimal latitude,
+        out decimal longitude,
+        out string address)
+    {
+        ArgumentNullException.ThrowIfNull(transfer);
+        var useDropoff = slot == RouteTimeSlotKind.PM &&
+                         transfer.DropoffLatitude is not null &&
+                         transfer.DropoffLongitude is not null;
+        var lat = useDropoff ? transfer.DropoffLatitude : transfer.PickupLatitude;
+        var lon = useDropoff ? transfer.DropoffLongitude : transfer.PickupLongitude;
+        if (lat is null || lon is null)
+        {
+            latitude = default;
+            longitude = default;
+            address = string.Empty;
+            return false;
+        }
+
+        latitude = lat.Value;
+        longitude = lon.Value;
+        address = useDropoff
+            ? (transfer.DropoffAddress ?? transfer.PickupAddress ?? string.Empty)
+            : (transfer.PickupAddress ?? string.Empty);
+        return true;
+    }
+
+    /// <summary>
+    /// Ordered stops from first pickup toward school. Returns arrival times per stop (same length).
+    /// <paramref name="underflow"/> is true when travel would push a stop before midnight (00:00);
+    /// arrivals are still clamped to zero so callers can warn or fail.
     /// </summary>
     public static IReadOnlyList<TimeSpan> ComputeAmPickupArrivals(
         IReadOnlyList<(double Latitude, double Longitude)> orderedStopsTowardSchool,
@@ -20,10 +54,12 @@ public static class PickupScheduleCalculator
         double schoolLon,
         TimeSpan schoolStartTime,
         RoutingDistrictSettings settings,
+        out bool underflow,
         TimeSpan? dwellPerStop = null)
     {
         ArgumentNullException.ThrowIfNull(orderedStopsTowardSchool);
         ArgumentNullException.ThrowIfNull(settings);
+        underflow = false;
 
         if (orderedStopsTowardSchool.Count == 0)
         {
@@ -51,12 +87,15 @@ public static class PickupScheduleCalculator
             }
 
             var minutes = LegMinutes(lat, lon, nextLat, nextLon, mph);
-            cursor = cursor - TimeSpan.FromMinutes(minutes) - (i < orderedStopsTowardSchool.Count - 1 ? dwell : TimeSpan.Zero);
-            if (cursor < TimeSpan.Zero)
+            var next = cursor - TimeSpan.FromMinutes(minutes) -
+                       (i < orderedStopsTowardSchool.Count - 1 ? dwell : TimeSpan.Zero);
+            if (next < TimeSpan.Zero)
             {
-                cursor = TimeSpan.Zero;
+                underflow = true;
+                next = TimeSpan.Zero;
             }
 
+            cursor = next;
             arrivals[i] = RoundToMinute(cursor);
         }
 

--- a/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationModels.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationModels.cs
@@ -53,6 +53,8 @@ public sealed class RouteGenerationResult
     public IReadOnlyList<int> UnclusteredStudentIds { get; set; } = Array.Empty<int>();
     public IReadOnlyList<string> Warnings { get; set; } = Array.Empty<string>();
     public int AssignedStudentCount { get; set; }
+    /// <summary>Routes whose stop times were rewritten (schedule regen); not student assigns.</summary>
+    public int RoutesUpdated { get; set; }
     public bool Success { get; set; }
     public string? Error { get; set; }
 }

--- a/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
+++ b/BusBuddy.Core/Services/RouteDetermination/RouteDeterminationService.cs
@@ -327,6 +327,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             }
 
             IReadOnlyList<TimeSpan> arrivals;
+            var warningsForRoute = new List<string>();
             if (route.RouteName.EndsWith("-PM", StringComparison.OrdinalIgnoreCase) &&
                 school.DismissalTime is TimeSpan dismissal)
             {
@@ -336,7 +337,12 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             else if (school.StartTime is TimeSpan start)
             {
                 arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
-                    coords, (double)schLat, (double)schLon, start, _settings);
+                    coords, (double)schLat, (double)schLon, start, _settings, out var underflow);
+                if (underflow)
+                {
+                    warningsForRoute.Add(
+                        $"Route {route.RouteName}: AM schedule underflow (travel exceeds StartTime); times clamped");
+                }
             }
             else
             {
@@ -356,8 +362,12 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
 
                 if (ai < arrivals.Count)
                 {
-                    stop.ScheduledArrival = arrivals[ai];
-                    stop.ScheduledDeparture = arrivals[ai] + PickupScheduleCalculator.DefaultDwell;
+                    var arrival = arrivals[ai];
+                    var departure = arrival + PickupScheduleCalculator.DefaultDwell;
+                    stop.ScheduledArrival = arrival;
+                    stop.ScheduledDeparture = departure;
+                    stop.EstimatedArrivalTime = DateTime.Today.Add(arrival);
+                    stop.EstimatedDepartureTime = DateTime.Today.Add(departure);
                     ai++;
                 }
 
@@ -369,6 +379,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             if (persist.IsSuccess)
             {
                 updated++;
+                failures.AddRange(warningsForRoute);
             }
             else
             {
@@ -380,15 +391,20 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             "Schedule regen School={SchoolId} RoutesUpdated={N} OpId={OpId}",
             schoolDestinationId, updated, opId);
 
+        // Underflow warnings are soft — regen still succeeded if persist worked.
+        var hardFailures = failures.Where(f => !f.Contains("underflow", StringComparison.OrdinalIgnoreCase)).ToList();
+        var softWarnings = failures.Where(f => f.Contains("underflow", StringComparison.OrdinalIgnoreCase)).ToList();
+
         return new RouteGenerationResult
         {
             OperationId = opId,
             SchoolDestinationId = schoolDestinationId,
             FleetKind = FleetKind.HomeToSchool,
-            Success = failures.Count == 0,
-            AssignedStudentCount = updated,
-            Warnings = failures,
-            Error = failures.Count == 0 ? null : string.Join("; ", failures.Take(3))
+            Success = hardFailures.Count == 0,
+            AssignedStudentCount = 0,
+            RoutesUpdated = updated,
+            Warnings = softWarnings.Concat(hardFailures).ToList(),
+            Error = hardFailures.Count == 0 ? null : string.Join("; ", hardFailures.Take(3))
         };
     }
 
@@ -453,6 +469,9 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         }
 
         var priorMode = transfers.ToDictionary(t => t.StudentId, _ => StudentRideMode.Both);
+        var transferByStudent = transfers
+            .GroupBy(t => t.StudentId)
+            .ToDictionary(g => g.Key, g => g.First());
         var proposals = new List<RouteProposalDto>();
         var hardFailures = new List<string>();
         var assigned = 0;
@@ -461,33 +480,49 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         {
             idx++;
             var cellId = pack.CellId;
-            var name = $"{prefix}{cellId}-{idx}";
-            var result = await MaterializeProposalAsync(
-                    name,
-                    school,
-                    pack,
-                    slot == RouteTimeSlotKind.PM ? RouteTimeSlotKind.PM : RouteTimeSlotKind.AM,
-                    FleetKind.Transfer,
-                    options.DryRun,
-                    assignAm: slot is not RouteTimeSlotKind.PM,
-                    priorMode,
-                    cancellationToken,
-                    assignPmMirror: !options.DryRun && slot == RouteTimeSlotKind.Both)
-                .ConfigureAwait(false);
-            proposals.Add(result.Dto);
-            hardFailures.AddRange(result.Failures);
-            assigned += result.AssignedCount;
+            var amName = $"{prefix}{cellId}-{idx}";
 
-            if (!options.DryRun && result.Dto.PersistedRouteId is int rid && _waypointRebuild is not null)
+            if (slot is RouteTimeSlotKind.AM or RouteTimeSlotKind.Both)
             {
-                try
-                {
-                    await _waypointRebuild.RebuildAndPersistAsync(rid, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Warning(ex, "Transfer waypoint rebuild failed RouteId={Id}", rid);
-                }
+                var amResult = await MaterializeProposalAsync(
+                        amName,
+                        school,
+                        pack,
+                        RouteTimeSlotKind.AM,
+                        FleetKind.Transfer,
+                        options.DryRun,
+                        assignAm: true,
+                        priorMode,
+                        cancellationToken,
+                        transferStopsByStudent: transferByStudent)
+                    .ConfigureAwait(false);
+                proposals.Add(amResult.Dto);
+                hardFailures.AddRange(amResult.Failures);
+                assigned += amResult.AssignedCount;
+                await TryRebuildWaypointsAsync(amResult.Dto.PersistedRouteId, options.DryRun, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (slot is RouteTimeSlotKind.PM or RouteTimeSlotKind.Both)
+            {
+                var pmName = $"{amName}-PM";
+                var pmResult = await MaterializeProposalAsync(
+                        pmName,
+                        school,
+                        pack,
+                        RouteTimeSlotKind.PM,
+                        FleetKind.Transfer,
+                        options.DryRun,
+                        assignAm: false,
+                        priorMode,
+                        cancellationToken,
+                        assignPmMirror: !options.DryRun,
+                        transferStopsByStudent: transferByStudent)
+                    .ConfigureAwait(false);
+                proposals.Add(pmResult.Dto);
+                hardFailures.AddRange(pmResult.Failures);
+                await TryRebuildWaypointsAsync(pmResult.Dto.PersistedRouteId, options.DryRun, cancellationToken)
+                    .ConfigureAwait(false);
             }
         }
 
@@ -508,6 +543,26 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
             Success = success,
             Error = success ? null : string.Join("; ", hardFailures.Take(3))
         };
+    }
+
+    private async Task TryRebuildWaypointsAsync(
+        int? routeId,
+        bool dryRun,
+        CancellationToken cancellationToken)
+    {
+        if (dryRun || routeId is not int rid || _waypointRebuild is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _waypointRebuild.RebuildAndPersistAsync(rid, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "Transfer waypoint rebuild failed RouteId={Id}", rid);
+        }
     }
 
     private async Task<int> ClearExistingDraftsAsync(
@@ -577,7 +632,8 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         bool assignAm,
         IReadOnlyDictionary<int, StudentRideMode> priorModeByStudent,
         CancellationToken cancellationToken,
-        bool assignPmMirror = false)
+        bool assignPmMirror = false,
+        IReadOnlyDictionary<int, StudentSchoolTransfer>? transferStopsByStudent = null)
     {
         var failures = new List<string>();
         var assignedCount = 0;
@@ -624,7 +680,8 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         dto.PersistedRouteId = create.Value.RouteId;
         var routeId = create.Value.RouteId;
 
-        await PersistScheduledStopsAsync(routeId, school, pack, slot, failures, cancellationToken)
+        await PersistScheduledStopsAsync(
+                routeId, school, pack, slot, fleetKind, failures, cancellationToken, transferStopsByStudent)
             .ConfigureAwait(false);
 
         if (assignAm && slot == RouteTimeSlotKind.AM)
@@ -678,8 +735,10 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         Destination school,
         PackedRoute pack,
         RouteTimeSlotKind slot,
+        FleetKind fleetKind,
         List<string> failures,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<int, StudentSchoolTransfer>? transferStopsByStudent = null)
     {
         if (school.Latitude is not decimal schLat || school.Longitude is not decimal schLon)
         {
@@ -698,6 +757,19 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         var meta = new List<(int StudentId, string Name, string Address, decimal? Lat, decimal? Lon)>();
         foreach (var id in pack.OrderedStudentIds)
         {
+            if (fleetKind == FleetKind.Transfer &&
+                transferStopsByStudent is not null &&
+                transferStopsByStudent.TryGetValue(id, out var transfer) &&
+                PickupScheduleCalculator.TryResolveTransferStop(
+                    transfer, slot, out var tLat, out var tLon, out var tAddr))
+            {
+                byId.TryGetValue(id, out var student);
+                var name = student?.StudentName ?? $"Student {id}";
+                coords.Add(((double)tLat, (double)tLon));
+                meta.Add((id, name, tAddr, tLat, tLon));
+                continue;
+            }
+
             if (!byId.TryGetValue(id, out var s) || s.Latitude is null || s.Longitude is null)
             {
                 continue;
@@ -721,7 +793,13 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         else if (school.StartTime is TimeSpan start)
         {
             arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
-                coords, (double)schLat, (double)schLon, start, _settings);
+                coords, (double)schLat, (double)schLon, start, _settings, out var underflow);
+            if (underflow)
+            {
+                Logger.Warning(
+                    "AM schedule underflow RouteId={RouteId} — travel exceeds StartTime; times clamped to 00:00",
+                    routeId);
+            }
         }
         else
         {
@@ -732,6 +810,7 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
         {
             var m = meta[i];
             var arrival = i < arrivals.Count ? arrivals[i] : TimeSpan.FromHours(7);
+            var departure = arrival + PickupScheduleCalculator.DefaultDwell;
             var stop = new RouteStop
             {
                 RouteId = routeId,
@@ -741,11 +820,11 @@ public sealed class RouteDeterminationService : IRouteDeterminationService
                 Longitude = m.Lon,
                 StopOrder = i + 1,
                 ScheduledArrival = arrival,
-                ScheduledDeparture = arrival + PickupScheduleCalculator.DefaultDwell,
+                ScheduledDeparture = departure,
                 Notes = $"StudentId={m.StudentId}",
                 CreatedDate = DateTime.UtcNow,
                 EstimatedArrivalTime = DateTime.Today.Add(arrival),
-                EstimatedDepartureTime = DateTime.Today.Add(arrival + PickupScheduleCalculator.DefaultDwell)
+                EstimatedDepartureTime = DateTime.Today.Add(departure)
             };
             var add = await _routeService.AddStopToRouteAsync(routeId, stop).ConfigureAwait(false);
             if (!add.IsSuccess)

--- a/BusBuddy.Core/Services/RouteService.cs
+++ b/BusBuddy.Core/Services/RouteService.cs
@@ -1290,6 +1290,8 @@ namespace BusBuddy.Core.Services
                         var match = dbStops.FirstOrDefault(s => s.RouteStopId == updated.RouteStopId);
                         if (match != null)
                         {
+                            match.ScheduledArrival = updated.ScheduledArrival;
+                            match.ScheduledDeparture = updated.ScheduledDeparture;
                             match.EstimatedArrivalTime = updated.EstimatedArrivalTime;
                             match.EstimatedDepartureTime = updated.EstimatedDepartureTime;
                             match.UpdatedDate = DateTime.UtcNow;

--- a/BusBuddy.Tests/Core/RouteDetermination/PickupScheduleTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/PickupScheduleTests.cs
@@ -28,8 +28,9 @@ public class PickupScheduleTests
         var schoolLon = -102.70;
 
         var arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
-            stops, schoolLat, schoolLon, start, Settings());
+            stops, schoolLat, schoolLon, start, Settings(), out var underflow);
 
+        Assert.That(underflow, Is.False);
         Assert.That(arrivals.Count, Is.EqualTo(3));
         Assert.That(PickupScheduleCalculator.IsMonotonicNonDecreasing(arrivals), Is.True);
         Assert.That(arrivals[^1], Is.LessThan(start));
@@ -56,12 +57,30 @@ public class PickupScheduleTests
     }
 
     [Test]
-    public void AmGeneration_RequiresStartTime_DocumentedByEmptyGuard()
+    public void AmGeneration_EmptyStops_ReturnsEmpty()
     {
-        // Calculator itself does not throw; service Fail path is covered by contract —
-        // empty stop list returns empty (StartTime gate lives in RouteDeterminationService).
         var arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
-            Array.Empty<(double, double)>(), 38.15, -102.70, TimeSpan.FromHours(8), Settings());
+            Array.Empty<(double, double)>(), 38.15, -102.70, TimeSpan.FromHours(8), Settings(), out var underflow);
         Assert.That(arrivals, Is.Empty);
+        Assert.That(underflow, Is.False);
+    }
+
+    [Test]
+    public void AmBackward_ImpossibleTravel_SetsUnderflowAndClamps()
+    {
+        // Very early start with distant stops → underflow
+        var start = new TimeSpan(0, 5, 0);
+        var stops = new List<(double, double)>
+        {
+            (40.0, -104.0),
+            (39.0, -103.0),
+            (38.5, -102.8)
+        };
+
+        var arrivals = PickupScheduleCalculator.ComputeAmPickupArrivals(
+            stops, 38.15, -102.70, start, Settings(), out var underflow);
+
+        Assert.That(underflow, Is.True);
+        Assert.That(arrivals.All(t => t >= TimeSpan.Zero), Is.True);
     }
 }

--- a/BusBuddy.Tests/Core/RouteDetermination/TransferFleetTests.cs
+++ b/BusBuddy.Tests/Core/RouteDetermination/TransferFleetTests.cs
@@ -1,4 +1,5 @@
 using BusBuddy.Core.Configuration;
+using BusBuddy.Core.Models;
 using BusBuddy.Core.Services.RouteDetermination;
 using NUnit.Framework;
 
@@ -42,5 +43,46 @@ public class TransferFleetTests
         Assert.That(xferPacked.Sum(p => p.OrderedStudentIds.Count), Is.EqualTo(2));
         Assert.That(homePacked.Count, Is.GreaterThanOrEqualTo(1));
         Assert.That(homeStudentIds.Intersect(transferOnlyPickups.Select(r => r.StudentId)).Any(), Is.False);
+    }
+
+    [Test]
+    public void TransferStopResolver_PrefersPickupForAm_AndDropoffForPm()
+    {
+        var transfer = new StudentSchoolTransfer
+        {
+            StudentId = 42,
+            PickupLatitude = 38.40m,
+            PickupLongitude = -102.50m,
+            PickupAddress = "Pickup Hub",
+            DropoffLatitude = 38.16m,
+            DropoffLongitude = -102.70m,
+            DropoffAddress = "Campus Door"
+        };
+
+        Assert.That(
+            PickupScheduleCalculator.TryResolveTransferStop(
+                transfer, RouteTimeSlotKind.AM, out var amLat, out var amLon, out var amAddr),
+            Is.True);
+        Assert.That(amLat, Is.EqualTo(38.40m));
+        Assert.That(amLon, Is.EqualTo(-102.50m));
+        Assert.That(amAddr, Is.EqualTo("Pickup Hub"));
+
+        Assert.That(
+            PickupScheduleCalculator.TryResolveTransferStop(
+                transfer, RouteTimeSlotKind.PM, out var pmLat, out var pmLon, out var pmAddr),
+            Is.True);
+        Assert.That(pmLat, Is.EqualTo(38.16m));
+        Assert.That(pmLon, Is.EqualTo(-102.70m));
+        Assert.That(pmAddr, Is.EqualTo("Campus Door"));
+    }
+
+    [Test]
+    public void TransferBothSlot_ProducesDistinctAmAndPmProposalNames()
+    {
+        // Naming contract used by GenerateTransferFleetAsync for RouteTimeSlotKind.Both
+        const string amName = "Draft-Xfer-Wiley-c1-1";
+        var pmName = $"{amName}-PM";
+        Assert.That(pmName, Does.EndWith("-PM"));
+        Assert.That(amName, Does.Not.EndWith("-PM"));
     }
 }

--- a/BusBuddy.WPF/ViewModels/Student/StudentFormViewModel.cs
+++ b/BusBuddy.WPF/ViewModels/Student/StudentFormViewModel.cs
@@ -538,7 +538,7 @@ namespace BusBuddy.WPF.ViewModels.Student
                     .RegenerateSchedulesForSchoolAsync(SelectedSchoolDestination.DestinationId)
                     .ConfigureAwait(true);
                 ValidationStatus = regen.Success
-                    ? $"School times saved; regenerated schedules on {regen.AssignedStudentCount} route(s)"
+                    ? $"School times saved; regenerated schedules on {regen.RoutesUpdated} route(s)"
                     : $"School times saved; schedule regen: {regen.Error}";
             }
         }

--- a/docs/action-items.md
+++ b/docs/action-items.md
@@ -34,7 +34,8 @@
 - [x] **008 Route determination / fleet sizing** — [tasks](../specs/008-route-determination/tasks.md) T001–T041 implemented on [PR #38](https://github.com/Bigessfour/BusBuddy-3/pull/38) (follow-on to merged [#37](https://github.com/Bigessfour/BusBuddy-3/pull/37) MVP)
   - Design locked 2026-08-17: Q1:A / Q2:B / Q3:B
   - [x] US1 generate/pack/override · US2 assign fitness · US3 school-time schedules · US4 transfer fleet · polish
-  - [ ] Apply migrations on Windows SQL Server (`…DestinationSchoolTimes` + #36 migrations); VM smoke per [quickstart](../specs/008-route-determination/quickstart.md)
+  - [x] Review hardenings (schedule regen persists Scheduled+Estimated; transfer stops use pickup/dropoff; Both creates AM+PM) — PR #39 follow-up
+  - [ ] Apply migrations on Windows SQL Server (`…DestinationSchoolTimes` + #36 migrations); VM smoke per [quickstart](../specs/008-route-determination/quickstart.md) (**T041 still open**)
   - Serilog expected: `Route generation completed`, `Assign fitness Blocked|Warned`, `Schedule regen School=`
 - [x] **006 Syncfusion Tool Integration** — [spec](../specs/006-syncfusion-tool-integration/spec.md) — merged [PR #21](https://github.com/Bigessfour/BusBuddy-3/pull/21)
   - [x] MCP paths, skills overlay, Syncfusion **34.2.3**, deps audit

--- a/specs/008-route-determination/tasks.md
+++ b/specs/008-route-determination/tasks.md
@@ -141,7 +141,7 @@
 - [x] T038 [P] Update `STEADY-STATE-AND-FINISH-ROADMAP.md` architecture map with RouteDetermination service if structural
 - [x] T039 [P] Re-scan function inventory / `docs/function-tree.md` for planner surfaces
 - [x] T040 Run `python -m rag.index` after doc/spec updates
-- [x] T041 VM smoke per [quickstart.md](./quickstart.md); record Serilog proof lines in action-items
+- [ ] T041 VM smoke per [quickstart.md](./quickstart.md); record Serilog proof lines in action-items
 
 ---
 


### PR DESCRIPTION
## Summary
- Follow-up to merged [#39](https://github.com/Bigessfour/BusBuddy-3/pull/39) addressing code-review blockers.
- **Schedule regen**: persist both `Scheduled*` and `Estimated*` via `UpdateRouteStopsTimingAsync`; expose `RoutesUpdated`.
- **Transfer stops**: use transfer pickup (AM) / dropoff (PM) coords, not home GPS.
- **Transfer Both**: materialize separate AM and `-PM` routes with PM assigns.
- **AM underflow**: flag via `out underflow` + Serilog warn; T041 left open for VM smoke.

## Test plan
- [ ] CI green
- [ ] Save school times → stop `ScheduledArrival` and `EstimatedArrivalTime` both update
- [ ] Transfer Routes → draft stops at pickup hubs; Both creates `Draft-Xfer-…` and `…-PM`
- [ ] VM T041 smoke still required