### PR TITLE
fix: Fluent theme ownership, persistence, and leftover chrome

### DIFF
--- a/BusBuddy.Core/Configuration/AppSettingsOptions.cs
+++ b/BusBuddy.Core/Configuration/AppSettingsOptions.cs
@@ -10,7 +10,8 @@ public class AppSettingsOptions
 {
     public const string SectionName = "AppSettings";
 
-    public string Theme { get; set; } = "Office2019Colorful";
+    /// <summary>FluentDark or FluentLight. Office2019Colorful is retired.</summary>
+    public string Theme { get; set; } = "FluentDark";
     public bool AutoSave { get; set; } = true;
 
     [Range(60, 3600)]

--- a/BusBuddy.Tests/WPF/SyncfusionThemeManagerTests.cs
+++ b/BusBuddy.Tests/WPF/SyncfusionThemeManagerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using BusBuddy.WPF.Utilities;
 using NUnit.Framework;
 
@@ -14,6 +16,8 @@ namespace BusBuddy.Tests.WPF
         [TestCase("FluentLight", "FluentLight")]
         [TestCase("light", "FluentLight")]
         [TestCase("FluentWhite", "FluentLight")]
+        [TestCase("Office2019Colorful", "FluentDark")]
+        [TestCase("Office2019", "FluentDark")]
         public void NormalizeThemeName_MapsAliases(string? input, string expected)
         {
             Assert.That(SyncfusionThemeManager.NormalizeThemeName(input), Is.EqualTo(expected));
@@ -24,6 +28,62 @@ namespace BusBuddy.Tests.WPF
         {
             Assert.That(SyncfusionThemeManager.ThemeDictionaryPath("FluentDark"), Does.Contain("FluentDarkTheme.xaml"));
             Assert.That(SyncfusionThemeManager.ThemeDictionaryPath("FluentLight"), Does.Contain("FluentLightTheme.xaml"));
+            Assert.That(SyncfusionThemeManager.ThemeDictionaryPath("Office2019Colorful"), Does.Contain("FluentDarkTheme.xaml"));
+        }
+    }
+
+    [TestFixture]
+    [Category("WPF")]
+    public class ThemePreferenceStoreTests
+    {
+        private string _originalPath = null!;
+        private string _tempDir = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalPath = ThemePreferenceStore.SettingsFilePath;
+            _tempDir = Path.Combine(Path.GetTempPath(), "busbuddy-theme-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+            ThemePreferenceStore.SettingsFilePath = Path.Combine(_tempDir, "user-settings.json");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ThemePreferenceStore.SettingsFilePath = _originalPath;
+            try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        [Test]
+        public void Load_ReturnsFallback_WhenFileMissing()
+        {
+            Assert.That(ThemePreferenceStore.Load(), Is.EqualTo("FluentDark"));
+        }
+
+        [Test]
+        public void Save_ThenLoad_RoundTripsFluentLight()
+        {
+            ThemePreferenceStore.Save("FluentLight");
+            Assert.That(ThemePreferenceStore.Load(), Is.EqualTo("FluentLight"));
+            Assert.That(File.ReadAllText(ThemePreferenceStore.SettingsFilePath), Does.Contain("FluentLight"));
+        }
+
+        [Test]
+        public void Save_MergesWithoutDroppingOtherKeys()
+        {
+            File.WriteAllText(ThemePreferenceStore.SettingsFilePath, """{"EnableActivityLogging":true,"Theme":"FluentDark"}""");
+            ThemePreferenceStore.Save("FluentLight");
+            var json = File.ReadAllText(ThemePreferenceStore.SettingsFilePath);
+            Assert.That(json, Does.Contain("FluentLight"));
+            Assert.That(json, Does.Contain("EnableActivityLogging").Or.Contain("enableActivityLogging"));
+        }
+
+        [Test]
+        public void Load_MapsRetiredOfficeThemeToFluentDark()
+        {
+            File.WriteAllText(ThemePreferenceStore.SettingsFilePath, """{"Theme":"Office2019Colorful"}""");
+            Assert.That(ThemePreferenceStore.Load(), Is.EqualTo("FluentDark"));
         }
     }
 }

--- a/BusBuddy.WPF/App.xaml.cs
+++ b/BusBuddy.WPF/App.xaml.cs
@@ -467,7 +467,7 @@ namespace BusBuddy.WPF
                         new HttpClient(),
                         sp.GetRequiredService<IConfiguration>()));
 
-                services.AddScoped<IUserSettingsService, UserSettingsService>();
+                services.AddSingleton<IUserSettingsService, UserSettingsService>();
                 services.AddScoped<IFuelService, FuelService>();
                 services.AddScoped<IMaintenanceService, MaintenanceService>();
                 services.AddScoped<IScheduleService, ScheduleService>();
@@ -1204,13 +1204,13 @@ Examples:
         }
 
         /// <summary>
-        /// Initialize SyncFusion themes according to v30.1.42 API guidelines
-        /// Sets up FluentDark as primary theme with FluentLight fallback
+        /// Initialize SyncFusion themes. SfSkinManager.ApplicationTheme owns the skin.
+        /// Restores the last theme saved from MainWindow / Settings.
         /// </summary>
         private void InitializeSyncfusionThemes()
         {
-            Log.Information("Initializing Syncfusion Fluent themes");
-            SyncfusionThemeManager.ApplyApplicationTheme(SyncfusionThemeManager.PRIMARY_THEME);
+            Log.Information("Initializing Syncfusion Fluent themes from saved preference");
+            SyncfusionThemeManager.ApplySavedApplicationTheme();
         }
     }
 }

--- a/BusBuddy.WPF/Resources/SyncfusionStyles.xaml
+++ b/BusBuddy.WPF/Resources/SyncfusionStyles.xaml
@@ -1,24 +1,14 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:syncfusion="http://schemas.syncfusion.com/wpf">
-    <!-- Syncfusion skin resources — per official docs include SfSkinManager style dictionaries from theme assemblies -->
-    <!-- Docs: https://help.syncfusion.com/wpf/themes/skin-manager -->
-    <ResourceDictionary.MergedDictionaries>
-        <!-- Fluent Dark theme styles for SfSkinManager -->
-        <ResourceDictionary Source="/Syncfusion.Themes.FluentDark.WPF;component/SfSkinManager/SfSkinManagerStyle.xaml"/>
-        <!-- Optional: include Fluent Light to ensure fallback resources are present at design-time -->
-        <ResourceDictionary Source="/Syncfusion.Themes.FluentLight.WPF;component/SfSkinManager/SfSkinManagerStyle.xaml"/>
-    </ResourceDictionary.MergedDictionaries>
-
     <!--
-    Note: Removed duplicate BusBuddy.Brush.Primary and BusBuddy.Brush.Text.Primary
-    to resolve "Item has already been added" errors in ResourceDictionary.
-    These brushes are defined in SyncfusionV30_Validated_ResourceDictionary.xaml
-    and will be used via DynamicResource bindings.
+    Do not merge FluentDark + FluentLight skin dictionaries here.
+    SfSkinManager.ApplicationTheme (set in SyncfusionThemeManager) owns the active skin.
+    Merging both caused last-wins (FluentLight chrome on a FluentDark app).
+    Docs: https://help.syncfusion.com/wpf/themes/skin-manager
     -->
 
-    <!-- Default styles for Syncfusion inputs -->
-    <!-- Note: Syncfusion controls pick up styles via SfSkinManager; keep minimal defaults here -->
+    <!-- Default styles for Syncfusion inputs — size only; skin paints chrome. -->
     <Style TargetType="syncfusion:SfTextBoxExt">
         <Setter Property="MinHeight" Value="30" />
     </Style>
@@ -27,9 +17,10 @@
         <Setter Property="MinHeight" Value="30" />
     </Style>
 
-    <!-- Standard ButtonAdv Styles Following Syncfusion Documentation and FluentDark Theme -->
-    
-    <!-- Default ButtonAdv Style -->
+    <!--
+    Implicit ButtonAdv: size/padding only. No Background/Foreground — those belong to
+    the Fluent skin injected by SfSkinManager.ApplyThemeAsDefaultStyle.
+    -->
     <Style TargetType="syncfusion:ButtonAdv">
         <Setter Property="SizeMode" Value="Normal"/>
         <Setter Property="IconHeight" Value="16"/>
@@ -40,50 +31,35 @@
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="FontWeight" Value="Normal"/>
         <Setter Property="Cursor" Value="Hand"/>
-        <Setter Property="Background" Value="{DynamicResource AccentBackgroundBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
     </Style>
 
-    <!-- Primary Action ButtonAdv Style -->
     <Style x:Key="PrimaryButtonAdvStyle" TargetType="syncfusion:ButtonAdv" BasedOn="{StaticResource {x:Type syncfusion:ButtonAdv}}">
-        <Setter Property="Background" Value="{DynamicResource AccentBackgroundBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Padding" Value="16,10"/>
     </Style>
 
-    <!-- Secondary Action ButtonAdv Style -->
     <Style x:Key="SecondaryButtonAdvStyle" TargetType="syncfusion:ButtonAdv" BasedOn="{StaticResource {x:Type syncfusion:ButtonAdv}}">
-        <Setter Property="Background" Value="{DynamicResource SecondaryBackgroundBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
     </Style>
 
-    <!-- Danger/Delete Action ButtonAdv Style -->
     <Style x:Key="DangerButtonAdvStyle" TargetType="syncfusion:ButtonAdv" BasedOn="{StaticResource {x:Type syncfusion:ButtonAdv}}">
-        <Setter Property="Background" Value="{DynamicResource ErrorTextBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Semantic.Error}"/>
+        <Setter Property="Foreground" Value="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
     </Style>
 
-    <!-- Success Action ButtonAdv Style -->
     <Style x:Key="SuccessButtonAdvStyle" TargetType="syncfusion:ButtonAdv" BasedOn="{StaticResource {x:Type syncfusion:ButtonAdv}}">
-        <Setter Property="Background" Value="{DynamicResource SuccessTextBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource PrimaryBackgroundBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Semantic.Success}"/>
+        <Setter Property="Foreground" Value="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
     </Style>
 
-    <!-- Warning Action ButtonAdv Style -->
     <Style x:Key="WarningButtonAdvStyle" TargetType="syncfusion:ButtonAdv" BasedOn="{StaticResource {x:Type syncfusion:ButtonAdv}}">
-        <Setter Property="Background" Value="{DynamicResource WarningTextBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Semantic.Warning}"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryBackgroundBrush}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
     </Style>
 
-    <!-- Small Icon ButtonAdv Style -->
     <Style x:Key="SmallIconButtonAdvStyle" TargetType="syncfusion:ButtonAdv" BasedOn="{StaticResource {x:Type syncfusion:ButtonAdv}}">
         <Setter Property="SizeMode" Value="Small"/>
         <Setter Property="IconHeight" Value="12"/>
@@ -93,7 +69,6 @@
         <Setter Property="MinHeight" Value="32"/>
     </Style>
 
-    <!-- Large ButtonAdv Style -->
     <Style x:Key="LargeButtonAdvStyle" TargetType="syncfusion:ButtonAdv" BasedOn="{StaticResource {x:Type syncfusion:ButtonAdv}}">
         <Setter Property="SizeMode" Value="Large"/>
         <Setter Property="IconHeight" Value="24"/>

--- a/BusBuddy.WPF/Resources/SyncfusionV30_Validated_ResourceDictionary.xaml
+++ b/BusBuddy.WPF/Resources/SyncfusionV30_Validated_ResourceDictionary.xaml
@@ -100,51 +100,10 @@
                    Color="{StaticResource BusBuddy.Semantic.Info}"/>
 
   <!--  ===============================================================================  -->
-  <!--  SECTION 2.1: FLUENTLIGHT THEME COMPATIBLE COLORS  -->
+  <!--  SECTION 2.1: PANEL AND CONTAINER BRUSHES  -->
   <!--  ===============================================================================  -->
-  <!--  FluentLight-specific colors for proper light mode support  -->
-
-  <!--  FluentLight Surface Colors  -->
-  <Color x:Key="BusBuddy.Surface.LightMode.Background">#FFFFFF</Color>
-  <Color x:Key="BusBuddy.Surface.LightMode.Surface">#F3F2F1</Color>
-  <Color x:Key="BusBuddy.Surface.LightMode.Border">#E1DFDD</Color>
-  <Color x:Key="BusBuddy.Surface.LightMode.Accent">#FAFAFA</Color>
-
-  <!--  FluentLight Text Colors  -->
-  <Color x:Key="BusBuddy.Text.LightMode.Primary">#000000</Color>
-  <Color x:Key="BusBuddy.Text.LightMode.Secondary">#323130</Color>
-  <Color x:Key="BusBuddy.Text.LightMode.Disabled">#A19F9D</Color>
-
-  <!--  FluentLight State Colors  -->
-  <Color x:Key="BusBuddy.State.LightMode.Hover">#F3F2F1</Color>
-  <Color x:Key="BusBuddy.State.LightMode.Pressed">#EDEBE9</Color>
-
-  <!--  FluentLight Brushes  -->
-  <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Background"
-                   Color="{StaticResource BusBuddy.Surface.LightMode.Background}"/>
-  <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Surface"
-                   Color="{StaticResource BusBuddy.Surface.LightMode.Surface}"/>
-  <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Border"
-                   Color="{StaticResource BusBuddy.Surface.LightMode.Border}"/>
-  <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Accent"
-                   Color="{StaticResource BusBuddy.Surface.LightMode.Accent}"/>
-
-  <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Primary"
-                   Color="{StaticResource BusBuddy.Text.LightMode.Primary}"/>
-  <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Secondary"
-                   Color="{StaticResource BusBuddy.Text.LightMode.Secondary}"/>
-  <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Disabled"
-                   Color="{StaticResource BusBuddy.Text.LightMode.Disabled}"/>
-
-  <SolidColorBrush x:Key="BusBuddy.Brush.State.LightMode.Hover"
-                   Color="{StaticResource BusBuddy.State.LightMode.Hover}"/>
-  <SolidColorBrush x:Key="BusBuddy.Brush.State.LightMode.Pressed"
-                   Color="{StaticResource BusBuddy.State.LightMode.Pressed}"/>
-
-  <!--  ===============================================================================  -->
-  <!--  SECTION 2.2: HIGH CONTRAST PANEL AND CONTAINER BRUSHES  -->
-  <!--  ===============================================================================  -->
-  <!--  Enhanced contrast brushes for panel backgrounds and data grid containers  -->
+  <!--  Surface.* / Text.* swap with the theme selector via FluentDark/FluentLight dictionaries.
+        Do not add a LightMode.* parallel set — use Surface / Panel / Text tokens instead.  -->
 
   <!--  High Contrast Panel Colors  -->
   <Color x:Key="BusBuddy.Panel.Background">#1A1A1A</Color>         <!-- Darker than Surface.Dark for better contrast -->

--- a/BusBuddy.WPF/Resources/Themes/FluentDarkTheme.xaml
+++ b/BusBuddy.WPF/Resources/Themes/FluentDarkTheme.xaml
@@ -50,28 +50,8 @@
     <SolidColorBrush x:Key="DataGridSelectionBackgroundBrush" Color="#094771"/>
     <SolidColorBrush x:Key="DataGridGridLinesBrush" Color="#3F3F46"/>
 
-    <!-- Syncfusion control styles integrated with Fluent Dark theme -->
-    <!-- Implicit style for ButtonAdv to improve contrast while preserving theme look -->
-    <!-- Properties are documented WPF dependency properties inherited by Syncfusion ButtonAdv -->
-    <Style TargetType="{x:Type syncfusion:ButtonAdv}">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource HoverBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="Padding" Value="12,6"/>
-        <Setter Property="Cursor" Value="Hand"/>
-        <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource ButtonHoverBackgroundBrush}"/>
-            </Trigger>
-            <Trigger Property="IsPressed" Value="True">
-                <Setter Property="Background" Value="{DynamicResource ButtonPressedBackgroundBrush}"/>
-            </Trigger>
-            <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Opacity" Value="0.6"/>
-            </Trigger>
-        </Style.Triggers>
-    </Style>
+    <!-- Syncfusion paints ButtonAdv chrome via SfSkinManager.ApplicationTheme.
+         Do not set implicit Background/Foreground here — that stomps the Fluent template. -->
 
     <!-- Named ButtonAdv Success style for semantic success actions -->
     <!-- Based on official Syncfusion ButtonAdv documentation: https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Tools.Controls.ButtonAdv.html -->
@@ -178,21 +158,21 @@
         </Style.Triggers>
     </Style>
 
-    <!-- Surface / text tokens used by docking panels. LightMode key names are historical; values follow FluentDark. -->
-    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Background" Color="#1E1E1E"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Surface" Color="#252526"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Border" Color="#3F3F46"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Accent" Color="#2D2D30"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Primary" Color="#FFFFFF"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Secondary" Color="#E5E5E5"/>
+    <!-- Surface / text tokens swap with the theme selector (DynamicResource). -->
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.Dark" Color="#1E1E1E"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.Medium" Color="#252526"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.Light" Color="#2D2D30"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.Border" Color="#3F3F46"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Text.Primary" Color="#FFFFFF"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Text.Secondary" Color="#E5E5E5"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.Disabled" Color="#999999"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Background" Color="#1A1A1A"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Content" Color="#252526"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Header" Color="#2D2D30"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Border" Color="#404040"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Header.Background" Color="#2D2D30"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Text.OnPrimary" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.DataGrid.Background" Color="#1F1F1F"/>
     <SolidColorBrush x:Key="FormLabelForegroundBrush" Color="#FFFFFF"/>
     <SolidColorBrush x:Key="FormInputForegroundBrush" Color="#FFFFFF"/>
     <SolidColorBrush x:Key="FormInputBackgroundBrush" Color="#2B2B2B"/>

--- a/BusBuddy.WPF/Resources/Themes/FluentLightTheme.xaml
+++ b/BusBuddy.WPF/Resources/Themes/FluentLightTheme.xaml
@@ -62,38 +62,7 @@
                      Color="#CCE8FF" />
     <SolidColorBrush x:Key="DataGridGridLinesBrush"
                      Color="#E1DFDD" />
-    <!-- Syncfusion control styles integrated with Fluent Light theme -->
-    <Style TargetType="{x:Type syncfusion:ButtonAdv}">
-        <Setter Property="Background"
-                Value="{DynamicResource ButtonBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ButtonForegroundBrush}" />
-        <Setter Property="BorderBrush"
-                Value="{DynamicResource HoverBorderBrush}" />
-        <Setter Property="BorderThickness"
-                Value="1" />
-        <Setter Property="Padding"
-                Value="12,6" />
-        <Setter Property="Cursor"
-                Value="Hand" />
-        <Style.Triggers>
-            <Trigger Property="IsMouseOver"
-                     Value="True">
-                <Setter Property="Background"
-                        Value="{DynamicResource ButtonHoverBackgroundBrush}" />
-            </Trigger>
-            <Trigger Property="IsPressed"
-                     Value="True">
-                <Setter Property="Background"
-                        Value="{DynamicResource ButtonPressedBackgroundBrush}" />
-            </Trigger>
-            <Trigger Property="IsEnabled"
-                     Value="False">
-                <Setter Property="Opacity"
-                        Value="0.6" />
-            </Trigger>
-        </Style.Triggers>
-    </Style>
+    <!-- Syncfusion paints ButtonAdv chrome via SfSkinManager.ApplicationTheme. -->
 
     <!-- Named ButtonAdv Success style for semantic success actions -->
     <!-- Based on official Syncfusion ButtonAdv documentation: https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Tools.Controls.ButtonAdv.html -->
@@ -205,21 +174,21 @@
     <SolidColorBrush x:Key="WarningTextBrush" Color="#8A6D00"/>
     <SolidColorBrush x:Key="SuccessTextBrush" Color="#107C10"/>
 
-    <!-- Same token keys as FluentDark so DynamicResource updates when the dictionary is swapped. -->
-    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Background" Color="#FFFFFF"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Surface" Color="#F3F2F1"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Border" Color="#E1DFDD"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.LightMode.Accent" Color="#FAFAFA"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Primary" Color="#201F1E"/>
-    <SolidColorBrush x:Key="BusBuddy.Brush.Text.LightMode.Secondary" Color="#323130"/>
+    <!-- Same Surface / Text / Panel keys as FluentDark so DynamicResource updates on switch. -->
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.Dark" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.Medium" Color="#F3F2F1"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.Light" Color="#FAFAFA"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Surface.Border" Color="#D2D0CE"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Text.Primary" Color="#201F1E"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Text.Secondary" Color="#605E5C"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.Text.Disabled" Color="#A19F9D"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Background" Color="#FFFFFF"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Content" Color="#FAFAFA"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Header" Color="#F3F2F1"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Panel.Border" Color="#D2D0CE"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Header.Background" Color="#F3F2F1"/>
     <SolidColorBrush x:Key="BusBuddy.Brush.Text.OnPrimary" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="BusBuddy.Brush.DataGrid.Background" Color="#FFFFFF"/>
     <SolidColorBrush x:Key="FormLabelForegroundBrush" Color="#201F1E"/>
     <SolidColorBrush x:Key="FormInputForegroundBrush" Color="#201F1E"/>
     <SolidColorBrush x:Key="FormInputBackgroundBrush" Color="#FFFFFF"/>

--- a/BusBuddy.WPF/Utilities/DebugOutputFilter.cs
+++ b/BusBuddy.WPF/Utilities/DebugOutputFilter.cs
@@ -196,7 +196,7 @@ namespace BusBuddy.WPF.Utilities
                 new Regex(@"SfSkinManager\.SetTheme", RegexOptions.IgnoreCase),
                 new Regex(@"theme.*not.*applied", RegexOptions.IgnoreCase),
                 new Regex(@"FluentDark.*theme.*error", RegexOptions.IgnoreCase),
-                new Regex(@"Office2019Colorful.*theme.*error", RegexOptions.IgnoreCase),
+                new Regex(@"FluentLight.*theme.*error", RegexOptions.IgnoreCase),
                 new Regex(@"SfSkinManager.*error", RegexOptions.IgnoreCase),
                 new Regex(@"ApplyStylesOnApplication.*error", RegexOptions.IgnoreCase),
                 new Regex(@"theme.*resource.*not.*found", RegexOptions.IgnoreCase)

--- a/BusBuddy.WPF/Utilities/SyncfusionThemeManager.cs
+++ b/BusBuddy.WPF/Utilities/SyncfusionThemeManager.cs
@@ -10,10 +10,12 @@ namespace BusBuddy.WPF.Utilities
     /// <summary>
     /// Single source of truth for FluentDark / FluentLight. Views inherit
     /// <see cref="SfSkinManager.ApplicationTheme"/>; windows/dialogs take the current theme.
+    /// Skin dictionaries are NOT merged in XAML — ApplicationTheme owns the skin.
     /// </summary>
     public static class SyncfusionThemeManager
     {
         private static readonly ILogger Logger = Log.ForContext(typeof(SyncfusionThemeManager));
+        private static bool _suppressPersist;
 
         public const string PRIMARY_THEME = "FluentDark";
         public const string FALLBACK_THEME = "FluentLight";
@@ -35,6 +37,7 @@ namespace BusBuddy.WPF.Utilities
                 return FALLBACK_THEME;
             }
 
+            // Retired Office2019Colorful (and any other leftover name) maps to FluentDark.
             return PRIMARY_THEME;
         }
 
@@ -81,6 +84,22 @@ namespace BusBuddy.WPF.Utilities
         }
 
         /// <summary>
+        /// Load the last saved Fluent theme (or <see cref="PRIMARY_THEME"/>) and apply it.
+        /// </summary>
+        public static void ApplySavedApplicationTheme()
+        {
+            _suppressPersist = true;
+            try
+            {
+                ApplyApplicationTheme(ThemePreferenceStore.Load());
+            }
+            finally
+            {
+                _suppressPersist = false;
+            }
+        }
+
+        /// <summary>
         /// Switch FluentDark / FluentLight for the whole app, including custom brush dictionaries.
         /// </summary>
         public static void ApplyApplicationTheme(string? themeName)
@@ -118,6 +137,11 @@ namespace BusBuddy.WPF.Utilities
                             Logger.Warning(ex, "[Theme] Could not apply {Theme} to {Window}", name, win.GetType().Name);
                         }
                     }
+                }
+
+                if (!_suppressPersist)
+                {
+                    ThemePreferenceStore.Save(name);
                 }
 
                 Logger.Information("Theme changed to {ThemeName} at application scope", name);

--- a/BusBuddy.WPF/Utilities/ThemePreferenceStore.cs
+++ b/BusBuddy.WPF/Utilities/ThemePreferenceStore.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Serilog;
+
+namespace BusBuddy.WPF.Utilities
+{
+    /// <summary>
+    /// Persists the Fluent theme selection in the same AppData file as
+    /// <c>UserSettingsService</c> so MainWindow and Settings stay in sync.
+    /// </summary>
+    public static class ThemePreferenceStore
+    {
+        private static readonly ILogger Logger = Log.ForContext(typeof(ThemePreferenceStore));
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        public const string ThemeKey = "Theme";
+
+        /// <summary>
+        /// Override in tests. Defaults to %AppData%/BusBuddy/user-settings.json.
+        /// </summary>
+        public static string SettingsFilePath { get; set; } = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "BusBuddy",
+            "user-settings.json");
+
+        public static string Load(string fallback = SyncfusionThemeManager.PRIMARY_THEME)
+        {
+            try
+            {
+                if (!File.Exists(SettingsFilePath))
+                {
+                    return SyncfusionThemeManager.NormalizeThemeName(fallback);
+                }
+
+                var json = File.ReadAllText(SettingsFilePath);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    return SyncfusionThemeManager.NormalizeThemeName(fallback);
+                }
+
+                using var doc = JsonDocument.Parse(json);
+                if (TryReadTheme(doc.RootElement, out var saved))
+                {
+                    return SyncfusionThemeManager.NormalizeThemeName(saved);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Could not load persisted theme from {Path}", SettingsFilePath);
+            }
+
+            return SyncfusionThemeManager.NormalizeThemeName(fallback);
+        }
+
+        public static void Save(string themeName)
+        {
+            var name = SyncfusionThemeManager.NormalizeThemeName(themeName);
+            try
+            {
+                var directory = Path.GetDirectoryName(SettingsFilePath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                Dictionary<string, JsonElement> data = new(StringComparer.OrdinalIgnoreCase);
+                if (File.Exists(SettingsFilePath))
+                {
+                    var existing = File.ReadAllText(SettingsFilePath);
+                    if (!string.IsNullOrWhiteSpace(existing))
+                    {
+                        var loaded = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(existing);
+                        if (loaded is not null)
+                        {
+                            foreach (var pair in loaded)
+                            {
+                                data[pair.Key] = pair.Value;
+                            }
+                        }
+                    }
+                }
+
+                using var themeDoc = JsonDocument.Parse($"\"{name}\"");
+                data[ThemeKey] = themeDoc.RootElement.Clone();
+
+                var payload = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+                foreach (var pair in data)
+                {
+                    payload[pair.Key] = JsonSerializer.Deserialize<object>(pair.Value.GetRawText());
+                }
+
+                File.WriteAllText(SettingsFilePath, JsonSerializer.Serialize(payload, JsonOptions));
+                Logger.Debug("Persisted theme {Theme} to {Path}", name, SettingsFilePath);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Could not persist theme {Theme} to {Path}", name, SettingsFilePath);
+            }
+        }
+
+        private static bool TryReadTheme(JsonElement root, out string? theme)
+        {
+            theme = null;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            foreach (var property in root.EnumerateObject())
+            {
+                if (property.Name.Equals(ThemeKey, StringComparison.OrdinalIgnoreCase)
+                    && property.Value.ValueKind == JsonValueKind.String)
+                {
+                    theme = property.Value.GetString();
+                    return !string.IsNullOrWhiteSpace(theme);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/BusBuddy.WPF/Views/Driver/DriversView.xaml
+++ b/BusBuddy.WPF/Views/Driver/DriversView.xaml
@@ -30,18 +30,18 @@
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <Border Grid.Row="0" Background="#007ACC"
+        <Border Grid.Row="0" Background="{DynamicResource BusBuddy.Brush.Primary}"
                 CornerRadius="5" Padding="15" Margin="0,0,0,10">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="&#xE7C4;" FontFamily="Segoe MDL2 Assets"
-                          FontSize="24" Foreground="White" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                          FontSize="24" Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <TextBlock Text="Driver Management" FontSize="20" FontWeight="Bold"
-                          Foreground="White" VerticalAlignment="Center"/>
+                          Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}" VerticalAlignment="Center"/>
             </StackPanel>
         </Border>
 
         <!-- Toolbar -->
-        <Border Grid.Row="1" Background="#F5F5F5"
+        <Border Grid.Row="1" Background="{DynamicResource BusBuddy.Brush.Panel.Header}"
                 CornerRadius="3" Padding="10" Margin="0,0,0,10">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -51,17 +51,17 @@
 
                 <!-- Main Actions -->
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
-                    <syncfusion:ButtonAdv Name="AddDriverButton" Label="➕ Add Driver"
+                    <syncfusion:ButtonAdv Name="AddDriverButton" Label="Add Driver"
                             Command="{Binding AddDriverCommand}"
-                            Background="{StaticResource BusBuddy.Brush.Primary}" Foreground="White"
+                            Background="{DynamicResource BusBuddy.Brush.Primary}" Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
                             AutomationProperties.Name="Add Driver"
                             AutomationProperties.HelpText="Opens form to add a new driver to the system"/>
-                    <syncfusion:ButtonAdv Name="EditDriverButton" Label="✏️ Edit Driver"
+                    <syncfusion:ButtonAdv Name="EditDriverButton" Label="Edit Driver"
                             Command="{Binding EditDriverCommand}"
                             IsEnabled="{Binding HasSelectedDriver}"
                             AutomationProperties.Name="Edit Driver"
                             AutomationProperties.HelpText="Opens form to edit the currently selected driver"/>
-                    <syncfusion:ButtonAdv Name="DeleteDriverButton" Label="🗑️ Delete Driver"
+                    <syncfusion:ButtonAdv Name="DeleteDriverButton" Label="Delete Driver"
                             Command="{Binding DeleteDriverCommand}"
                             IsEnabled="{Binding HasSelectedDriver}"
                             AutomationProperties.Name="Delete Driver"
@@ -69,27 +69,27 @@
                     <Separator Margin="10,0"/>
 
                     <!-- Driver Specific Actions -->
-                    <syncfusion:ButtonAdv Name="ViewLicenseButton" Label="📄 View License"
+                    <syncfusion:ButtonAdv Name="ViewLicenseButton" Label="View License"
                             Command="{Binding ViewLicenseCommand}"
                             IsEnabled="{Binding HasSelectedDriver}"
-                            Background="{StaticResource BusBuddy.Brush.Semantic.Info}" Foreground="White"
+                            Background="{DynamicResource BusBuddy.Brush.Semantic.Info}" Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
                             AutomationProperties.Name="View License Details"
                             AutomationProperties.HelpText="View license information and expiration details"/>
-            <syncfusion:ButtonAdv Name="TrainingRecordsButton" Label="🎓 Training"
+            <syncfusion:ButtonAdv Name="TrainingRecordsButton" Label="Training"
                 Command="{Binding TrainingRecordsCommand}"
                             IsEnabled="{Binding HasSelectedDriver}"
-                            Background="{StaticResource BusBuddy.Brush.SafetyOrange}" Foreground="White"
+                            Background="{DynamicResource BusBuddy.Brush.SafetyOrange}" Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
                             AutomationProperties.Name="View Training Records"
                             AutomationProperties.HelpText="View and manage driver training records"/>
                 </StackPanel>
 
                 <!-- Quick Actions -->
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <syncfusion:ButtonAdv Name="RefreshButton" Label="🔄 Refresh"
+                    <syncfusion:ButtonAdv Name="RefreshButton" Label="Refresh"
                             Command="{Binding RefreshCommand}"
                             AutomationProperties.Name="Refresh Driver List"
                             AutomationProperties.HelpText="Reload driver data from the database"/>
-            <syncfusion:ButtonAdv Name="ExportButton" Label="📤 Export"
+            <syncfusion:ButtonAdv Name="ExportButton" Label="Export"
                 Command="{Binding GenerateReportsCommand}"
                             AutomationProperties.Name="Export Drivers"
                             AutomationProperties.HelpText="Export driver data to CSV file"/>
@@ -97,7 +97,7 @@
                     <!-- Quick Filter -->
             <syncfusion:SfTextBoxExt Name="QuickSearchBox" Width="150" Margin="10,0,0,0"
                 Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
-                            Watermark="🔍 Search drivers..."
+                            Watermark="Search drivers..."
                             AutomationProperties.Name="Quick Search Drivers"
                             AutomationProperties.HelpText="Type to search drivers by name, license, or status"/>
                 </StackPanel>
@@ -136,7 +136,7 @@
         </syncfusion:SfDataGrid>
 
         <!-- Status Bar -->
-        <Border Grid.Row="3" Background="#E9ECEF" CornerRadius="3" Padding="10" Margin="0,10,0,0">
+        <Border Grid.Row="3" Background="{DynamicResource BusBuddy.Brush.Panel.Header}" CornerRadius="3" Padding="10" Margin="0,10,0,0">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -144,15 +144,15 @@
                 </Grid.ColumnDefinitions>
 
                 <TextBlock Grid.Column="0" Text="{Binding StatusMessage}"
-                          VerticalAlignment="Center" Foreground="#6C757D"/>
+                          VerticalAlignment="Center" Foreground="{DynamicResource BusBuddy.Brush.Text.Secondary}"/>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="Total Drivers: " Foreground="#6C757D"/>
-                    <TextBlock Text="{Binding TotalDrivers}" FontWeight="Bold" Foreground="#007ACC" Margin="0,0,15,0"/>
-                    <TextBlock Text="Active: " Foreground="#6C757D"/>
-                    <TextBlock Text="{Binding ActiveDrivers}" FontWeight="Bold" Foreground="#28A745" Margin="0,0,15,0"/>
-                    <TextBlock Text="Training Pending: " Foreground="#6C757D"/>
-                    <TextBlock Text="{Binding TrainingPendingDrivers}" FontWeight="Bold" Foreground="#FFC107"/>
+                    <TextBlock Text="Total Drivers: " Foreground="{DynamicResource BusBuddy.Brush.Text.Secondary}"/>
+                    <TextBlock Text="{Binding TotalDrivers}" FontWeight="Bold" Foreground="{DynamicResource BusBuddy.Brush.Primary}" Margin="0,0,15,0"/>
+                    <TextBlock Text="Active: " Foreground="{DynamicResource BusBuddy.Brush.Text.Secondary}"/>
+                    <TextBlock Text="{Binding ActiveDrivers}" FontWeight="Bold" Foreground="{DynamicResource BusBuddy.Brush.Semantic.Success}" Margin="0,0,15,0"/>
+                    <TextBlock Text="Training Pending: " Foreground="{DynamicResource BusBuddy.Brush.Text.Secondary}"/>
+                    <TextBlock Text="{Binding TrainingPendingDrivers}" FontWeight="Bold" Foreground="{DynamicResource BusBuddy.Brush.Semantic.Warning}"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/BusBuddy.WPF/Views/Fuel/FuelReconciliationDialog.xaml
+++ b/BusBuddy.WPF/Views/Fuel/FuelReconciliationDialog.xaml
@@ -29,10 +29,10 @@
                 Margin="0,0,0,10">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="⛽" FontSize="20"
-                           Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
+                           Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
                            VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <TextBlock FontSize="18" FontWeight="Bold"
-                           Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
+                           Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}"
                            VerticalAlignment="Center"
                            Text="{Binding Title, RelativeSource={RelativeSource AncestorType=syncfusion:ChromelessWindow}}"/>
             </StackPanel>
@@ -91,32 +91,36 @@
                         </Grid.ColumnDefinitions>
 
                         <Border Grid.Column="0"
-                                Background="#E6F7FF"
-                                BorderBrush="#A6D8FF"
-                                BorderThickness="1"
+                                Background="{DynamicResource BusBuddy.Brush.Panel.Header}"
+                                BorderBrush="{DynamicResource BusBuddy.Brush.Semantic.Info}"
+                                BorderThickness="3,1,1,1"
                                 CornerRadius="5"
                                 Margin="0,0,5,0"
                                 Padding="10">
                             <StackPanel>
-                                <TextBlock Text="Bulk Station Meter" FontWeight="Bold"/>
+                                <TextBlock Text="Bulk Station Meter" FontWeight="Bold"
+                                           Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
                                 <TextBlock Text="{Binding BulkStationGallons, StringFormat='{}{0:N2} gallons'}"
                                            FontSize="18"
-                                           Margin="0,5,0,0"/>
+                                           Margin="0,5,0,0"
+                                           Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
                             </StackPanel>
                         </Border>
 
                         <Border Grid.Column="1"
-                                Background="#FFF9E6"
-                                BorderBrush="#FFE0A6"
-                                BorderThickness="1"
+                                Background="{DynamicResource BusBuddy.Brush.Panel.Content}"
+                                BorderBrush="{DynamicResource BusBuddy.Brush.Semantic.Warning}"
+                                BorderThickness="3,1,1,1"
                                 CornerRadius="5"
                                 Margin="5,0"
                                 Padding="10">
                             <StackPanel>
-                                <TextBlock Text="Vehicle Usage" FontWeight="Bold"/>
+                                <TextBlock Text="Vehicle Usage" FontWeight="Bold"
+                                           Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
                                 <TextBlock Text="{Binding VehicleUsageGallons, StringFormat='{}{0:N2} gallons'}"
                                            FontSize="18"
-                                           Margin="0,5,0,0"/>
+                                           Margin="0,5,0,0"
+                                           Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
                             </StackPanel>
                         </Border>
 

--- a/BusBuddy.WPF/Views/GoogleEarth/GoogleEarthView.xaml
+++ b/BusBuddy.WPF/Views/GoogleEarth/GoogleEarthView.xaml
@@ -86,14 +86,20 @@
                     </Border>
 
                     <!-- Layer selector — values map to InitializeMapLayer(..) via MapLayerComboBox_SelectionChanged -->
-                    <syncfusion:ComboBoxAdv x:Name="MapLayerComboBox"
-                                            Width="150"
-                                            Height="32"
-                                            Margin="16,0"
-                                            SelectedIndex="0"
-                                            SelectionChanged="MapLayerComboBox_SelectionChanged">
-                        <syncfusion:ComboBoxItemAdv Content="OpenStreetMap"/>
-                    </syncfusion:ComboBoxAdv>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="16,0">
+                        <TextBlock Text="Map layer"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,0"
+                                   Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
+                        <syncfusion:ComboBoxAdv x:Name="MapLayerComboBox"
+                                                Width="150"
+                                                Height="32"
+                                                SelectedIndex="0"
+                                                AutomationProperties.Name="Map layer"
+                                                SelectionChanged="MapLayerComboBox_SelectionChanged">
+                            <syncfusion:ComboBoxItemAdv Content="OpenStreetMap"/>
+                        </syncfusion:ComboBoxAdv>
+                    </StackPanel>
                 </StackPanel>
             </Grid>
         </Border>

--- a/BusBuddy.WPF/Views/Main/MainWindow.xaml
+++ b/BusBuddy.WPF/Views/Main/MainWindow.xaml
@@ -90,15 +90,39 @@
                                           ToolTip="Generate and view transportation reports"
                                           AutomationProperties.Name="Reports and Print Routes"/>
 
-                    <!-- Theme Selector & Quick Toggle -->
+                    <!-- Theme selector — label is required; emoji-only tiles render blank under Fluent. -->
                     <StackPanel Orientation="Horizontal" Margin="20,0,0,0" VerticalAlignment="Center">
-                        <TextBlock Text="Theme:" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                        <syncfusion:ComboBoxAdv x:Name="ThemeSelector" Width="150" SelectedIndex="0" SelectionChanged="ThemeSelector_SelectionChanged" ToolTip="Select application theme (Syncfusion Fluent themes)">
+                        <TextBlock Text="Theme"
+                                   Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,0"/>
+                        <syncfusion:ComboBoxAdv x:Name="ThemeSelector"
+                                                Width="150"
+                                                SelectedIndex="0"
+                                                SelectionChanged="ThemeSelector_SelectionChanged"
+                                                ToolTip="Select application theme"
+                                                AutomationProperties.Name="Theme">
                             <syncfusion:ComboBoxItemAdv Content="FluentDark"/>
                             <syncfusion:ComboBoxItemAdv Content="FluentLight"/>
                         </syncfusion:ComboBoxAdv>
-                        <syncfusion:ButtonAdv Label="🌙" Width="38" Margin="8,0,0,0" Padding="4" ToolTip="Switch to FluentDark" Click="DarkThemeButton_Click" Background="{DynamicResource ButtonBackgroundBrush}" Foreground="{DynamicResource ButtonForegroundBrush}"/>
-                        <syncfusion:ButtonAdv Label="☀️" Width="38" Margin="4,0,0,0" Padding="4" ToolTip="Switch to FluentLight" Click="LightThemeButton_Click" Background="{DynamicResource ButtonBackgroundBrush}" Foreground="{DynamicResource ButtonForegroundBrush}"/>
+                        <syncfusion:ButtonAdv Label="Dark"
+                                              Width="56"
+                                              Margin="8,0,0,0"
+                                              Padding="8,4"
+                                              ToolTip="Switch to FluentDark"
+                                              AutomationProperties.Name="Switch to FluentDark"
+                                              Click="DarkThemeButton_Click"
+                                              Background="{DynamicResource ButtonBackgroundBrush}"
+                                              Foreground="{DynamicResource ButtonForegroundBrush}"/>
+                        <syncfusion:ButtonAdv Label="Light"
+                                              Width="56"
+                                              Margin="4,0,0,0"
+                                              Padding="8,4"
+                                              ToolTip="Switch to FluentLight"
+                                              AutomationProperties.Name="Switch to FluentLight"
+                                              Click="LightThemeButton_Click"
+                                              Background="{DynamicResource ButtonBackgroundBrush}"
+                                              Foreground="{DynamicResource ButtonForegroundBrush}"/>
                     </StackPanel>
                 </StackPanel>
             </Grid>

--- a/BusBuddy.WPF/Views/Main/MainWindow.xaml.cs
+++ b/BusBuddy.WPF/Views/Main/MainWindow.xaml.cs
@@ -75,6 +75,7 @@ namespace BusBuddy.WPF.Views.Main
 
                 Logger.Debug("Applying Syncfusion theme");
                 ApplySyncfusionTheme();
+                TrySyncThemeSelector(SyncfusionThemeManager.CurrentThemeName);
 
                 Logger.Debug("Initializing MainWindow components and DataContext");
                 InitializeMainWindow();

--- a/BusBuddy.WPF/Views/Reports/ReportsView.xaml
+++ b/BusBuddy.WPF/Views/Reports/ReportsView.xaml
@@ -16,8 +16,8 @@
             <Style TargetType="GroupBox">
                 <Setter Property="Margin" Value="10"/>
                 <Setter Property="Padding" Value="15"/>
-                <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Surface.LightMode.Accent}"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource BusBuddy.Brush.Surface.LightMode.Border}"/>
+                <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Surface.Light}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource BusBuddy.Brush.Surface.Border}"/>
                 <Setter Property="BorderThickness" Value="1"/>
             </Style>
         </ResourceDictionary>
@@ -240,7 +240,7 @@
         </ScrollViewer>
 
         <!-- Recent Generated Reports - SfDataGrid (Finish UI element per roadmap + RAG: Syncfusion key components) -->
-        <Border Grid.Row="2" Background="{DynamicResource BusBuddy.Brush.Surface.LightMode.Accent}" CornerRadius="4" Padding="8" Margin="0,6,0,4">
+        <Border Grid.Row="2" Background="{DynamicResource BusBuddy.Brush.Surface.Light}" CornerRadius="4" Padding="8" Margin="0,6,0,4">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -261,7 +261,7 @@
         </Border>
 
         <!-- Status Bar -->
-    <Border Grid.Row="3" Background="{DynamicResource BusBuddy.Brush.Surface.LightMode.Surface}" CornerRadius="3" Padding="10" Margin="0,10,0,0">
+    <Border Grid.Row="3" Background="{DynamicResource BusBuddy.Brush.Surface.Medium}" CornerRadius="3" Padding="10" Margin="0,10,0,0">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -272,7 +272,7 @@
                           VerticalAlignment="Center" Foreground="{DynamicResource BusBuddy.Brush.Text.Secondary}"/>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                    <Border Background="{DynamicResource BusBuddy.Brush.Surface.LightMode.Accent}" BorderBrush="{DynamicResource BusBuddy.Brush.Semantic.Warning}" BorderThickness="1"
+                    <Border Background="{DynamicResource BusBuddy.Brush.Surface.Light}" BorderBrush="{DynamicResource BusBuddy.Brush.Semantic.Warning}" BorderThickness="1"
                             CornerRadius="3" Padding="8,4" Margin="0,0,10,0"
                             Visibility="{Binding IsGeneratingReport, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel Orientation="Horizontal">

--- a/BusBuddy.WPF/Views/Route/RouteAssignmentView.xaml
+++ b/BusBuddy.WPF/Views/Route/RouteAssignmentView.xaml
@@ -95,7 +95,7 @@
         </Border>
         <!-- Route Configuration Bar -->
         <Border Grid.Row="1"
-                Background="{DynamicResource BusBuddy.Brush.Surface.LightMode.Surface}"
+                Background="{DynamicResource BusBuddy.Brush.Surface.Medium}"
                 CornerRadius="6"
                 Padding="10"
                 Margin="0,0,0,12">
@@ -378,7 +378,7 @@
         <!-- Footer / Status -->
         <Border Grid.Row="4"
                 Margin="0,12,0,0"
-                Background="{DynamicResource BusBuddy.Brush.Surface.LightMode.Surface}"
+                Background="{DynamicResource BusBuddy.Brush.Surface.Medium}"
                 CornerRadius="6"
                 Padding="10">
             <TextBlock Text="{Binding StatusMessage}"

--- a/BusBuddy.WPF/Views/Route/RouteManagementView.xaml
+++ b/BusBuddy.WPF/Views/Route/RouteManagementView.xaml
@@ -29,14 +29,14 @@
                 CornerRadius="5" Padding="15" Margin="10,10,10,0">
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="&#xE1C4;" FontFamily="Segoe MDL2 Assets"
-              FontSize="24" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+              FontSize="24" Foreground="{DynamicResource BusBuddy.Brush.Text.OnPrimary}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <TextBlock Text="Route Management &amp; Planning" FontSize="20" FontWeight="Bold"
               Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" VerticalAlignment="Center"/>
             </StackPanel>
         </Border>
 
         <!-- Enhanced Toolbar -->
-    <Border Grid.Row="1" Background="{DynamicResource BusBuddy.Brush.Surface.LightMode.Accent}"
+    <Border Grid.Row="1" Background="{DynamicResource BusBuddy.Brush.Panel.Header}"
                 CornerRadius="3" Padding="10" Margin="10,10,10,0">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -240,7 +240,7 @@
                               HeaderLinesVisibility="Both"
                               ColumnSizer="Star"
                               Margin="0,0,0,10"
-                              Background="{DynamicResource FluentDarkBackgroundBrush}"
+                              Background="{DynamicResource BusBuddy.Brush.DataGrid.Background}"
                               MouseDoubleClick="RoutesDataGrid_MouseDoubleClick"
                               AutomationProperties.Name="Routes Data Grid"
                               AutomationProperties.HelpText="Grid displaying all routes with their assignments and schedule information">
@@ -258,7 +258,7 @@
         </syncfusion:SfDataGrid>
 
             <!-- Stops editor (reuses MVP control; DataContext expected to be RouteAssignmentViewModel when opened in Manage dialog, so here show helper tip) -->
-            <Border Grid.Row="1" Background="{DynamicResource BusBuddy.Brush.Surface.LightMode.Surface}" CornerRadius="3" Padding="8">
+            <Border Grid.Row="1" Background="{DynamicResource BusBuddy.Brush.Surface.Medium}" CornerRadius="3" Padding="8">
                 <StackPanel>
                     <TextBlock Text="Tip: Select a route and click 'Manage Route' to add/move/delete stops and assign students."/>
                 </StackPanel>
@@ -266,7 +266,7 @@
         </Grid>
 
         <!-- Status Bar -->
-    <Border Grid.Row="3" Background="{DynamicResource BusBuddy.Brush.Surface.LightMode.Surface}" CornerRadius="3" Padding="10" Margin="10,0,10,10">
+    <Border Grid.Row="3" Background="{DynamicResource BusBuddy.Brush.Surface.Medium}" CornerRadius="3" Padding="10" Margin="10,0,10,10">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>

--- a/BusBuddy.WPF/Views/Student/StudentForm.xaml
+++ b/BusBuddy.WPF/Views/Student/StudentForm.xaml
@@ -120,8 +120,8 @@
                 <Setter Property="Height" Value="40"/>
                 <Setter Property="Padding" Value="8"/>
                 <Setter Property="Margin" Value="0,0,0,10"/>
-                <Setter Property="Foreground" Value="{StaticResource BusBuddy.Brush.Text.Primary}"/>
-                <Setter Property="Background" Value="{StaticResource BusBuddy.Brush.Surface.Light}"/>
+                <Setter Property="Foreground" Value="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
+                <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Surface.Light}"/>
             </Style>
             <Style TargetType="syncfusion:SfDatePicker" BasedOn="{StaticResource {x:Type syncfusion:SfDatePicker}}">
                 <Setter Property="Height" Value="40"/>
@@ -132,18 +132,18 @@
                 <Setter Property="Height" Value="40"/>
                 <Setter Property="Padding" Value="8"/>
                 <Setter Property="Margin" Value="0,0,0,10"/>
-                <Setter Property="Foreground" Value="{StaticResource BusBuddy.Brush.Text.Primary}"/>
-                <Setter Property="Background" Value="{StaticResource BusBuddy.Brush.Surface.Light}"/>
+                <Setter Property="Foreground" Value="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
+                <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Surface.Light}"/>
             </Style>
             <Style TargetType="syncfusion:SfDatePicker" BasedOn="{StaticResource {x:Type syncfusion:SfDatePicker}}">
                 <Setter Property="Height" Value="40"/>
                 <Setter Property="Margin" Value="0,0,0,10"/>
-                <Setter Property="Foreground" Value="{StaticResource BusBuddy.Brush.Text.Primary}"/>
-                <Setter Property="Background" Value="{StaticResource BusBuddy.Brush.Surface.Light}"/>
+                <Setter Property="Foreground" Value="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
+                <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Surface.Light}"/>
             </Style>
             <Style TargetType="syncfusion:SfTextBoxExt" BasedOn="{StaticResource {x:Type syncfusion:SfTextBoxExt}}">
-                <Setter Property="Foreground" Value="{StaticResource BusBuddy.Brush.Text.Primary}"/>
-                <Setter Property="Background" Value="{StaticResource BusBuddy.Brush.Surface.Light}"/>
+                <Setter Property="Foreground" Value="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
+                <Setter Property="Background" Value="{DynamicResource BusBuddy.Brush.Surface.Light}"/>
                 <Setter Property="Height" Value="40"/>
                 <Setter Property="Padding" Value="8"/>
                 <Setter Property="Margin" Value="0,0,0,10"/>
@@ -151,7 +151,7 @@
             <Style TargetType="Label" BasedOn="{StaticResource {x:Type Label}}">
                 <Setter Property="Margin" Value="0,0,0,5"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
-                <Setter Property="Foreground" Value="{StaticResource BusBuddy.Brush.Text.Primary}"/>
+                <Setter Property="Foreground" Value="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
             </Style>
         </ResourceDictionary>
     </syncfusion:ChromelessWindow.Resources>
@@ -181,15 +181,15 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock Grid.Column="0" Text="⚠️" FontSize="16" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
+                    <TextBlock Grid.Column="0" Text="⚠️" FontSize="16" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
                               VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <TextBlock Grid.Column="1" Text="{Binding GlobalErrorMessage}"
-                              Foreground="{StaticResource BusBuddy.Brush.Text.Primary}" FontWeight="Bold" TextWrapping="Wrap"
+                              Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" FontWeight="Bold" TextWrapping="Wrap"
                               VerticalAlignment="Center"/>
                     <syncfusion:ButtonAdv Grid.Column="2" Label="✖"
                                          Command="{Binding ClearGlobalErrorCommand}"
-                                         Background="Transparent" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
-                                         BorderThickness="1" BorderBrush="{StaticResource BusBuddy.Brush.Text.Primary}"
+                                         Background="Transparent" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
+                                         BorderThickness="1" BorderBrush="{DynamicResource BusBuddy.Brush.Text.Primary}"
                                          Width="30" Height="30"
                                              ToolTip="Clear error message"
                                              AutomationProperties.Name="Clear Error"/>
@@ -201,9 +201,9 @@
                     CornerRadius="5" Padding="15" Margin="0,0,0,20">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="&#xE716;" FontFamily="Segoe MDL2 Assets"
-                              FontSize="24" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                              FontSize="24" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <TextBlock Text="{Binding FormTitle}" FontSize="18" FontWeight="Bold"
-                              Foreground="{StaticResource BusBuddy.Brush.Text.Primary}" VerticalAlignment="Center"/>
+                              Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}" VerticalAlignment="Center"/>
                 </StackPanel>
             </Border>
 
@@ -540,20 +540,20 @@
                 <syncfusion:ButtonAdv Name="SuggestRoutesButton"
                     Label="🤖 AI Suggest Routes"
                                     Command="{Binding SuggestRoutesCommand}"
-                                    Background="{StaticResource BusBuddy.Brush.SafetyOrange}" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
+                                    Background="{StaticResource BusBuddy.Brush.SafetyOrange}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
                                     ToolTip="Use xAI Grok to suggest optimal routes based on address"
                                     AutomationProperties.Name="AI Suggest Routes"/>
                 <syncfusion:ButtonAdv Name="ViewOnMapButton"
                     Label="🗺️ View on Map"
                                     Command="{Binding ViewOnMapCommand}"
-                                    Background="{StaticResource BusBuddy.Brush.Semantic.Info}" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
+                                    Background="{StaticResource BusBuddy.Brush.Semantic.Info}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
                                     Margin="10,0,0,0"
                                     ToolTip="Show student location on Google Earth Engine map"
                                     AutomationProperties.Name="View on Map"/>
                 <syncfusion:ButtonAdv Name="ImportCsvButton"
                     Label="📥 Import CSV"
                                     Command="{Binding ImportCsvCommand}"
-                                    Background="{StaticResource BusBuddy.Brush.FleetGreen}" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
+                                    Background="{StaticResource BusBuddy.Brush.FleetGreen}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
                                     Margin="10,0,0,0"
                                     ToolTip="Import student data from CSV file"
                                     AutomationProperties.Name="Import CSV"/>
@@ -640,7 +640,7 @@
             </StackPanel>
 
             <!-- Form Actions with Validation Status -->
-            <Border Grid.Row="3" Background="{StaticResource BusBuddy.Brush.Surface.Light}"
+            <Border Grid.Row="3" Background="{DynamicResource BusBuddy.Brush.Surface.Light}"
                     CornerRadius="3" Padding="15" Margin="0,20,0,0">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -663,13 +663,13 @@
                     </StackPanel>
 
                     <!-- Detailed Validation Errors -->
-                    <Border Grid.Row="1" Background="{StaticResource BusBuddy.Brush.Surface.Dark}"
+                    <Border Grid.Row="1" Background="{DynamicResource BusBuddy.Brush.Surface.Dark}"
                             CornerRadius="3" Padding="10" Margin="0,0,0,10"
                             Visibility="{Binding HasValidationErrors, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel>
                             <TextBlock Text="Please fix the following:"
                                        FontWeight="SemiBold"
-                                       Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
+                                       Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
                                        Margin="0,0,0,8"/>
                             <ItemsControl ItemsSource="{Binding ValidationErrors}">
                                 <ItemsControl.ItemTemplate>
@@ -688,21 +688,21 @@
             <syncfusion:ButtonAdv Name="ValidateButton"
         Label="🔍 Validate Data"
                 Command="{Binding ValidateDataCommand}"
-                Background="{StaticResource BusBuddy.Brush.Semantic.Warning}" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
+                Background="{StaticResource BusBuddy.Brush.Semantic.Warning}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
                 Margin="0,0,10,0"
                 ToolTip="Validate all student data and address"
                 AutomationProperties.Name="Validate Data"/>
             <syncfusion:ButtonAdv Name="SaveButton" Label="💾 Save Student"
                 Command="{Binding SaveCommand}"
                 IsEnabled="{Binding CanSave}"
-                                Background="{StaticResource BusBuddy.Brush.Primary}" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
+                                Background="{StaticResource BusBuddy.Brush.Primary}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
                                 Margin="0,0,10,0"
                                 IsDefault="True"
                                 ToolTip="Save student information to database"
                                 AutomationProperties.Name="Save Student"/>
             <syncfusion:ButtonAdv Name="CancelButton" Label="❌ Cancel"
                 Command="{Binding CancelCommand}"
-                Background="{StaticResource BusBuddy.Brush.Semantic.Error}" Foreground="{StaticResource BusBuddy.Brush.Text.Primary}"
+                Background="{StaticResource BusBuddy.Brush.Semantic.Error}" Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"
                 IsCancel="True"
                 ToolTip="Cancel and return to students list"
                 AutomationProperties.Name="Cancel"/>

--- a/BusBuddy.WPF/Views/Student/StudentsView.xaml
+++ b/BusBuddy.WPF/Views/Student/StudentsView.xaml
@@ -249,17 +249,17 @@
                     <syncfusion:GridTemplateColumn.CellTemplate>
                         <DataTemplate>
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                    <syncfusion:ButtonAdv Label="🗺️"
+                                    <syncfusion:ButtonAdv Label="Map"
                                                           ToolTip="View on Map"
                                                           Command="{Binding DataContext.ViewOnMapCommand, RelativeSource={RelativeSource AncestorType=syncfusion:ChromelessWindow}}"
                                                           CommandParameter="{Binding}"
-                                                          Width="28" Height="28" Margin="2"
+                                                          Padding="8,4" Margin="2"
                                                           AutomationProperties.Name="View Student On Map"/>
-                                    <syncfusion:ButtonAdv Label="🎯"
+                                    <syncfusion:ButtonAdv Label="Suggest"
                                                           ToolTip="AI Route Suggest"
                                                           Command="{Binding DataContext.SuggestRouteCommand, RelativeSource={RelativeSource AncestorType=syncfusion:ChromelessWindow}}"
                                                           CommandParameter="{Binding}"
-                                                          Width="28" Height="28" Margin="2"
+                                                          Padding="8,4" Margin="2"
                                                           AutomationProperties.Name="Suggest Route For Student"/>
                                 </StackPanel>
                         </DataTemplate>

--- a/BusBuddy.WPF/Views/Vehicle/VehicleManagementView.xaml
+++ b/BusBuddy.WPF/Views/Vehicle/VehicleManagementView.xaml
@@ -90,12 +90,17 @@
                     Watermark="Search buses by make, model, or plate number..."
                     Margin="0,0,15,0"/>
 
-            <syncfusion:ComboBoxAdv Grid.Column="1"
-                     ItemsSource="{Binding StatusFilterOptions}"
-                     SelectedItem="{Binding SelectedStatusFilter}"
-                     Width="150"
-                     Padding="10"
-                     Margin="0,0,15,0"/>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,15,0">
+                <TextBlock Text="Status"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,0"
+                           Foreground="{DynamicResource BusBuddy.Brush.Text.Primary}"/>
+                <syncfusion:ComboBoxAdv ItemsSource="{Binding StatusFilterOptions}"
+                         SelectedItem="{Binding SelectedStatusFilter}"
+                         Width="150"
+                         Padding="10"
+                         AutomationProperties.Name="Status"/>
+            </StackPanel>
 
          <syncfusion:ButtonAdv Grid.Column="2"
              Label="🔄 Refresh"


### PR DESCRIPTION
## Summary
Architectural theme fixes (items 1–6) on a clean branch from `master`. Independent of conflicted #42.

1. **One Fluent skin** — `SyncfusionStyles.xaml` no longer merges FluentDark + FluentLight. `SfSkinManager.ApplicationTheme` owns the skin.
2. **ButtonAdv chrome** — implicit styles keep size/padding only. Background/Foreground setters removed so Fluent templates paint buttons.
3. **Surface / Text swap** — `BusBuddy.Brush.Surface.*` and `Text.*` are overridden in both Fluent dictionaries. `LightMode.*` parallel set deleted; views retargeted to Surface / Panel / Text.
4. **Persist theme** — MainWindow combo + Dark/Light buttons write `%AppData%/BusBuddy/user-settings.json`. Startup loads the saved theme. `Office2019Colorful` maps to FluentDark and is no longer the `AppSettingsOptions` default.
5. **Hardcoded hex** — Drivers, Fuel reconciliation, and Route Management (`FluentDarkBackgroundBrush`) now use theme tokens.
6. **Captions** — “Status” on the vehicle filter, “Map layer” on the map combo, “Theme” next to the selector, Dark/Light text instead of moon/sun, Map / Suggest instead of 🗺️ / 🎯.

Item 7 (UTM desktop shortcut) is a VM path — not changed here.

## Test plan
- [ ] Cold start: last selected theme is applied before MainWindow shows; combo matches.
- [ ] Switch Dark ↔ Light without restart: surfaces, text, and grids update; buttons keep Fluent chrome (no blank tiles).
- [ ] Drivers / Fuel reconciliation / Route Management: no light-hex toolbars or missing grid background.
- [ ] Vehicle filter shows **Status**; Maps shows **Map layer**; header shows **Theme** + Dark/Light labels.
- [ ] Students grid Actions: **Map** and **Suggest** are readable.
- [ ] Settings page Theme still lists only FluentDark / FluentLight.
- [ ] Retired `Office2019Colorful` in user-settings.json loads as FluentDark.